### PR TITLE
Expose chebpy preferences to the user

### DIFF
--- a/chebpy/core/algorithms.py
+++ b/chebpy/core/algorithms.py
@@ -36,7 +36,7 @@ def rootsunit(ak, htol=None):
     .. [3] L. N. Trefethen, Approximation Theory and Approximation
         Practice, SIAM, 2013, chapter 18.
     """
-    htol = 1e2*prefs.eps if htol is None else htol
+    htol = htol if htol is not None else 1e2*prefs.eps
     n = standard_chop(ak)
     ak = ak[:n]
 
@@ -153,7 +153,7 @@ def standard_chop(coeffs, tol=None):
     (http://arxiv.org/pdf/1512.01803v1.pdf)
     """
 
-    tol = prefs.eps if tol is None else tol
+    tol = tol if tol is not None else prefs.eps
     # ensure length at least 17:
     n = coeffs.size
     cutoff = n
@@ -305,7 +305,7 @@ def coeffs2vals2(coeffs):
 def newtonroots(fun, rts, tol=None, maxiter=10):
     """Rootfinding for a callable and differentiable fun, typically used to
     polish already computed roots."""
-    tol = 2*prefs.eps if tol is None else tol
+    tol = tol if tol is not None else 2*prefs.eps
     if rts.size > 0:
         dfun = fun.diff()
         prv = np.inf*rts

--- a/chebpy/core/algorithms.py
+++ b/chebpy/core/algorithms.py
@@ -304,10 +304,11 @@ def coeffs2vals2(coeffs):
     return vals
 
 
-def newtonroots(fun, rts, tol=None, maxiter=10):
+def newtonroots(fun, rts, tol=None, maxiter=None):
     """Rootfinding for a callable and differentiable fun, typically used to
     polish already computed roots."""
     tol = tol if tol is not None else 2*prefs.eps
+    maxiter = maxiter if maxiter is not None else prefs.maxiter
     if rts.size > 0:
         dfun = fun.diff()
         prv = np.inf*rts

--- a/chebpy/core/algorithms.py
+++ b/chebpy/core/algorithms.py
@@ -7,21 +7,20 @@ import numpy as np
 
 from chebpy.core.ffts import fft, ifft
 from chebpy.core.utilities import Interval
-from chebpy.core.settings import DefaultPrefs
+from chebpy.core.settings import userPrefs as prefs
 from chebpy.core.decorators import preandpostprocess
 
 # supress numpy division and multiply warnings
 np.seterr(divide='ignore', invalid='ignore')
 
 # constants
-eps = DefaultPrefs.eps
 SPLITPOINT = -0.004849834917525
 
 # local helpers
 def find(x):
     return np.where(x)[0]
 
-def rootsunit(ak, htol=1e2*eps):
+def rootsunit(ak, htol=None):
     """Compute the roots of a funciton on [-1,1] using the coefficeints
     in the associated Chebyshev series representation.
 
@@ -37,6 +36,7 @@ def rootsunit(ak, htol=1e2*eps):
     .. [3] L. N. Trefethen, Approximation Theory and Approximation
         Practice, SIAM, 2013, chapter 18.
     """
+    htol = 1e2*prefs.eps if htol is None else htol
     n = standard_chop(ak)
     ak = ak[:n]
 
@@ -145,7 +145,7 @@ def clenshaw(xx, ak):
     return out
 
 
-def standard_chop(coeffs, tol=eps):
+def standard_chop(coeffs, tol=None):
     """Chop a Chebyshev series to a given tolerance. This is a Python
     transcription of the algorithm described in:
 
@@ -153,6 +153,7 @@ def standard_chop(coeffs, tol=eps):
     (http://arxiv.org/pdf/1512.01803v1.pdf)
     """
 
+    tol = prefs.eps if tol is None else tol
     # ensure length at least 17:
     n = coeffs.size
     cutoff = n
@@ -301,9 +302,10 @@ def coeffs2vals2(coeffs):
     return vals
 
 
