### PR TITLE
Add pickling support to Interval

### DIFF
--- a/chebpy/core/utilities.py
+++ b/chebpy/core/utilities.py
@@ -42,6 +42,17 @@ class Interval(np.ndarray):
         self.invmap = lambda x: (2.*x-a-b) / (b-a)
         self.drvmap = lambda y: 0.*y + .5*(b-a)
         return self
+      
+    def __reduce__(self):
+        old_pickle = super(Interval, self).__reduce__()
+        new_pickle = old_pickle[2] + (self.formap, self.invmap, self.drvmap)
+        return (old_pickle[0], old_pickle[1], new_pickle)
+      
+    def __setstate__(self):
+        self.formap = state[-3]
+        self.invmap = state[-2]
+        self.drvmap = state[-1]
+        super(Interval, self).__setstate__(state[:-3])
 
     def __eq__(self, other):
         (a,b), (x,y) = self, other

--- a/chebpy/core/utilities.py
+++ b/chebpy/core/utilities.py
@@ -37,23 +37,20 @@ class Interval(np.ndarray):
     def __new__(cls, a=-1., b=1.):
         if a >= b:
             raise IntervalValues
-        self = np.asarray((a,b), dtype=float).view(cls)
-        self.formap = lambda y: .5*b*(y+1.) + .5*a*(1.-y)
-        self.invmap = lambda x: (2.*x-a-b) / (b-a)
-        self.drvmap = lambda y: 0.*y + .5*(b-a)
-        return self
-      
-    def __reduce__(self):
-        old_pickle = super(Interval, self).__reduce__()
-        new_pickle = old_pickle[2] + (self.formap, self.invmap, self.drvmap)
-        return (old_pickle[0], old_pickle[1], new_pickle)
-      
-    def __setstate__(self):
-        self.formap = state[-3]
-        self.invmap = state[-2]
-        self.drvmap = state[-1]
-        super(Interval, self).__setstate__(state[:-3])
+        return np.asarray((a,b), dtype=float).view(cls)
 
+    def formap(self, y):
+        a, b = self
+        return .5*b*(y+1.) + .5*a*(1.-y)
+
+    def invmap(self, x):
+        a, b = self
+        return (2.*x-a-b) / (b-a)
+
+    def drvmap(self, y):
+        a, b = self
+        return 0.*y + .5*(b-a)
+      
     def __eq__(self, other):
         (a,b), (x,y) = self, other
         return (a==x) & (y==b)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import pickle
 import numpy as np
 from chebpy import chebfun, pwc
 from chebpy.core.settings import DefaultPrefs
@@ -76,3 +77,17 @@ class Constructors(unittest.TestCase):
         for fun, val in zip(f,vals):
             self.assertTrue(fun.isconst)
             self.assertEqual(fun.coeffs[0], val)
+
+class Pickling(unittest.TestCase):
+
+    def setUp(self):
+        self.f0 = chebfun(np.sin, [-2, 0, 1])
+        self.f1 = pickle.loads(pickle.dumps(self.f0))
+
+    def test_evaluate(self):
+        x = -1
+        self.assertEqual(self.f0(x), self.f1(x))
+
+    #TODO: implement test for equality once objects can be compared
+    #def test_equality(self):
+        #self.assertEqual(vars(self.f0), vars(self.f1))


### PR DESCRIPTION
See #27 

Solution follows [this example](https://stackoverflow.com/a/26599346), by providing the [`__reduce__`](https://numpy.org/devdocs/reference/generated/numpy.ndarray.__reduce__.html) and [`__setstate__`](https://numpy.org/devdocs/reference/generated/numpy.ndarray.__setstate__.html) methods.

Sadly, Python's default `pickle` module does not support `lambda` expressions (yet?). This means the user must use [dill](https://github.com/uqfoundation/dill).