### PR TITLE
Improve adaptive construction

### DIFF
--- a/chebpy/core/algorithms.py
+++ b/chebpy/core/algorithms.py
@@ -153,7 +153,12 @@ def standard_chop(coeffs, tol=None):
     (http://arxiv.org/pdf/1512.01803v1.pdf)
     """
 
+    # check magnitude of tol:
     tol = tol if tol is not None else prefs.eps
+    if tol >= 1:
+        cutoff = 1
+        return cutoff
+
     # ensure length at least 17:
     n = coeffs.size
     cutoff = n

--- a/chebpy/core/algorithms.py
+++ b/chebpy/core/algorithms.py
@@ -203,7 +203,7 @@ def standard_chop(coeffs, tol=None):
     return min( (cutoff, n-1) )
 
 
-def adaptive(cls, fun, maxpow2=None):
+def adaptive(cls, fun, hscale=1, maxpow2=None):
     """Adaptive constructor: cycle over powers of two, calling
     standard_chop each time, the output of which determines whether or not
     we are happy."""
@@ -214,7 +214,9 @@ def adaptive(cls, fun, maxpow2=None):
         points = cls._chebpts(n)
         values = fun(points)
         coeffs = cls._vals2coeffs(values)
-        chplen = standard_chop(coeffs)
+        eps = prefs.eps
+        tol = eps*max(hscale, 1)  # scale (decrease) tolerance by hscale
+        chplen = standard_chop(coeffs, tol=tol)
         if chplen < coeffs.size:
             coeffs = coeffs[:chplen]
             break

--- a/chebpy/core/algorithms.py
+++ b/chebpy/core/algorithms.py
@@ -320,3 +320,11 @@ def newtonroots(fun, rts, tol=None, maxiter=None):
             prv = rts
             rts = rts - fun(rts) / dfun(rts)
     return rts
+
+
+def interval2hscale(interval):
+    dom = (interval[0], interval[-1])
+    hscale = max(np.linalg.norm(dom, np.inf), 1)
+    hscaleF = dom[-1]-dom[0]  # this scales hscale back to 1 if interval=domain
+    hscale = max(hscale/hscaleF, 1)  # otherwise, hscale < 1 in default case
+    return hscale

--- a/chebpy/core/algorithms.py
+++ b/chebpy/core/algorithms.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 
 from chebpy.core.ffts import fft, ifft
-from chebpy.core.utilities import Interval
+from chebpy.core.utilities import Interval, infnorm
 from chebpy.core.settings import userPrefs as prefs
 from chebpy.core.decorators import preandpostprocess
 
@@ -320,16 +320,8 @@ def newtonroots(fun, rts, tol=None, maxiter=None):
         dfun = fun.diff()
         prv = np.inf*rts
         count = 0
-        while (np.linalg.norm(rts-prv, np.inf)>tol) & (count<=maxiter):
+        while (infnorm(rts-prv)>tol) & (count<=maxiter):
             count += 1
             prv = rts
             rts = rts - fun(rts) / dfun(rts)
     return rts
-
-
-def interval2hscale(interval):
-    dom = (interval[0], interval[-1])
-    hscale = max(np.linalg.norm(dom, np.inf), 1)
-    hscaleF = dom[-1]-dom[0]  # this scales hscale back to 1 if interval=domain
-    hscale = max(hscale/hscaleF, 1)  # otherwise, hscale < 1 in default case
-    return hscale

--- a/chebpy/core/algorithms.py
+++ b/chebpy/core/algorithms.py
@@ -37,7 +37,7 @@ def rootsunit(ak, htol=None):
         Practice, SIAM, 2013, chapter 18.
     """
     htol = htol if htol is not None else 1e2*prefs.eps
-    n = standard_chop(ak)
+    n = standard_chop(ak, tol=htol)
     ak = ak[:n]
 
     # if n > 50, we split and recurse

--- a/chebpy/core/chebtech.py
+++ b/chebpy/core/chebtech.py
@@ -63,10 +63,15 @@ class Chebtech(Smoothfun):
         return cls(coeffs)
 
     @classmethod
-    def initfun_adaptive(cls, fun):
+    def initfun_adaptive(cls, fun, interval=None):
         '''Initialise a Chebtech from the callable fun utilising the adaptive
         constructor to determine the number of degrees of freedom parameter.'''
-        coeffs = adaptive(cls, fun)
+        interval = interval if interval is not None else prefs.domain
+        dom = (interval[0], interval[-1])
+        hscale = max(np.linalg.norm(dom, np.inf), 1)
+        hscaleF = dom[-1]-dom[0]  # this scales hscale back to 1 if interval=domain
+        hscale = max(hscale/hscaleF, 1)  # otherwise, hscale < 1 in default case
+        coeffs = adaptive(cls, fun, hscale=hscale)
         return cls(coeffs)
 
     @classmethod

--- a/chebpy/core/chebtech.py
+++ b/chebpy/core/chebtech.py
@@ -177,13 +177,16 @@ class Chebtech(Smoothfun):
         '''Call standard_chop on the coefficients of self, returning a
         Chebtech comprised of a copy of the truncated coefficients.'''
         # coefficients
-        cfs = self.coeffs
+        oldlen = len(self.coeffs)
+        longself = self.prolong(max(17, oldlen))
+        cfs = longself.coeffs
         # tolerance
         hscale = interval2hscale(self.interval)
         eps = prefs.eps
         tol = eps*max(hscale, 1)  # scale (decrease) tolerance by hscale
         # chop
         npts = standard_chop(cfs, tol=tol)
+        npts = min(oldlen, npts)
         # construct
         return self.__class__(cfs[:npts].copy(), interval=self.interval)
 

--- a/chebpy/core/chebtech.py
+++ b/chebpy/core/chebtech.py
@@ -11,8 +11,9 @@ from chebpy.core.decorators import self_empty
 from chebpy.core.algorithms import (bary, clenshaw, adaptive, coeffmult,
                                     vals2coeffs2, coeffs2vals2, chebpts2,
                                     barywts2, rootsunit, newtonroots,
-                                    standard_chop, interval2hscale)
+                                    standard_chop)
 from chebpy.core.plotting import import_plt, plotfun, plotfuncoeffs