-def newtonroots(fun, rts, tol=2*eps, maxiter=10):
+def newtonroots(fun, rts, tol=None, maxiter=10):
     """Rootfinding for a callable and differentiable fun, typically used to
     polish already computed roots."""
+    tol = 2*prefs.eps if tol is None else tol
     if rts.size > 0:
         dfun = fun.diff()
         prv = np.inf*rts

--- a/chebpy/core/algorithms.py
+++ b/chebpy/core/algorithms.py
@@ -203,11 +203,13 @@ def standard_chop(coeffs, tol=None):
     return min( (cutoff, n-1) )
 
 
-def adaptive(cls, fun, maxpow2=16):
+def adaptive(cls, fun, maxpow2=None):
     """Adaptive constructor: cycle over powers of two, calling
     standard_chop each time, the output of which determines whether or not
     we are happy."""
-    for k in range(4, maxpow2+1):
+    minpow2 = 4  # 17 points
+    maxpow2 = maxpow2 if maxpow2 is not None else prefs.maxpow2
+    for k in range(minpow2, max(minpow2, maxpow2)+1):
         n = 2**k + 1
         points = cls._chebpts(n)
         values = fun(points)

--- a/chebpy/core/chebfun.py
+++ b/chebpy/core/chebfun.py
@@ -23,19 +23,19 @@ class Chebfun(object):
 
     @classmethod
     def initconst(cls, c, domain=None):
-        domain = prefs.domain if domain is None else domain
+        domain = domain if domain is not None else prefs.domain
         funs = generate_funs(domain, Bndfun.initconst, [c])
         return cls(funs)
 
     @classmethod
     def initidentity(cls, domain=None):
-        domain = prefs.domain if domain is None else domain
+        domain = domain if domain is not None else prefs.domain
         funs = generate_funs(domain, Bndfun.initidentity)
         return cls(funs)
 
     @classmethod
     def initfun(cls, f, domain=None, n=None):
-        domain = prefs.domain if domain is None else domain
+        domain = domain if domain is not None else prefs.domain
         if n:
             return Chebfun.initfun_fixedlen(f, n, domain)
         else:
@@ -43,13 +43,13 @@ class Chebfun(object):
 
     @classmethod
     def initfun_adaptive(cls, f, domain=None):
-        domain = prefs.domain if domain is None else domain
+        domain = domain if domain is not None else prefs.domain
         funs = generate_funs(domain, Bndfun.initfun_adaptive, [f])
         return cls(funs)
 
     @classmethod
     def initfun_fixedlen(cls, f, n, domain=None):
-        domain = prefs.domain if domain is None else domain
+        domain = domain if domain is not None else prefs.domain
         domain = np.array(domain)
         nn = np.array(n)
         if domain.size < 2:

--- a/chebpy/core/chebfun.py
+++ b/chebpy/core/chebfun.py
@@ -294,9 +294,10 @@ class Chebfun(object):
 
     @cache
     @self_empty(np.array([]))
-    def roots(self):
+    def roots(self, merge=None):
         '''Compute the roots of a Chebfun, i.e., the set of values x for which
         f(x) = 0.'''
+        merge = merge if merge is not None else prefs.mergeroots
         allrts = []
         prvrts = np.array([])
         htol = 1e2 * self.hscale * prefs.eps
@@ -305,7 +306,7 @@ class Chebfun(object):
             # ignore first root if equal to the last root of previous fun
             # TODO: there could be multiple roots at breakpoints
             if prvrts.size > 0 and rts.size > 0:
-                if abs(prvrts[-1]-rts[0]) <= htol:
+                if merge and abs(prvrts[-1]-rts[0]) <= htol:
                     rts = rts[1:]
             allrts.append(rts)
             prvrts = rts

--- a/chebpy/core/chebfun.py
+++ b/chebpy/core/chebfun.py
@@ -6,7 +6,7 @@ import operator
 import numpy as np
 
 from chebpy.core.bndfun import Bndfun
