### PR TITLE
Fix small syntax errors

### DIFF
--- a/chebpy/core/ui.py
+++ b/chebpy/core/ui.py
@@ -22,7 +22,7 @@ def chebfun(f=None, domain=None, n=None):
         return Chebfun.initfun(f, domain, n)
 
     # chebfun('x', ... )
-    if isinstance(f, str) and len(f) is 1 and f.isalpha():
+    if isinstance(f, str) and len(f) == 1 and f.isalpha():
         if n:
             return Chebfun.initfun(lambda x: x, domain, n)
         else:

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -97,7 +97,7 @@ class Evaluation(unittest.TestCase):
                 fc = ff(xx, "clenshaw")
                 self.assertEquals(type(fb), type(fc))
 
-evalpts = [np.linspace(-1,1,n) for n in np.array([1e2, 1e3, 1e4, 1e5])]
+evalpts = [np.linspace(-1,1,int(n)) for n in np.array([1e2, 1e3, 1e4, 1e5])]
 ptsarry = [Chebtech2._chebpts(n) for n in np.array([100, 200])]
 methods = [bary, clenshaw]
 


### PR DESCRIPTION
test_algorithms.py:
New versions of NumPy require integer type for `numpy.linspace(_, n)`

ui.py:
Python 3.8+ reports `SyntaxWarning: "is" with a literal. Did you mean "=="?`
