### PR TITLE
Fix linspace TypeError bug

### DIFF
--- a/chebpy/core/algorithms.py
+++ b/chebpy/core/algorithms.py
@@ -195,7 +195,7 @@ def standard_chop(coeffs, tol=eps):
             j2 = j3 + 1
             envelope[j2] = tol**(7./6.)
         cc = np.log10(envelope[:int(j2)])
-        cc = cc + np.linspace(0, (-1./3.)*np.log10(tol), j2)
+        cc = cc + np.linspace(0, (-1./3.)*np.log10(tol), int(j2))
         d = np.argmin(cc)
         # TODO: check this
         cutoff = d # + 2


### PR DESCRIPTION
Numpy 1.12 deprecated the float types for the `num` argument to `linspace`. Recently (1.18.x), support was finally removed in [this commit](https://github.com/numpy/numpy/commit/f4dfe833e3e037bb69113f7250fad3699f918cfc).

This can cause the `TypeError` for users that have chebpy together with a new version of NumPy installed. See: #9 

In `algorithms.py`, j2 is of type float, but `linspace` requires an integer. We can safely cast j2 to an int, though.