### PR TITLE
Add Binder support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,8 @@ ChebPy - A Python implementation of Chebfun
     :target: https://travis-ci.org/chebpy/chebpy
 .. image:: https://img.shields.io/conda/dn/conda-forge/chebfun?label=conda%20downloads
     :target: https://anaconda.org/conda-forge/chebfun
+.. image:: https://mybinder.org/badge_logo.svg
+    :target: https://mybinder.org/v2/gh/chebpy/chebpy/HEAD?filepath=docs%2Fnotebook-getting-started.ipynb
 
 |
 


### PR DESCRIPTION
I did some investigating and the repo almost supports Binder out of the box. The only problem is the `matplotlib` dependency which is optional since #11.

Right now, Binder uses the `requirements.txt` file to spin up the server. There are several [other config files supported by Binder](https://mybinder.readthedocs.io/en/latest/using/config_files.html#config-files). I'm not 100% sure about the current community standards for the various files (`requirements.txt`, `setup.py`, `project.toml`) so some investigation is needed. Before merging and declaring this repo Binder friendly, we should discuss this in a separate issue.

## Changes

The badge in the README is generated by https://mybinder.org/ and results in the clickable link. I have left the "Git ref" as `HEAD` (I think in GitHub that refers to HEAD of the default branch) and added a link to the [docs/notebook-getting-started.ipynb](https://github.com/chebpy/chebpy/blob/master/docs/notebook-getting-started.ipynb) notebook.
