### PR TITLE
Update conda badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ ChebPy - A Python implementation of Chebfun
     :target: https://coveralls.io/github/chebpy/chebpy?branch=master
 .. image:: https://img.shields.io/badge/python-%203.6,%203.7,%203.8-blue.svg?
     :target: https://travis-ci.org/chebpy/chebpy
-.. image:: https://anaconda.org/conda-forge/chebfun/badges/installer/conda.svg
+.. image:: https://img.shields.io/conda/dn/conda-forge/chebfun?label=conda%20downloads
     :target: https://anaconda.org/conda-forge/chebfun
 
 |


### PR DESCRIPTION
Badge provided through anaconda.org does not fit the style of the other badges (rounded corners, aka "flat").
Luckily, shields.io has a special /conda mechanism that takes care of color & data, but with usual control over badge style.
As a result, the badge now shows the number of downloads.