-from chebpy.core.settings import DefaultPrefs
+from chebpy.core.settings import userPrefs as prefs
 from chebpy.core.utilities import (Interval, Domain, check_funs,
                                    generate_funs, compute_breakdata)
 from chebpy.core.decorators import (self_empty, float_argument,
@@ -22,38 +22,43 @@ class Chebfun(object):
         return cls(np.array([]))
 
     @classmethod
-    def initconst(cls, c, domain=DefaultPrefs.domain):
+    def initconst(cls, c, domain=None):
+        domain = prefs.domain if domain is None else domain
         funs = generate_funs(domain, Bndfun.initconst, [c])
         return cls(funs)
 
     @classmethod
-    def initidentity(cls, domain=DefaultPrefs.domain):
+    def initidentity(cls, domain=None):
+        domain = prefs.domain if domain is None else domain
         funs = generate_funs(domain, Bndfun.initidentity)
         return cls(funs)
 
     @classmethod
-    def initfun(cls, f, domain=DefaultPrefs.domain, n=None):
+    def initfun(cls, f, domain=None, n=None):
+        domain = prefs.domain if domain is None else domain
         if n:
             return Chebfun.initfun_fixedlen(f, n, domain)
         else:
             return Chebfun.initfun_adaptive(f, domain)
 
     @classmethod
-    def initfun_adaptive(cls, f, domain=DefaultPrefs.domain):
+    def initfun_adaptive(cls, f, domain=None):
+        domain = prefs.domain if domain is None else domain
         funs = generate_funs(domain, Bndfun.initfun_adaptive, [f])
         return cls(funs)
 
     @classmethod
-    def initfun_fixedlen(cls, f, n, domain=DefaultPrefs.domain):
+    def initfun_fixedlen(cls, f, n, domain=None):
+        domain = prefs.domain if domain is None else domain
         domain = np.array(domain)
         nn = np.array(n)
+        if domain.size < 2:
+            raise BadDomainArgument
         if nn.size == 1:
             nn = nn * np.ones(domain.size-1)
         elif nn.size > 1:
             if nn.size != domain.size - 1:
                 raise BadFunLengthArgument
-        if domain.size < 2:
-            raise BadDomainArgument
         funs = np.array([])
         intervals = zip(domain[:-1], domain[1:])
         for interval, length in zip(intervals, nn):
@@ -294,7 +299,7 @@ class Chebfun(object):
         f(x) = 0.'''
         allrts = []
         prvrts = np.array([])
-        htol = 1e2 * self.hscale * DefaultPrefs.eps
+        htol = 1e2 * self.hscale * prefs.eps
         for fun in self:
             rts = fun.roots()
             # ignore first root if equal to the last root of previous fun

--- a/chebpy/core/chebtech.py
+++ b/chebpy/core/chebtech.py
@@ -276,12 +276,15 @@ class Chebtech(Smoothfun):
     # -------
     #  roots
     # -------
-    def roots(self):
+    def roots(self, sort=None):
         '''Compute the roots of the Chebtech on [-1,1] using the
         coefficients in the associated Chebyshev series approximation'''
+        sort = sort if sort is not None else prefs.sortroots
         rts = rootsunit(self.coeffs)
         rts = newtonroots(self, rts)
+        # fix problems with newton for roots that are numerically very close
         rts = np.clip(rts, -1, 1)  # if newton roots are just outside [-1,1]
+        rts = rts if not sort else np.sort(finalrts)
         return rts
 
     # ----------

--- a/chebpy/core/chebtech.py
+++ b/chebpy/core/chebtech.py
@@ -6,17 +6,13 @@ import abc
 import numpy as np
 
 from chebpy.core.smoothfun import Smoothfun
-from chebpy.core.settings import DefaultPrefs
+from chebpy.core.settings import userPrefs as prefs
 from chebpy.core.decorators import self_empty
 from chebpy.core.algorithms import (bary, clenshaw, adaptive, coeffmult,
                                     vals2coeffs2, coeffs2vals2, chebpts2,
                                     barywts2, rootsunit, newtonroots,
                                     standard_chop)
 from chebpy.core.plotting import import_plt, plotfun, plotfuncoeffs
-
-
-# machine epsilon
-eps = DefaultPrefs.eps
 
 
 class Chebtech(Smoothfun):
@@ -199,6 +195,7 @@ class Chebtech(Smoothfun):
             cfs = f.coeffs + g.coeffs
 
             # check for zero output
+            eps = prefs.eps
             tol = .2 * eps * max([f.vscale, g.vscale])
             if all(abs(cfs)<tol):
                 return cls.initconst(0.)

--- a/chebpy/core/classicfun.py
+++ b/chebpy/core/classicfun.py
@@ -8,7 +8,7 @@ import numpy as np
 from chebpy.core.fun import Fun
 from chebpy.core.chebtech import Chebtech2
 from chebpy.core.utilities import Interval
-from chebpy.core.settings import DefaultPrefs
+from chebpy.core.settings import userPrefs as prefs
 from chebpy.core.decorators import self_empty
 from chebpy.core.exceptions import IntervalMismatch, NotSubinterval
 from chebpy.core.plotting import import_plt, plotfun
@@ -17,8 +17,6 @@ from chebpy.core.plotting import import_plt, plotfun
 techdict = {
     'Chebtech2': Chebtech2,
 }
-
-Tech = techdict[DefaultPrefs.tech]
 
 
 class Classicfun(Fun):
@@ -35,19 +33,19 @@ class Classicfun(Fun):
         relevance to the emptiness status of a Classicfun so we
         arbitrarily set this to be DefaultPrefs.interval'''
         interval = Interval()
-        onefun = Tech.initempty()
+        onefun = techdict[prefs.tech].initempty()
         return cls(onefun, interval)
 
     @classmethod
     def initconst(cls, c, interval):
         '''Classicfun representation of a constant on the supplied interval'''
-        onefun = Tech.initconst(c)
+        onefun = techdict[prefs.tech].initconst(c)
         return cls(onefun, interval)
 
     @classmethod
     def initidentity(cls, interval):
         '''Classicfun representation of f(x) = x on the supplied interval'''
-        onefun = Tech.initvalues(np.asarray(interval))
+        onefun = techdict[prefs.tech].initvalues(np.asarray(interval))
         return cls(onefun, interval)
 
     @classmethod
@@ -55,7 +53,7 @@ class Classicfun(Fun):
         '''Adaptive initialisation of a BndFun from a callable function f
         and a Interval object'''
         uifunc = lambda y: f(interval(y))
-        onefun = Tech.initfun(uifunc)
+        onefun = techdict[prefs.tech].initfun(uifunc)
         return cls(onefun, interval)
 
     @classmethod
@@ -63,7 +61,7 @@ class Classicfun(Fun):
         '''Fixed length initialisation of a BndFun from a callable
         function f and a Interval object'''
         uifunc = lambda y: f(interval(y))
-        onefun = Tech.initfun(uifunc, n)
+        onefun = techdict[prefs.tech].initfun(uifunc, n)
         return cls(onefun, interval)
 
     # -------------------

--- a/chebpy/core/plotting.py
+++ b/chebpy/core/plotting.py
@@ -23,7 +23,7 @@ def import_plt():
 
 def plotfun(fn_y, support, ax=None, N=None, **kwargs):
     ax = ax or import_plt().gca()
-    N = prefs.N_plot if N is None else N
+    N = N if N is not None else prefs.N_plot
     a, b = support
     xx = np.linspace(a, b, N)
     ax.plot(xx, fn_y(xx), **kwargs)

--- a/chebpy/core/plotting.py
+++ b/chebpy/core/plotting.py
@@ -2,6 +2,7 @@ import importlib
 
 import numpy as np
 
+from chebpy.core.settings import userPrefs as prefs
 
 def _import_optional(name):
     """Attempt to import the specified module.
@@ -20,8 +21,9 @@ def import_plt():
     return _import_optional('matplotlib.pyplot')
 
 
-def plotfun(fn_y, support, ax=None, N=2001, **kwargs):
+def plotfun(fn_y, support, ax=None, N=None, **kwargs):
     ax = ax or import_plt().gca()
+    N = prefs.N_plot if N is None else N
     a, b = support
     xx = np.linspace(a, b, N)
     ax.plot(xx, fn_y(xx), **kwargs)

--- a/chebpy/core/settings.py
+++ b/chebpy/core/settings.py
@@ -14,6 +14,9 @@ class UserPrefs():
         self.domain = np.array([-1., 1.])
         self.N_plot = 2001
         self.maxpow2 = 16
+        self.maxiter = 10
+        self.sortroots = False
+        self.mergeroots = True
     def reset(self, *names):
         """Reset default preferences.
         `.reset()` resets all preferences to the DefaultPrefs state

--- a/chebpy/core/settings.py
+++ b/chebpy/core/settings.py
@@ -19,6 +19,7 @@ class DefaultPrefs():
     eps = np.finfo(float).eps
     tech = "Chebtech2"
     domain = np.array([-1., 1.])
+    N_plot = 2001
 
 class UserPrefs():
     def __init__(self):

--- a/chebpy/core/settings.py
+++ b/chebpy/core/settings.py
@@ -3,33 +3,30 @@
 import numpy as np
 
 
-def default_names(cls):
-    return [n for n in cls.__dict__.keys() if n[0] != "_"]
-
-def default_values(cls):
-    return [cls.__dict__[k] for k in default_names(cls)]
-
-def default_prefs(cls):
-    prefs = dict()
-    for key, val in zip(default_names(cls), default_values(cls)):
-        prefs[key] = val
-    return prefs
-
 class DefaultPrefs():
-    eps = np.finfo(float).eps
-    tech = "Chebtech2"
-    domain = np.array([-1., 1.])
-    N_plot = 2001
+    pass
+
 
 class UserPrefs():
     def __init__(self):
-        for name, val in default_prefs(DefaultPrefs).items():
-            setattr(self, name, val)
+        self.eps = np.finfo(float).eps
+        self.tech = "Chebtech2"
+        self.domain = np.array([-1., 1.])
+        self.N_plot = 2001
     def reset(self, *names):
-        # only reset DefaultPrefs, in case user set their own attributes
-        names = default_names(DefaultPrefs) if len(names) == 0 else names
+        """Reset default preferences.
+        `.reset()` resets all preferences to the DefaultPrefs state
+        `.reset(*names)` resets only the selected ones.
+        This leaves additional user-added prefs untouched."""
+        if len(names) == 0:
+            names = DefaultPrefs.__dict__.keys()
         for name in names:
             self.__setattr__(name, DefaultPrefs.__dict__[name])
 
-defaultPrefs = DefaultPrefs()
 userPrefs = UserPrefs()
+
+for name, val in userPrefs.__dict__.items():
+    if name[0] != "_":
+        setattr(DefaultPrefs, name, val)
+
+defaultPrefs = DefaultPrefs()

--- a/chebpy/core/settings.py
+++ b/chebpy/core/settings.py
@@ -2,7 +2,33 @@
 
 import numpy as np
 
+
+def default_names(cls):
+    return [n for n in cls.__dict__.keys() if n[0] != "_"]
+
+def default_values(cls):
+    return [cls.__dict__[k] for k in default_names(cls)]
+
+def default_prefs(cls):
+    prefs = dict()
+    for key, val in zip(default_names(cls), default_values(cls)):
+        prefs[key] = val
+    return prefs
+
 class DefaultPrefs():
-    eps  = np.finfo(float).eps
+    eps = np.finfo(float).eps
     tech = "Chebtech2"
     domain = np.array([-1., 1.])
+
+class UserPrefs():
+    def __init__(self):
+        for name, val in default_prefs(DefaultPrefs).items():
+            setattr(self, name, val)
+    def reset(self, *names):
+        # only reset DefaultPrefs, in case user set their own attributes
+        names = default_names(DefaultPrefs) if len(names) == 0 else names
+        for name in names:
+            self.__setattr__(name, DefaultPrefs.__dict__[name])
+
+defaultPrefs = DefaultPrefs()
+userPrefs = UserPrefs()

--- a/chebpy/core/settings.py
+++ b/chebpy/core/settings.py
@@ -13,6 +13,7 @@ class UserPrefs():
         self.tech = "Chebtech2"
         self.domain = np.array([-1., 1.])
         self.N_plot = 2001
+        self.maxpow2 = 16
     def reset(self, *names):
         """Reset default preferences.
         `.reset()` resets all preferences to the DefaultPrefs state

--- a/chebpy/core/settings.py
+++ b/chebpy/core/settings.py
@@ -19,7 +19,7 @@ class UserPrefs():
         `.reset(*names)` resets only the selected ones.
         This leaves additional user-added prefs untouched."""
         if len(names) == 0:
-            names = DefaultPrefs.__dict__.keys()
+            names = [k for k in DefaultPrefs.__dict__.keys() if k[0] != "_"]
         for name in names:
             self.__setattr__(name, DefaultPrefs.__dict__[name])
 

--- a/chebpy/core/ui.py
+++ b/chebpy/core/ui.py
@@ -15,7 +15,7 @@ def chebfun(f=None, domain=None, n=None):
     if f is None:
         return Chebfun.initempty()
 
-    domain = prefs.domain if domain is None else domain
+    domain = domain if domain is not None else prefs.domain
 
     # chebfun(lambda x: f(x), ... )
     if hasattr(f, "__call__"):

--- a/chebpy/core/ui.py
+++ b/chebpy/core/ui.py
@@ -5,7 +5,7 @@
 from chebpy.core.bndfun import Bndfun
 from chebpy.core.chebfun import Chebfun
 from chebpy.core.utilities import Domain
-from chebpy.core.settings import DefaultPrefs
+from chebpy.core.settings import userPrefs as prefs
 
 
 def chebfun(f=None, domain=None, n=None):
@@ -15,7 +15,7 @@ def chebfun(f=None, domain=None, n=None):
     if f is None:
         return Chebfun.initempty()
 
-    domain = DefaultPrefs.domain if domain is None else domain
+    domain = prefs.domain if domain is None else domain
 
     # chebfun(lambda x: f(x), ... )
     if hasattr(f, "__call__"):

--- a/implementation-notes.rst
+++ b/implementation-notes.rst
@@ -32,7 +32,13 @@ in their present form in Matlab Chebfun:
 
 -  ``Interval`` (core/utilities.py)
 -  ``Domain`` (core/utilities.py)
--  ``DefaultPrefs`` (core/settings.py)
+
+Chebpy allows the user to override some default preferences, similar to 
+what is available through ``chebfunpref`` in ``Chebfun`` (bottom right).
+Not all options are the same, and chebpy allows additional customisation
+not found in ``Chebfun``.
+
+-  ``UserPrefs`` (core/settings.py)
 
 The general rule is that each Chebpy class lives in its own python file.
 
@@ -331,4 +337,23 @@ values mapped to [a,b]:
             -8.00000000e-01,  -6.00000000e-01,  -4.00000000e-01,
             -2.00000000e-01,  -2.22044605e-16])
 
