### PR TITLE
Travis CI and setup.py configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,35 @@
-*.pyc
-*~
+*.py[cod]
 *.todo
 *.ini
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+*.DS_Store
+*.dylib
+*.pyc
+.idea/
+docs/_*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: python
+python:
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+addons:
+  apt:
+    packages:
+    - libopenblas-dev
+    - liblapack-dev
+    - libatlas-dev
+    - libfftw3-dev
+script:
+    - nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ python:
 addons:
   apt:
     packages:
-    - libopenblas-dev
-    - liblapack-dev
-    - libatlas-dev
     - libfftw3-dev
 script:
     - nosetests

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,24 @@
+================================================
+chebpy - A provisional Python implementation of Chebfun
+================================================
+
+
+.. image:: https://travis-ci.org/chebfun/chebfun.svg?branch=master
+    :target: https://travis-ci.org/chebfun/chebfun
+
+
+Installation
+------------
+
+To install chebpy, you should first install the `fftw` library::
+
+    # On Linux
+    $ sudo apt-get install libfftw3-dev
+
+    # Via Homebrew on Mac
+    $ brew install fftw
+
+And then proceed to install chebpy with::
+
+    $ python setup.py install
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+cycler==0.10.0
+matplotlib==1.5.2
+nose==1.3.7
+numpy==1.11.1
+py==1.4.31
+pyFFTW==0.10.4
+pyparsing==2.1.8
+python-dateutil==2.5.3
+pytz==2016.6.1
+six==1.10.0
+wheel==0.24.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+setup(
+    name='chebpy',
+    version='0.0.1',
+    description='A Python implementation of Chebfun',
+    long_description=open('README.rst',"rt").read(),
+    # author='',
+    author_email='',
+    url='https://github.com/chebpy/chebpy',
+    # license='',
+    packages= ['chebpy'],
+    install_requires=[
+        "numpy >= 1.11.0",
+        "matplotlib < 2.0.0", # mpl > 2.0 only works on py3
+        "pyFFTW >= 0.8.1",
+    ],
+    test_suite="tests",
+)


### PR DESCRIPTION
Hi @markrichardson, here's the basic Travis config you need to get going. You should be able to see where you need to modify stuff - in python 2.7, your tests are failing (see [here](https://travis-ci.org/jpiper/chebpy/jobs/156393907#L2144) onwards ), and your code isn't yet compatible with python 3 yet (see [here](https://travis-ci.org/jpiper/chebpy/jobs/156393908#L2047) onwards), so that's why the python 3 builds fail.

I've also attached the instructions to get going with fftw on mac and ubuntu. Given that fftw is rather easy to install, I don't see any need to provide the user with the option to not use it (given the performance benefits you mentioned), especially considering it will make testing more complicated, but it's your call!