### PR TITLE
use `numpy.vectorize` if unable to sample function directly

### DIFF
--- a/chebpy/core/algorithms.py
+++ b/chebpy/core/algorithms.py
@@ -130,7 +130,7 @@ def bary(xx, fk, xk, vk):
 
 @preandpostprocess
 def clenshaw(xx, ak):
-    """Clenshaw's algorithm for the evaluation of a first-kind Chebyshev 
+    """Clenshaw's algorithm for the evaluation of a first-kind Chebyshev
     series expansion at some array of points x"""
     bk1 = 0*xx
     bk2 = 0*xx
@@ -209,7 +209,10 @@ def adaptive(cls, fun, maxpow2=16):
     for k in range(4, maxpow2+1):
         n = 2**k + 1
         points = cls._chebpts(n)
-        values = fun(points)
+        try:
+            values = fun(points)
+        except:  # needed when trying to sample wrapped C functions
+            values = np.vectorize(fun)(points)
         coeffs = cls._vals2coeffs(values)
         chplen = standard_chop(coeffs)
         if chplen < coeffs.size:


### PR DESCRIPTION
**ChebPy** is currently unable to fit to wrapped C functions. For instance, with the following simple C function compiled to a shared library and installed in the library path:

```C
#include <math.h>
double myfunc(double t) { return sin(2 * M_PI * t) + cos(2 * M_PI * t); }
```

**CTypes** is working fine:

```Python
from ctypes import *
libtest = CDLL("libtest.so")
myfunc = libtest.myfunc
myfunc.argtypes = [c_double]
myfunc.restype = c_double
myfunc(0.1)
Out[5]: 1.3968022466674206
```

but when trying to fit it using **ChebPy**:

```Python
from chebpy import *
cheb = chebfun(myfunc)
---------------------------------------------------------------------------
ArgumentError                             Traceback (most recent call last)
<ipython-input-2-cf4f5971b57a> in <module>
      1 from chebpy import *
----> 2 cheb = chebfun(myfunc)

/usr/local/lib/python3.6/dist-packages/chebpy/core/ui.py in chebfun(f, domain, n)
     20     # chebfun(lambda x: f(x), ... )
     21     if hasattr(f, "__call__"):
---> 22         return Chebfun.initfun(f, domain, n)
     23 
     24     # chebfun('x', ... )

/usr/local/lib/python3.6/dist-packages/chebpy/core/chebfun.py in initfun(cls, f, domain, n)
     37             return Chebfun.initfun_fixedlen(f, n, domain)
     38         else:
---> 39             return Chebfun.initfun_adaptive(f, domain)
     40 
     41     @classmethod

/usr/local/lib/python3.6/dist-packages/chebpy/core/chebfun.py in initfun_adaptive(cls, f, domain)
     41     @classmethod
     42     def initfun_adaptive(cls, f, domain=DefaultPrefs.domain):
---> 43         funs = generate_funs(domain, Bndfun.initfun_adaptive, [f])
     44         return cls(funs)
     45 

/usr/local/lib/python3.6/dist-packages/chebpy/core/utilities.py in generate_funs(domain, bndfun_constructor, arglist)
    239         interval = Interval(*interval)
    240         args = arglist + [interval]
--> 241         fun = bndfun_constructor(*args)
    242         funs = np.append(funs, fun)
    243     return funs

/usr/local/lib/python3.6/dist-packages/chebpy/core/classicfun.py in initfun_adaptive(cls, f, interval)
     56         and a Interval object'''
     57         uifunc = lambda y: f(interval(y))
---> 58         onefun = Tech.initfun(uifunc)
     59         return cls(onefun, interval)
     60 

/usr/local/lib/python3.6/dist-packages/chebpy/core/chebtech.py in initfun(cls, fun, n)
     53         fixedlen constructor from the input arguments passed.'''
     54         if n is None:
---> 55             return cls.initfun_adaptive(fun)
     56         else:
     57             return cls.initfun_fixedlen(fun, n)

/usr/local/lib/python3.6/dist-packages/chebpy/core/chebtech.py in initfun_adaptive(cls, fun)
     70         '''Initialise a Chebtech from the callable fun utilising the adaptive
     71         constructor to determine the number of degrees of freedom parameter.'''
---> 72         coeffs = adaptive(cls, fun)
     73         return cls(coeffs)
     74 

/usr/local/lib/python3.6/dist-packages/chebpy/core/algorithms.py in adaptive(cls, fun, maxpow2)
    210         n = 2**k + 1
    211         points = cls._chebpts(n)
--> 212         values = fun(points)
    213         coeffs = cls._vals2coeffs(values)
    214         chplen = standard_chop(coeffs)

/usr/local/lib/python3.6/dist-packages/chebpy/core/classicfun.py in <lambda>(y)
     55         '''Adaptive initialisation of a BndFun from a callable function f
     56         and a Interval object'''
---> 57         uifunc = lambda y: f(interval(y))
     58         onefun = Tech.initfun(uifunc)
     59         return cls(onefun, interval)

ArgumentError: argument 1: <class 'TypeError'>: wrong type
```

It is unclear to me why the trace is indicating `classicfun.py` line 57 as the site of the problem, which actually is at `algorithms.py` line 212.

Anyhow, the problem is that `fun`, which is a **CTypes** wrapper object to the C function is getting passed a `numpy.array` object and it doesn't know what to do with it.

The solution is to use `numpy.vectorize` on the wrapper object to produce a new object that is able to handle `numpy.ndarray`.

However, I have patched it not to always use vectorize because I learnt [here](https://stackoverflow.com/a/35216364/) that it has some [issues](https://github.com/numpy/numpy/search?q=vectorize&type=Issues), so I'm using it only if the regular method fails.