+
+UserPrefs
+~~~~~~~~~~~~~~
+
+The user may want to specify different tolerances, for example if speed is important
+or the function under consideration is particularly difficult. It is also possible to
+change default behaviour like plotting.
+
+.. code:: python
+
+    import matplotlib.pyplot as plt
+    import chebpy
+    chebpy.core.settings.userPrefs.eps = 1e-10  # lower the tolerance in chebpy
+    cheb = chebpy.chebfun(lambda x: x**2)
+    chebpy.core.settings.userPrefs.N_plot = 21  # use fewer points for plotting
+    cheb.plot(marker='x', label='few points')
+    chebpy.core.settings.userPrefs.reset('N_plot')  # restore default
+    cheb.plot(label='many points')
+    plt.show()
 

--- a/tests/test_chebfun.py
+++ b/tests/test_chebfun.py
@@ -133,7 +133,8 @@ class Construction(unittest.TestCase):
         initfun = Chebfun.initfun_adaptive
         self.assertRaises(BadDomainArgument, initfun, self.f, [-2])
         self.assertRaises(BadDomainArgument, initfun, self.f, domain=[-2])
-        self.assertRaises(BadDomainArgument, initfun, self.f, domain=None)
+        self.assertRaises(BadDomainArgument, initfun, self.f, domain=0)
+        self.assertRaises(BadDomainArgument, initfun, self.f, domain=[])
 
     def test_initfun_fixedlen_continuous_domain(self):
         ff = Chebfun.initfun_fixedlen(self.f, 20, [-2,-1])