+from chebpy.core.utilities import Interval
 
 
 class Chebtech(Smoothfun):
@@ -67,8 +68,8 @@ class Chebtech(Smoothfun):
         '''Initialise a Chebtech from the callable fun utilising the adaptive
         constructor to determine the number of degrees of freedom parameter.'''
         interval = interval if interval is not None else prefs.domain
-        hscale = interval2hscale(interval)
-        coeffs = adaptive(cls, fun, hscale=hscale)
+        interval = Interval(*interval)
+        coeffs = adaptive(cls, fun, hscale=interval.hscale)
         return cls(coeffs, interval=interval)
 
     @classmethod
@@ -79,7 +80,7 @@ class Chebtech(Smoothfun):
     def __init__(self, coeffs, interval=None):
         interval = interval if interval is not None else prefs.domain
         self._coeffs = np.array(coeffs, dtype=float)
-        self._interval = np.array(interval)
+        self._interval = Interval(*interval)
 
     def __call__(self, x, how='clenshaw'):
         method = {
@@ -180,10 +181,8 @@ class Chebtech(Smoothfun):
         oldlen = len(self.coeffs)
         longself = self.prolong(max(17, oldlen))
         cfs = longself.coeffs
-        # tolerance
-        hscale = interval2hscale(self.interval)
-        eps = prefs.eps
-        tol = eps*max(hscale, 1)  # scale (decrease) tolerance by hscale
+        # scale (decrease) tolerance by hscale
+        tol = prefs.eps*max(self.interval.hscale, 1)
         # chop
         npts = standard_chop(cfs, tol=tol)
         npts = min(oldlen, npts)

--- a/chebpy/core/classicfun.py
+++ b/chebpy/core/classicfun.py
@@ -33,19 +33,19 @@ class Classicfun(Fun):
         relevance to the emptiness status of a Classicfun so we
         arbitrarily set this to be DefaultPrefs.interval'''
         interval = Interval()
-        onefun = techdict[prefs.tech].initempty()
+        onefun = techdict[prefs.tech].initempty(interval=interval)
         return cls(onefun, interval)
 
     @classmethod
     def initconst(cls, c, interval):
         '''Classicfun representation of a constant on the supplied interval'''
-        onefun = techdict[prefs.tech].initconst(c)
+        onefun = techdict[prefs.tech].initconst(c, interval=interval)
         return cls(onefun, interval)
 
     @classmethod
     def initidentity(cls, interval):
         '''Classicfun representation of f(x) = x on the supplied interval'''
-        onefun = techdict[prefs.tech].initvalues(np.asarray(interval))
+        onefun = techdict[prefs.tech].initvalues(np.asarray(interval), interval=interval)
         return cls(onefun, interval)
 
     @classmethod
@@ -53,7 +53,7 @@ class Classicfun(Fun):
         '''Adaptive initialisation of a BndFun from a callable function f
         and a Interval object'''
         uifunc = lambda y: f(interval(y))
-        onefun = techdict[prefs.tech].initfun(uifunc)
+        onefun = techdict[prefs.tech].initfun(uifunc, interval=interval)
         return cls(onefun, interval)
 
     @classmethod
@@ -61,7 +61,7 @@ class Classicfun(Fun):
         '''Fixed length initialisation of a BndFun from a callable
         function f and a Interval object'''
         uifunc = lambda y: f(interval(y))
-        onefun = techdict[prefs.tech].initfun(uifunc, n)
+        onefun = techdict[prefs.tech].initfun(uifunc, n, interval=interval)
         return cls(onefun, interval)
 
     # -------------------

--- a/chebpy/core/utilities.py
+++ b/chebpy/core/utilities.py
@@ -61,6 +61,14 @@ class Interval(np.ndarray):
         a,b = self
         return np.logical_and(a<x, x<b)
 
+    @property
+    def hscale(self):
+        a, b = self
+        h = max(infnorm(self), 1)
+        hF = b - a             # if interval == domain: scale hscale back to 1
+        hscale = max(h/hF, 1)  #                  else: hscale < 1
+        return hscale
+
 
 def _merge_duplicates(arr, tols):
     """Remove duplicate entries from an input array to within array tolerance
@@ -242,3 +250,7 @@ def generate_funs(domain, bndfun_constructor, arglist=[]):
         fun = bndfun_constructor(*args)
         funs = np.append(funs, fun)
     return funs
+
+
+def infnorm(vals):
+    return np.linalg.norm(vals, np.inf)


### PR DESCRIPTION
This mostly adds support for intervals at the Chebtech level. Even though Chebtech works on [-1, 1] and has no notion of scale, this change informs the tech algorithms of the hscale of the interval the function is fit to and passes the relaxed tolerances to standard_chop. This is also done in Chebfun.

