### PR TITLE
Clip roots to [-1, 1]

### DIFF
--- a/chebpy/core/chebtech.py
+++ b/chebpy/core/chebtech.py
@@ -284,6 +284,7 @@ class Chebtech(Smoothfun):
         coefficients in the associated Chebyshev series approximation'''
         rts = rootsunit(self.coeffs)
         rts = newtonroots(self, rts)
+        rts = np.clip(rts, -1, 1)  # if newton roots are just outside [-1,1]
         return rts
 
     # ----------


### PR DESCRIPTION
## Problem

In very rare cases, `.roots()` returns roots outside the domain. For example, the following example:

```Python
import numpy as np
from chebpy import chebfun

F = lambda x: -np.sin(x)*np.cos(x)*np.exp(x/100)
cheb = chebfun(F, (0, 1000))
x0 = cheb.roots()
print(x0[0])
```
outputs `-1.3322676295501878e-11`.

## Fix

This happens because `newtonroots` called in `Chebtech.roots` does not respect the interval. Due to numerical error, a root at or very close to the domain edge may end up being placed just outside the domain. This is solved with a call to `np.clip`.