@@ -173,7 +174,8 @@ class Construction(unittest.TestCase):
         initfun = Chebfun.initfun_fixedlen
         self.assertRaises(BadDomainArgument, initfun, self.f, 10, [-2])
         self.assertRaises(BadDomainArgument, initfun, self.f, n=10, domain=[-2])
-        self.assertRaises(BadDomainArgument, initfun, self.f, n=10, domain=None)
+        self.assertRaises(BadDomainArgument, initfun, self.f, n=10, domain=0)
+        self.assertRaises(BadDomainArgument, initfun, self.f, n=10, domain=[])
         self.assertRaises(BadFunLengthArgument, initfun, self.f, [30,40], [-1,1])
         self.assertRaises(TypeError, initfun, self.f, None, [-1,1])
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import chebpy
+
+def userPref(name):
+    from chebpy.core.settings import userPrefs
+    return getattr(userPrefs, name)
+
+class Settings(unittest.TestCase):
+
+    def test_update_pref(self):
+        eps_new = 1e-3
+        eps_old = chebpy.core.settings.userPrefs.eps
+        chebpy.core.settings.userPrefs.eps = eps_new
+        self.assertEqual(eps_new, userPref('eps'))
+        chebpy.core.settings.userPrefs.eps = eps_old  # we *must* change it back
+
+    def test_reset(self):
+        def change(reset_named=False):
+            chebpy.core.settings.userPrefs.eps = 99
+            if reset_named:
+                chebpy.core.settings.userPrefs.reset('eps')
+            else:
+                chebpy.core.settings.userPrefs.reset()
+        eps_bak = chebpy.core.settings.defaultPrefs.eps
+        change(False)
+        self.assertEqual(eps_bak, userPref('eps'))
+        change(True)
+        self.assertEqual(eps_bak, userPref('eps'))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -20,6 +20,7 @@ from tests.utilities import infnorm
 
 np.random.seed(0)
 eps = DefaultPrefs.eps
+HTOL = HTOL()
 
 
 # tests for usage of the Interval class


### PR DESCRIPTION
A lot of defaults in chebpy are either hard-coded or stored in `chebpy.core.settings.DefaultPrefs`. Even though these `DefaultPrefs` may be changed by the user, their usage in defaults for optional function arguments means the values are locked in at import time and not accessible to the user. I have refactored the way default settings are accessed, which now allows anyone to alter them if desired. They can also be reset.

For example:
```Python
import matplotlib.pyplot as plt
import chebpy
chebpy.core.settings.userPrefs.eps = 1e-10  # lower the tolerance for adaptive construction
cheb = chebpy.chebfun(lambda x: x**2)
chebpy.core.settings.userPrefs.N_plot = 21  # use fewer points for plotting
cheb.plot(marker='x', label='few points')
chebpy.core.settings.userPrefs.reset('N_plot')  # restore default
cheb.plot(label='many points')
plt.show()
```

Note that if we use `from chebpy.core.settings import userPrefs`, changes to `userPrefs` are local only.

## ToDo before merging

- [x] Add to the documentation
- [x] Track down other defaults in the code and add to `userPrefs`