### PR TITLE
Make matplotlib an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: python
 install:
     - pip install -r requirements.txt
     - pip install coveralls
+    - pip install matplotlib
 python:
 #    - "2.7"
 #    - "3.4"

--- a/chebpy/core/chebfun.py
+++ b/chebpy/core/chebfun.py
@@ -4,7 +4,6 @@ from __future__ import division
 
 import operator
 import numpy as np
-import matplotlib.pyplot as plt
 
 from chebpy.core.bndfun import Bndfun
 from chebpy.core.settings import DefaultPrefs
@@ -13,6 +12,7 @@ from chebpy.core.utilities import (Interval, Domain, check_funs,
 from chebpy.core.decorators import (self_empty, float_argument,
                                     cast_arg_to_chebfun, cache)
 from chebpy.core.exceptions import BadDomainArgument, BadFunLengthArgument
+from chebpy.core.plotting import import_plt, plotfun
 
 
 class Chebfun(object):
@@ -334,22 +334,6 @@ class Chebfun(object):
         return (self*f).sum()
 
     # ----------
-    #  plotting
-    # ----------
-    def plot(self, ax=None, *args, **kwargs):
-        ax = ax or plt.gca()
-        a, b = self.support
-        xx = np.linspace(a, b, 2001)
-        ax.plot(xx, self(xx), *args, **kwargs)
-        return ax
-
-    def plotcoeffs(self, ax=None, *args, **kwargs):
-        ax = ax or plt.gca()
-        for fun in self:
-            fun.plotcoeffs(ax=ax)
-        return ax
-
-    # ----------
     #  utilities
     # ----------
     @self_empty()
@@ -391,6 +375,24 @@ class Chebfun(object):
                 subfun = other.restrict(subdom)
             funs = np.append(funs, subfun.funs)
         return self.__class__(funs)
+
+# ----------
+#  plotting
+# ----------
+
+plt = import_plt()
+if plt:
+    def plot(self, ax=None, *args, **kwargs):
+        return plotfun(self, self.support, ax=ax, *args, **kwargs)
+    setattr(Chebfun, 'plot', plot)
+
+    def plotcoeffs(self, ax=None, *args, **kwargs):
+        ax = ax or plt.gca()
+        for fun in self:
+            fun.plotcoeffs(ax=ax)
+        return ax
+    setattr(Chebfun, 'plotcoeffs', plotcoeffs)
+
 
 # ---------
 #  ufuncs

--- a/chebpy/core/chebfun.py
+++ b/chebpy/core/chebfun.py
@@ -382,14 +382,14 @@ class Chebfun(object):
 
 plt = import_plt()
 if plt:
-    def plot(self, ax=None, *args, **kwargs):
-        return plotfun(self, self.support, ax=ax, *args, **kwargs)
+    def plot(self, ax=None, **kwargs):
+        return plotfun(self, self.support, ax=ax, **kwargs)
     setattr(Chebfun, 'plot', plot)
 
-    def plotcoeffs(self, ax=None, *args, **kwargs):
+    def plotcoeffs(self, ax=None, **kwargs):
         ax = ax or plt.gca()
         for fun in self:
-            fun.plotcoeffs(ax=ax)
+            fun.plotcoeffs(ax=ax, **kwargs)
         return ax
     setattr(Chebfun, 'plotcoeffs', plotcoeffs)
 

--- a/chebpy/core/chebtech.py
+++ b/chebpy/core/chebtech.py
@@ -365,7 +365,7 @@ class Chebtech(Smoothfun):
 plt = import_plt()
 if plt:
     def plot(self, ax=None, **kwargs):
-        return plotfun(self, self.support, ax=ax, **kwargs)
+        return plotfun(self, (-1, 1), ax=ax, **kwargs)
     setattr(Chebtech, 'plot', plot)
 
     def plotcoeffs(self, ax=None, **kwargs):

--- a/chebpy/core/chebtech.py
+++ b/chebpy/core/chebtech.py
@@ -364,13 +364,13 @@ class Chebtech(Smoothfun):
 
 plt = import_plt()
 if plt:
-    def plot(self, ax=None, *args, **kwargs):
-        return plotfun(self, self.support, ax, *args, **kwargs)
+    def plot(self, ax=None, **kwargs):
+        return plotfun(self, self.support, ax=ax, **kwargs)
     setattr(Chebtech, 'plot', plot)
 
-    def plotcoeffs(self, ax=None, *args, **kwargs):
+    def plotcoeffs(self, ax=None, **kwargs):
         ax = ax or plt.gca()
-        return plotfuncoeffs(abs(self.coeffs), ax, *args, **kwargs)
+        return plotfuncoeffs(abs(self.coeffs), ax=ax, **kwargs)
     setattr(Chebtech, 'plotcoeffs', plotcoeffs)
 
 

--- a/chebpy/core/chebtech.py
+++ b/chebpy/core/chebtech.py
@@ -4,7 +4,6 @@ from __future__ import division
 
 import abc
 import numpy as np
-import matplotlib.pyplot as plt
 
 from chebpy.core.smoothfun import Smoothfun
 from chebpy.core.settings import DefaultPrefs
@@ -13,6 +12,8 @@ from chebpy.core.algorithms import (bary, clenshaw, adaptive, coeffmult,
                                     vals2coeffs2, coeffs2vals2, chebpts2,
                                     barywts2, rootsunit, newtonroots,
                                     standard_chop)
+from chebpy.core.plotting import import_plt, plotfun, plotfuncoeffs
+
 
 # machine epsilon
 eps = DefaultPrefs.eps
@@ -338,24 +339,6 @@ class Chebtech(Smoothfun):
             out = self.__class__(zk)
         return out
 
-    # ----------
-    #  plotting
-    # ----------
-    def plot(self, ax=None, *args, **kwargs):
-        ax = ax or plt.gca()
-        xx = np.linspace(-1, 1, 2001)
-        yy = self(xx)
-        ax.plot(xx, yy, *args, **kwargs)
-        return ax
-
-    def plotcoeffs(self, ax=None, *args, **kwargs):
-        ax = ax or plt.gca()
-        abscoeffs = abs(self.coeffs)
-        ax.semilogy(abscoeffs, '.', *args, **kwargs)
-        ax.set_ylabel('coefficient magnitude')
-        ax.set_xlabel('polynomial degree')
-        return ax
-
     # ---------------------------------
     #  subclasses must implement these
     # ---------------------------------
@@ -374,6 +357,21 @@ class Chebtech(Smoothfun):
     @abc.abstractmethod
     def _coeffs2vals():
         pass
+
+# ----------
+#  plotting
+# ----------
+
+plt = import_plt()
+if plt:
+    def plot(self, ax=None, *args, **kwargs):
+        return plotfun(self, self.support, ax, *args, **kwargs)
+    setattr(Chebtech, 'plot', plot)
+
+    def plotcoeffs(self, ax=None, *args, **kwargs):
+        ax = ax or plt.gca()
+        return plotfuncoeffs(abs(self.coeffs), ax, *args, **kwargs)
+    setattr(Chebtech, 'plotcoeffs', plotcoeffs)
 
 
 class Chebtech2(Chebtech):

--- a/chebpy/core/classicfun.py
+++ b/chebpy/core/classicfun.py
@@ -175,8 +175,8 @@ class Classicfun(Fun):
 
 plt = import_plt()
 if plt:
-    def plot(self, ax=None, *args, **kwargs):
-        return plotfun(self, self.support, ax, *args, **kwargs)
+    def plot(self, ax=None, **kwargs):
+        return plotfun(self, self.support, ax=ax, **kwargs)
     setattr(Classicfun, 'plot', plot)
 
 # ----------------------------------------------------------------

--- a/chebpy/core/classicfun.py
+++ b/chebpy/core/classicfun.py
@@ -4,7 +4,6 @@ from __future__ import division
 
 import abc
 import numpy as np
-import matplotlib.pyplot as plt
 
 from chebpy.core.fun import Fun
 from chebpy.core.chebtech import Chebtech2
@@ -12,6 +11,7 @@ from chebpy.core.utilities import Interval
 from chebpy.core.settings import DefaultPrefs
 from chebpy.core.decorators import self_empty
 from chebpy.core.exceptions import IntervalMismatch, NotSubinterval
+from chebpy.core.plotting import import_plt, plotfun
 
 
 techdict = {
@@ -168,16 +168,16 @@ class Classicfun(Fun):
         a, b = self.support
         return .5*(b-a) * self.onefun.sum()
 
-    # ----------
-    #  plotting
-    # ----------
+
+# ----------
+#  plotting
+# ----------
+
+plt = import_plt()
+if plt:
     def plot(self, ax=None, *args, **kwargs):
-        a, b = self.support
-        ax = ax or plt.gca()
-        xx = np.linspace(a, b, 2001)
-        yy = self(xx)
-        ax.plot(xx, yy, *args, **kwargs)
-        return ax
+        return plotfun(self, self.support, ax, *args, **kwargs)
+    setattr(Classicfun, 'plot', plot)
 
 # ----------------------------------------------------------------
 #  methods that execute the corresponding onefun method as is
@@ -193,6 +193,8 @@ def addUtility(methodname):
     setattr(Classicfun, methodname, method)
 
 for methodname in methods_onefun_other:
+    if methodname[:4] == 'plot' and plt is None:
+        continue
     addUtility(methodname)
 
 

--- a/chebpy/core/plotting.py
+++ b/chebpy/core/plotting.py
@@ -1,0 +1,36 @@
+import importlib
+
+import numpy as np
+
+
+def _import_optional(name):
+    """Attempt to import the specified module.
+    Either returns the module, or None.
+    
+    See https://github.com/pandas-dev/pandas/blob/master/pandas/compat/_optional.py
+    """
+    try:
+        module = importlib.import_module(name)
+    except ImportError:
+        return None
+    return module
+
+
+def import_plt():
+    return _import_optional('matplotlib.pyplot')
+
+
+def plotfun(fn_y, support, ax=None, *args, **kwargs):
+    ax = ax or import_plt().gca()
+    a, b = support
+    xx = np.linspace(a, b, 2001)
+    ax.plot(xx, fn_y(xx), *args, **kwargs)
+    return ax
+
+
+def plotfuncoeffs(abscoeffs, ax=None, *args, **kwargs):
+    ax = ax or import_plt().gca()
+    ax.semilogy(abscoeffs, '.', *args, **kwargs)
+    ax.set_ylabel('coefficient magnitude')
+    ax.set_xlabel('polynomial degree')
+    return ax

--- a/chebpy/core/plotting.py
+++ b/chebpy/core/plotting.py
@@ -20,17 +20,17 @@ def import_plt():
     return _import_optional('matplotlib.pyplot')
 
 
-def plotfun(fn_y, support, ax=None, *args, **kwargs):
+def plotfun(fn_y, support, ax=None, N=2001, **kwargs):
     ax = ax or import_plt().gca()
     a, b = support
-    xx = np.linspace(a, b, 2001)
-    ax.plot(xx, fn_y(xx), *args, **kwargs)
+    xx = np.linspace(a, b, N)
+    ax.plot(xx, fn_y(xx), **kwargs)
     return ax
 
 
-def plotfuncoeffs(abscoeffs, ax=None, *args, **kwargs):
+def plotfuncoeffs(abscoeffs, ax=None, **kwargs):
     ax = ax or import_plt().gca()
-    ax.semilogy(abscoeffs, '.', *args, **kwargs)
-    ax.set_ylabel('coefficient magnitude')
-    ax.set_xlabel('polynomial degree')
+    ax.set_ylabel(kwargs.pop('xlabel', 'coefficient magnitude'))
+    ax.set_xlabel(kwargs.pop('ylabel', 'polynomial degree'))
+    ax.semilogy(abscoeffs, '.', **kwargs)
     return ax

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cycler==0.10.0
-matplotlib==3.0.3
 nose==1.3.7
 numpy==1.16.4
 py==1.8.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     packages= ['chebpy', 'chebpy.core'],
     install_requires=[
         'numpy>=1.16',
-        'matplotlib>=3.0',
         'pyfftw>=0.11',
     ],
     test_suite="tests",

--- a/tests/test_bndfun.py
+++ b/tests/test_bndfun.py
@@ -8,13 +8,13 @@ import itertools
 import operator
 import unittest
 import numpy as np
-import matplotlib.pyplot as plt
 
 from chebpy.core.bndfun import Bndfun
 from chebpy.core.chebtech import Chebtech2
 from chebpy.core.settings import DefaultPrefs
 from chebpy.core.utilities import Interval
 from chebpy.core.algorithms import standard_chop
+from chebpy.core.plotting import import_plt
 
 from tests.utilities import testfunctions, infnorm
 
@@ -169,13 +169,17 @@ class Plotting(unittest.TestCase):
         self.f1 = Bndfun.initfun_adaptive(f, subinterval)
 
     def test_plot(self):
-        fig, ax = plt.subplots()
-        self.f0.plot(ax=ax, color="g", marker="o", markersize=2, linestyle="")
+        plt = import_plt()
+        if plt:
+            fig, ax = plt.subplots()
+            self.f0.plot(ax=ax, color="g", marker="o", markersize=2, linestyle="")
 
     def test_plotcoeffs(self):
-        fig, ax = plt.subplots()
-        self.f0.plotcoeffs(ax=ax)
-        self.f1.plotcoeffs(ax=ax, color="r")
+        plt = import_plt()
+        if plt:
+            fig, ax = plt.subplots()
+            self.f0.plotcoeffs(ax=ax)
+            self.f1.plotcoeffs(ax=ax, color="r")
 
 
 

--- a/tests/test_chebfun.py
+++ b/tests/test_chebfun.py
@@ -8,7 +8,6 @@ import itertools
 import operator
 import unittest
 import numpy as np
-import matplotlib.pyplot as plt
 
 from chebpy import chebfun
 from chebpy.core.bndfun import Bndfun
@@ -17,6 +16,7 @@ from chebpy.core.settings import DefaultPrefs
 from chebpy.core.utilities import Domain, Interval
 from chebpy.core.exceptions import (IntervalGap, IntervalOverlap,
                                     BadDomainArgument, BadFunLengthArgument)
+from chebpy.core.plotting import import_plt
 
 from tests.utilities import infnorm, testfunctions
 
@@ -907,14 +907,18 @@ class Plotting(unittest.TestCase):
         self.f3 = Chebfun.initfun_adaptive(f, [-2,-0.3,1.2])
 
     def test_plot(self):
-        for fun in [self.f1, self.f2, self.f3]:
-            fig, ax = plt.subplots()
-            fun.plot(ax=ax)
+        plt = import_plt()
+        if plt:
+            for fun in [self.f1, self.f2, self.f3]:
+                fig, ax = plt.subplots()
+                fun.plot(ax=ax)
 
     def test_plotcoeffs(self):
-        for fun in [self.f1, self.f2, self.f3]:
-            fig, ax = plt.subplots()
-            fun.plotcoeffs(ax=ax)
+        plt = import_plt()
+        if plt:
+            for fun in [self.f1, self.f2, self.f3]:
+                fig, ax = plt.subplots()
+                fun.plotcoeffs(ax=ax)
 
 
 class PrivateMethods(unittest.TestCase):

--- a/tests/test_chebtech.py
+++ b/tests/test_chebtech.py
@@ -8,11 +8,11 @@ import itertools
 import operator
 import unittest
 import numpy as np
-import matplotlib.pyplot as plt
 
 from chebpy.core.settings import DefaultPrefs
 from chebpy.core.chebtech import Chebtech2
 from chebpy.core.algorithms import standard_chop
+from chebpy.core.plotting import import_plt
 from tests.utilities import (testfunctions, infnorm, scaled_tol,
                              infNormLessThanTol)
 
@@ -242,13 +242,17 @@ class Plotting(unittest.TestCase):
         self.f1 = Chebtech2.initfun_adaptive(f)
 
     def test_plot(self):
-        fig, ax = plt.subplots()
-        self.f0.plot(ax=ax)
+        plt = import_plt()
+        if plt:
+            fig, ax = plt.subplots()
+            self.f0.plot(ax=ax)
 
     def test_plotcoeffs(self):
-        fig, ax = plt.subplots()
-        self.f0.plotcoeffs(ax=ax)
-        self.f1.plotcoeffs(ax=ax, color="r")
+        plt = import_plt()
+        if plt:
+            fig, ax = plt.subplots()
+            self.f0.plotcoeffs(ax=ax)
+            self.f1.plotcoeffs(ax=ax, color="r")
 
 
 


### PR DESCRIPTION
### Purpose

Plotting via matplotlib should not be a core dependency for this package: #5 

### Changes

I added the new module `core/plotting.py`, which centralizes the plotting functions. It also provides an import mechanism for the (optional) matplotlib dependency.

The `plot` and `plotcoeffs` methods are only added to the classes `Chebfun`, `Chebtech`, and `Classicfun` if `pyplot` is successfully imported.