### PR TITLE
Code format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,18 @@
+name: Check code format
+
+on: [push, pull_request]
+
+jobs:
+
+  black-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Black
+        run: pip install black
+      - name: Run black --check
+        run: black --check .

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,8 @@ ChebPy - A Python implementation of Chebfun
     :target: https://github.com/chebpy/chebpy
 .. image:: https://img.shields.io/conda/dn/conda-forge/chebfun?label=conda%20downloads
     :target: https://anaconda.org/conda-forge/chebfun
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/psf/black
 .. image:: https://mybinder.org/badge_logo.svg
     :target: https://mybinder.org/v2/gh/chebpy/chebpy/v0.4.3?filepath=docs%2Fnotebook-getting-started.ipynb
 

--- a/chebpy/api.py
+++ b/chebpy/api.py
@@ -32,7 +32,7 @@ def chebfun(f=None, domain=None, n=None):
         raise ValueError(f)
 
 
-def pwc(domain=[-1,0,1], values=[0,1]):
+def pwc(domain=[-1, 0, 1], values=[0, 1]):
     """Initialise a piecewise-constant Chebfun"""
     funs = []
     intervals = [x for x in Domain(domain).intervals]

--- a/chebpy/core/algorithms.py
+++ b/chebpy/core/algorithms.py
@@ -8,7 +8,7 @@ from .settings import _preferences as prefs
 from .decorators import preandpostprocess
 
 # supress numpy division and multiply warnings
-np.seterr(divide='ignore', invalid='ignore')
+np.seterr(divide="ignore", invalid="ignore")
 
 # constants
 SPLITPOINT = -0.004849834917525
@@ -16,6 +16,7 @@ SPLITPOINT = -0.004849834917525
 # local helpers
 def find(x):
     return np.where(x)[0]
+
 
 def rootsunit(ak, htol=None):
     """Compute the roots of a funciton on [-1,1] using the coefficeints
@@ -33,7 +34,7 @@ def rootsunit(ak, htol=None):
     .. [3] L. N. Trefethen, Approximation Theory and Approximation
         Practice, SIAM, 2013, chapter 18.
     """
-    htol = htol if htol is not None else 1e2*prefs.eps
+    htol = htol if htol is not None else 1e2 * prefs.eps
     n = standard_chop(ak, tol=htol)
     ak = ak[:n]
 
@@ -48,8 +49,8 @@ def rootsunit(ak, htol=None):
         rval = clenshaw(rpts, ak)
         lcfs = vals2coeffs2(lval)
         rcfs = vals2coeffs2(rval)
-        lrts = rootsunit(lcfs, 2*htol)
-        rrts = rootsunit(rcfs, 2*htol)
+        lrts = rootsunit(lcfs, 2 * htol)
+        rrts = rootsunit(rcfs, 2 * htol)
         return np.append(lmap(lrts), rmap(rrts))
 
     # trivial base case
@@ -59,26 +60,27 @@ def rootsunit(ak, htol=None):
     # nontrivial base case: either compute directly or solve
     # a Colleague Matrix eigenvalue problem
     if n == 2:
-        rts = np.array([-ak[0]/ak[1]])
+        rts = np.array([-ak[0] / ak[1]])
     elif n <= 50:
-        v = .5 * np.ones(n-2)
-        C = np.diag(v,-1) + np.diag(v, 1)
-        C[0,1] = 1
+        v = 0.5 * np.ones(n - 2)
+        C = np.diag(v, -1) + np.diag(v, 1)
+        C[0, 1] = 1
         D = np.zeros(C.shape, dtype=ak.dtype)
-        D[-1,:] = ak[:-1]
-        E = C - .5 * 1./ak[-1] * D
+        D[-1, :] = ak[:-1]
+        E = C - 0.5 * 1.0 / ak[-1] * D
         rts = np.linalg.eigvals(E)
 
     # discard values with large imaginary part and treat the remaining
     # ones as real; then sort and retain only the roots inside [-1,1]
     mask = abs(np.imag(rts)) < htol
     rts = np.real(rts[mask])
-    rts = rts[abs(rts)<=1.+htol]
+    rts = rts[abs(rts) <= 1.0 + htol]
     rts = np.sort(rts)
     if rts.size >= 2:
-        rts[ 0] = max([rts[ 0],-1])
+        rts[0] = max([rts[0], -1])
         rts[-1] = min([rts[-1], 1])
     return rts
+
 
 @preandpostprocess
 def bary(xx, fk, xk, vk):
@@ -100,7 +102,7 @@ def bary(xx, fk, xk, vk):
     """
 
     # either iterate over the evaluation points, or ...
-    if xx.size < 4*xk.size:
+    if xx.size < 4 * xk.size:
         out = np.zeros(xx.size)
         for i in range(xx.size):
             tt = vk / (xx[i] - xk)
@@ -118,7 +120,7 @@ def bary(xx, fk, xk, vk):
 
     # replace NaNs
     for k in find(np.isnan(out)):
-        idx = find( xx[k] == xk )
+        idx = find(xx[k] == xk)
         if idx.size > 0:
             out[k] = fk[idx[0]]
 
@@ -127,18 +129,18 @@ def bary(xx, fk, xk, vk):
 
 @preandpostprocess
 def clenshaw(xx, ak):
-    """Clenshaw's algorithm for the evaluation of a first-kind Chebyshev 
+    """Clenshaw's algorithm for the evaluation of a first-kind Chebyshev
     series expansion at some array of points x"""
-    bk1 = 0*xx
-    bk2 = 0*xx
-    xx = 2*xx
+    bk1 = 0 * xx
+    bk2 = 0 * xx
+    xx = 2 * xx
     idx = range(ak.size)
-    for k in idx[ak.size:1:-2]:
-        bk2 = ak[k] + xx*bk1 - bk2
-        bk1 = ak[k-1] + xx*bk2 - bk1
-    if np.mod(ak.size-1, 2) == 1:
-        bk1, bk2 = ak[1] + xx*bk1 - bk2, bk1
-    out = ak[0] + .5*xx*bk1 - bk2
+    for k in idx[ak.size : 1 : -2]:
+        bk2 = ak[k] + xx * bk1 - bk2
+        bk1 = ak[k - 1] + xx * bk2 - bk1
+    if np.mod(ak.size - 1, 2) == 1:
+        bk1, bk2 = ak[1] + xx * bk1 - bk2, bk1
+    out = ak[0] + 0.5 * xx * bk1 - bk2
     return out
 
 
@@ -166,23 +168,23 @@ def standard_chop(coeffs, tol=None):
     # vector (envelope) normalized to begin with the value 1.
     b = np.flipud(np.abs(coeffs))
     m = np.flipud(np.maximum.accumulate(b))
-    if m[0] == 0.:
+    if m[0] == 0.0:
         # TODO: check this
-        cutoff = 1 # cutoff = 0
+        cutoff = 1  # cutoff = 0
         return cutoff
     envelope = m / m[0]
 
     # Step 2: Scan envelope for a value plateauPoint, the first point, if any,
     # that is followed by a plateau
     for j in np.arange(1, n):
-        j2 = round(1.25*j+5)
-        if j2 > n-1:
+        j2 = round(1.25 * j + 5)
+        if j2 > n - 1:
             # there is no plateau: exit
             return cutoff
         e1 = envelope[j]
         e2 = envelope[int(j2)]
         r = 3 * (1 - np.log(e1) / np.log(tol))
-        plateau = (e1==0.) | (e2/e1>r)
+        plateau = (e1 == 0.0) | (e2 / e1 > r)
         if plateau:
             # a plateau has been found: go to Step 3
             plateauPoint = j
@@ -190,19 +192,19 @@ def standard_chop(coeffs, tol=None):
 
     # Step 3: Fix cutoff at a point where envelope, plus a linear function
     # included to bias the result towards the left end, is minimal.
-    if envelope[int(plateauPoint)] == 0.:
+    if envelope[int(plateauPoint)] == 0.0:
         cutoff = plateauPoint
     else:
-        j3 = sum(envelope >= tol**(7./6.))
+        j3 = sum(envelope >= tol ** (7.0 / 6.0))
         if j3 < j2:
             j2 = j3 + 1
-            envelope[j2] = tol**(7./6.)
-        cc = np.log10(envelope[:int(j2)])
-        cc = cc + np.linspace(0, (-1./3.)*np.log10(tol), int(j2))
+            envelope[j2] = tol ** (7.0 / 6.0)
+        cc = np.log10(envelope[: int(j2)])
+        cc = cc + np.linspace(0, (-1.0 / 3.0) * np.log10(tol), int(j2))
         d = np.argmin(cc)
         # TODO: check this
-        cutoff = d # + 2
-    return min( (cutoff, n-1) )
+        cutoff = d  # + 2
+    return min((cutoff, n - 1))
 
 
 def adaptive(cls, fun, hscale=1, maxpow2=None):
@@ -211,20 +213,22 @@ def adaptive(cls, fun, hscale=1, maxpow2=None):
     we are happy."""
     minpow2 = 4  # 17 points
     maxpow2 = maxpow2 if maxpow2 is not None else prefs.maxpow2
-    for k in range(minpow2, max(minpow2, maxpow2)+1):
-        n = 2**k + 1
+    for k in range(minpow2, max(minpow2, maxpow2) + 1):
+        n = 2 ** k + 1
         points = cls._chebpts(n)
         values = fun(points)
         coeffs = cls._vals2coeffs(values)
         eps = prefs.eps
-        tol = eps*max(hscale, 1)  # scale (decrease) tolerance by hscale
+        tol = eps * max(hscale, 1)  # scale (decrease) tolerance by hscale
         chplen = standard_chop(coeffs, tol=tol)
         if chplen < coeffs.size:
             coeffs = coeffs[:chplen]
             break
         if k == maxpow2:
-            warnings.warn('The {} constructor did not converge: '\
-                          'using {} points'.format(cls.__name__, n))
+            warnings.warn(
+                "The {} constructor did not converge: "
+                "using {} points".format(cls.__name__, n)
+            )
             break
     return coeffs
 
@@ -232,11 +236,11 @@ def adaptive(cls, fun, hscale=1, maxpow2=None):
 def coeffmult(fc, gc):
     """Coefficient-Space multiplication of equal-length first-kind
     Chebyshev series."""
-    Fc = np.append( 2.*fc[:1], (fc[1:], fc[:0:-1]) )
-    Gc = np.append( 2.*gc[:1], (gc[1:], gc[:0:-1]) )
-    ak = ifft( fft(Fc) * fft(Gc) )
-    ak = np.append( ak[:1], ak[1:] + ak[:0:-1] ) * .25
-    ak = ak[:fc.size]
+    Fc = np.append(2.0 * fc[:1], (fc[1:], fc[:0:-1]))
+    Gc = np.append(2.0 * gc[:1], (gc[1:], gc[:0:-1]))
+    ak = ifft(fft(Fc) * fft(Gc))
+    ak = np.append(ak[:1], ak[1:] + ak[:0:-1]) * 0.25
+    ak = ak[: fc.size]
     inputcfs = np.append(fc, gc)
     out = np.real(ak) if np.isreal(inputcfs).all() else ak
     return out
@@ -249,19 +253,19 @@ def barywts2(n):
     elif n == 1:
         wts = np.array([1])
     else:
-        wts = np.append(np.ones(n-1), .5)
-        wts[n-2::-2] = -1
-        wts[0] = .5 * wts[0]
+        wts = np.append(np.ones(n - 1), 0.5)
+        wts[n - 2 :: -2] = -1
+        wts[0] = 0.5 * wts[0]
     return wts
 
 
 def chebpts2(n):
     """Return n Chebyshev points of the second-kind"""
     if n == 1:
-        pts = np.array([0.])
+        pts = np.array([0.0])
     else:
         nn = np.arange(n)
-        pts = np.cos(nn[::-1]*np.pi/(n-1))
+        pts = np.cos(nn[::-1] * np.pi / (n - 1))
     return pts
 
 
@@ -272,17 +276,17 @@ def vals2coeffs2(vals):
     if n <= 1:
         coeffs = vals
         return coeffs
-    tmp = np.append( vals[::-1], vals[1:-1] )
+    tmp = np.append(vals[::-1], vals[1:-1])
     if np.isreal(vals).all():
         coeffs = ifft(tmp)
         coeffs = np.real(coeffs)
-    elif np.isreal( 1j*vals ).all():
+    elif np.isreal(1j * vals).all():
         coeffs = ifft(np.imag(tmp))
         coeffs = 1j * np.real(coeffs)
     else:
         coeffs = ifft(tmp)
     coeffs = coeffs[:n]
-    coeffs[1:n-1] = 2*coeffs[1:n-1]
+    coeffs[1 : n - 1] = 2 * coeffs[1 : n - 1]
     return coeffs
 
 
@@ -294,30 +298,30 @@ def coeffs2vals2(coeffs):
         vals = coeffs
         return vals
     coeffs = coeffs.copy()
-    coeffs[1:n-1] = .5 * coeffs[1:n-1]
-    tmp = np.append( coeffs, coeffs[n-2:0:-1] )
+    coeffs[1 : n - 1] = 0.5 * coeffs[1 : n - 1]
+    tmp = np.append(coeffs, coeffs[n - 2 : 0 : -1])
     if np.isreal(coeffs).all():
         vals = fft(tmp)
         vals = np.real(vals)
-    elif np.isreal(1j*coeffs).all():
+    elif np.isreal(1j * coeffs).all():
         vals = fft(np.imag(tmp))
         vals = 1j * np.real(vals)
     else:
         vals = fft(tmp)
-    vals = vals[n-1::-1]
+    vals = vals[n - 1 :: -1]
     return vals
 
 
 def newtonroots(fun, rts, tol=None, maxiter=None):
     """Rootfinding for a callable and differentiable fun, typically used to
     polish already computed roots."""
-    tol = tol if tol is not None else 2*prefs.eps
+    tol = tol if tol is not None else 2 * prefs.eps
     maxiter = maxiter if maxiter is not None else prefs.maxiter
     if rts.size > 0:
         dfun = fun.diff()
-        prv = np.inf*rts
+        prv = np.inf * rts
         count = 0
-        while (infnorm(rts-prv)>tol) & (count<=maxiter):
+        while (infnorm(rts - prv) > tol) & (count <= maxiter):
             count += 1
             prv = rts
             rts = rts - fun(rts) / dfun(rts)

--- a/chebpy/core/bndfun.py
+++ b/chebpy/core/bndfun.py
@@ -1,5 +1,7 @@
 from .classicfun import Classicfun
 
+
 class Bndfun(Classicfun):
     """Class to approximate functions on bounded intervals [a,b]"""
+
     pass

--- a/chebpy/core/chebtech.py
+++ b/chebpy/core/chebtech.py
@@ -5,28 +5,37 @@ import numpy as np
 from .smoothfun import Smoothfun
 from .settings import _preferences as prefs
 from .decorators import self_empty
-from .algorithms import (bary, clenshaw, adaptive, coeffmult,
-                         vals2coeffs2, coeffs2vals2, chebpts2,
-                         barywts2, rootsunit, newtonroots,
-                         standard_chop)
+from .algorithms import (
+    bary,
+    clenshaw,
+    adaptive,
+    coeffmult,
+    vals2coeffs2,
+    coeffs2vals2,
+    chebpts2,
+    barywts2,
+    rootsunit,
+    newtonroots,
+    standard_chop,
+)
 from .plotting import import_plt, plotfun, plotfuncoeffs
 from .utilities import Interval, coerce_list
 
 
 class Chebtech(Smoothfun, ABC):
-    '''Abstract base class serving as the template for Chebtech1 and
-    Chebtech2 subclasses. 
+    """Abstract base class serving as the template for Chebtech1 and
+    Chebtech2 subclasses.
 
-    Chebtech objects always work with first-kind coefficients, so much 
+    Chebtech objects always work with first-kind coefficients, so much
     of the core operational functionality is defined this level.
 
     The user will rarely work with these classes directly so we make
     several assumptions regarding input data types.
-    '''
-    
+    """
+
     @classmethod
     def initconst(cls, c, *, interval=None):
-        '''Initialise a Chebtech from a constant c'''
+        """Initialise a Chebtech from a constant c"""
         if not np.isscalar(c):
             raise ValueError(c)
         if isinstance(c, int):
@@ -35,18 +44,18 @@ class Chebtech(Smoothfun, ABC):
 
     @classmethod
     def initempty(cls, *, interval=None):
-        '''Initialise an empty Chebtech'''
+        """Initialise an empty Chebtech"""
         return cls(np.array([]), interval=interval)
 
     @classmethod
     def initidentity(cls, *, interval=None):
-        '''Chebtech representation of f(x) = x on [-1,1]'''
-        return cls(np.array([0,1]), interval=interval)
+        """Chebtech representation of f(x) = x on [-1,1]"""
+        return cls(np.array([0, 1]), interval=interval)
 
     @classmethod
     def initfun(cls, fun, n=None, *, interval=None):
-        '''Convenience constructor to automatically select the adaptive or
-        fixedlen constructor from the input arguments passed.'''
+        """Convenience constructor to automatically select the adaptive or
+        fixedlen constructor from the input arguments passed."""
         if n is None:
             return cls.initfun_adaptive(fun, interval=interval)
         else:
@@ -54,8 +63,8 @@ class Chebtech(Smoothfun, ABC):
 
     @classmethod
     def initfun_fixedlen(cls, fun, n, *, interval=None):
-        '''Initialise a Chebtech from the callable fun using n degrees of
-        freedom.'''
+        """Initialise a Chebtech from the callable fun using n degrees of
+        freedom."""
         points = cls._chebpts(n)
         values = fun(points)
         coeffs = vals2coeffs2(values)
@@ -63,8 +72,8 @@ class Chebtech(Smoothfun, ABC):
 
     @classmethod
     def initfun_adaptive(cls, fun, *, interval=None):
-        '''Initialise a Chebtech from the callable fun utilising the adaptive
-        constructor to determine the number of degrees of freedom parameter.'''
+        """Initialise a Chebtech from the callable fun utilising the adaptive
+        constructor to determine the number of degrees of freedom parameter."""
         interval = interval if interval is not None else prefs.domain
         interval = Interval(*interval)
         coeffs = adaptive(cls, fun, hscale=interval.hscale)
@@ -72,7 +81,7 @@ class Chebtech(Smoothfun, ABC):
 
     @classmethod
     def initvalues(cls, values, *, interval=None):
-        '''Initialise a Chebtech from an array of values at Chebyshev points'''
+        """Initialise a Chebtech from an array of values at Chebyshev points"""
         return cls(cls._vals2coeffs(values), interval=interval)
 
     def __init__(self, coeffs, interval=None):
@@ -80,11 +89,11 @@ class Chebtech(Smoothfun, ABC):
         self._coeffs = np.array(coeffs)
         self._interval = Interval(*interval)
 
-    def __call__(self, x, how='clenshaw'):
+    def __call__(self, x, how="clenshaw"):
         method = {
-            'clenshaw': self.__call__clenshaw,
-            'bary': self.__call__bary,
-            }
+            "clenshaw": self.__call__clenshaw,
+            "bary": self.__call__bary,
+        }
         try:
             return method[how](x)
         except KeyError:
@@ -92,7 +101,7 @@ class Chebtech(Smoothfun, ABC):
 
     def __call__clenshaw(self, x):
         return clenshaw(x, self.coeffs)
-        
+
     def __call__bary(self, x):
         fk = self.values()
         xk = self._chebpts(fk.size)
@@ -100,7 +109,7 @@ class Chebtech(Smoothfun, ABC):
         return bary(x, fk, xk, vk)
 
     def __repr__(self):
-        out = '<{0}{{{1}}}>'.format(self.__class__.__name__, self.size)
+        out = "<{0}{{{1}}}>".format(self.__class__.__name__, self.size)
         return out
 
     # ------------
@@ -108,45 +117,45 @@ class Chebtech(Smoothfun, ABC):
     # ------------
     @property
     def coeffs(self):
-        '''Chebyshev expansion coefficients in the T_k basis'''
+        """Chebyshev expansion coefficients in the T_k basis"""
         return self._coeffs
 
     @property
     def interval(self):
-        '''Interval that Chebtech is mapped to'''
+        """Interval that Chebtech is mapped to"""
         return self._interval
 
     @property
     def size(self):
-        '''Return the size of the object'''
+        """Return the size of the object"""
         return self.coeffs.size
 
     @property
     def isempty(self):
-        '''Return True if the Chebtech is empty'''
+        """Return True if the Chebtech is empty"""
         return self.size == 0
 
     @property
     def iscomplex(self):
-        '''Determine whether the underlying onefun is complex or real valued'''
+        """Determine whether the underlying onefun is complex or real valued"""
         return self._coeffs.dtype == complex
 
     @property
     def isconst(self):
-        '''Return True if the Chebtech represents a constant'''
+        """Return True if the Chebtech represents a constant"""
         return self.size == 1
 
     @property
-    @self_empty(0.)
+    @self_empty(0.0)
     def vscale(self):
-        '''Estimate the vertical scale of a Chebtech'''
+        """Estimate the vertical scale of a Chebtech"""
         return np.abs(coerce_list((self.values()))).max()
 
     # -----------
     #  utilities
     # -----------
     def copy(self):
-        '''Return a deep copy of the Chebtech'''
+        """Return a deep copy of the Chebtech"""
         return self.__class__(self.coeffs.copy(), interval=self.interval.copy())
 
     def imag(self):
@@ -156,17 +165,17 @@ class Chebtech(Smoothfun, ABC):
             return self.initconst(0, interval=self.interval)
 
     def prolong(self, n):
-        '''Return a Chebtech of length n, obtained either by truncating
+        """Return a Chebtech of length n, obtained either by truncating
         if n < self.size or zero-padding if n > self.size. In all cases a
         deep copy is returned.
-        '''
+        """
         m = self.size
         ak = self.coeffs
         cls = self.__class__
         if n - m < 0:
             out = cls(ak[:n].copy(), interval=self.interval)
         elif n - m > 0:
-            out = cls(np.append(ak, np.zeros(n-m)), interval=self.interval)
+            out = cls(np.append(ak, np.zeros(n - m)), interval=self.interval)
         else:
             out = self.copy()
         return out
@@ -178,14 +187,14 @@ class Chebtech(Smoothfun, ABC):
             return self
 
     def simplify(self):
-        '''Call standard_chop on the coefficients of self, returning a
-        Chebtech comprised of a copy of the truncated coefficients.'''
+        """Call standard_chop on the coefficients of self, returning a
+        Chebtech comprised of a copy of the truncated coefficients."""
         # coefficients
         oldlen = len(self.coeffs)
         longself = self.prolong(max(17, oldlen))
         cfs = longself.coeffs
         # scale (decrease) tolerance by hscale
-        tol = prefs.eps*max(self.interval.hscale, 1)
+        tol = prefs.eps * max(self.interval.hscale, 1)
         # chop
         npts = standard_chop(cfs, tol=tol)
         npts = min(oldlen, npts)
@@ -193,7 +202,7 @@ class Chebtech(Smoothfun, ABC):
         return self.__class__(cfs[:npts].copy(), interval=self.interval)
 
     def values(self):
-        '''Function values at Chebyshev points'''
+        """Function values at Chebyshev points"""
         return coeffs2vals2(self.coeffs)
 
     # ---------
@@ -212,7 +221,7 @@ class Chebtech(Smoothfun, ABC):
             return cls(cfs, interval=self.interval)
         else:
             # TODO: is a more general decorator approach better here?
-            # TODO: for constant Chebtech, convert to constant and call __add__ again 
+            # TODO: for constant Chebtech, convert to constant and call __add__ again
             if f.isempty:
                 return f.copy()
             g = self
@@ -225,9 +234,9 @@ class Chebtech(Smoothfun, ABC):
 
             # check for zero output
             eps = prefs.eps
-            tol = .5 * eps * max([f.vscale, g.vscale])
-            if all(abs(cfs)<tol):
-                return cls.initconst(0., interval=self.interval)
+            tol = 0.5 * eps * max([f.vscale, g.vscale])
+            if all(abs(cfs) < tol):
+                return cls.initconst(0.0, interval=self.interval)
             else:
                 return cls(cfs, interval=self.interval)
 
@@ -235,7 +244,7 @@ class Chebtech(Smoothfun, ABC):
     def __div__(self, f):
         cls = self.__class__
         if np.isscalar(f):
-            cfs = 1./f * self.coeffs
+            cfs = 1.0 / f * self.coeffs
             return cls(cfs, interval=self.interval)
         else:
             # TODO: review with reference to __add__
@@ -282,14 +291,14 @@ class Chebtech(Smoothfun, ABC):
     def __rdiv__(self, f):
         # Executed when __div__(f, self) fails, which is to say whenever f
         # is not a Chebtech. We proceeed on the assumption f is a scalar.
-        constfun = lambda x: .0*x + f
+        constfun = lambda x: 0.0 * x + f
         quotient = lambda x: constfun(x) / self(x)
         return self.__class__.initfun_adaptive(quotient, interval=self.interval)
 
     __radd__ = __add__
 
     def __rsub__(self, f):
-        return -(self-f)
+        return -(self - f)
 
     @self_empty()
     def __rpow__(self, f):
@@ -306,8 +315,8 @@ class Chebtech(Smoothfun, ABC):
     #  roots
     # -------
     def roots(self, sort=None):
-        '''Compute the roots of the Chebtech on [-1,1] using the
-        coefficients in the associated Chebyshev series approximation'''
+        """Compute the roots of the Chebtech on [-1,1] using the
+        coefficients in the associated Chebyshev series approximation"""
         sort = sort if sort is not None else prefs.sortroots
         rts = rootsunit(self.coeffs)
         rts = newtonroots(self, rts)
@@ -321,51 +330,51 @@ class Chebtech(Smoothfun, ABC):
     # ----------
     # Note that function returns 0 for an empty Chebtech object; this is
     # consistent with numpy, which returns zero for the sum of an empty array
-    @self_empty(resultif=0.)
+    @self_empty(resultif=0.0)
     def sum(self):
-        '''Definite integral of a Chebtech on the interval [-1,1]'''
+        """Definite integral of a Chebtech on the interval [-1,1]"""
         if self.isconst:
-            out = 2.*self(0.)
+            out = 2.0 * self(0.0)
         else:
             ak = self.coeffs.copy()
             ak[1::2] = 0
             kk = np.arange(2, ak.size)
-            ii = np.append([2,0], 2/(1-kk**2))
-            out = (ak*ii).sum()
+            ii = np.append([2, 0], 2 / (1 - kk ** 2))
+            out = (ak * ii).sum()
         return out
 
     @self_empty()
     def cumsum(self):
-        '''Return a Chebtech object representing the indefinite integral
+        """Return a Chebtech object representing the indefinite integral
         of a Chebtech on the interval [-1,1]. The constant term is chosen
-        such that F(-1) = 0.'''
+        such that F(-1) = 0."""
         n = self.size
         ak = np.append(self.coeffs, [0, 0])
-        bk = np.zeros(n+1, dtype=self.coeffs.dtype)
-        rk = np.arange(2,n+1)
-        bk[2:] = .5*(ak[1:n] - ak[3:]) / rk
-        bk[1] = ak[0] - .5*ak[2]
+        bk = np.zeros(n + 1, dtype=self.coeffs.dtype)
+        rk = np.arange(2, n + 1)
+        bk[2:] = 0.5 * (ak[1:n] - ak[3:]) / rk
+        bk[1] = ak[0] - 0.5 * ak[2]
         vk = np.ones(n)
         vk[1::2] = -1
-        bk[0] = (vk*bk[1:]).sum()
+        bk[0] = (vk * bk[1:]).sum()
         out = self.__class__(bk, interval=self.interval)
         return out
 
     @self_empty()
     def diff(self):
-        '''Return a Chebtech object representing the derivative of a
-        Chebtech on the interval [-1,1].'''
+        """Return a Chebtech object representing the derivative of a
+        Chebtech on the interval [-1,1]."""
         if self.isconst:
-            out = self.__class__(np.array([0.]), interval=self.interval)
+            out = self.__class__(np.array([0.0]), interval=self.interval)
         else:
             n = self.size
             ak = self.coeffs
-            zk = np.zeros(n-1, dtype=self.coeffs.dtype)
-            wk = 2*np.arange(1, n)
+            zk = np.zeros(n - 1, dtype=self.coeffs.dtype)
+            wk = 2 * np.arange(1, n)
             vk = wk * ak[1:]
             zk[-1::-2] = vk[-1::-2].cumsum()
             zk[-2::-2] = vk[-2::-2].cumsum()
-            zk[0] = .5 * zk[0]
+            zk[0] = 0.5 * zk[0]
             out = self.__class__(zk, interval=self.interval)
         return out
 
@@ -388,43 +397,47 @@ class Chebtech(Smoothfun, ABC):
     def _coeffs2vals():
         raise NotImplementedError
 
+
 # ----------
 #  plotting
 # ----------
 
 plt = import_plt()
 if plt:
+
     def plot(self, ax=None, **kwargs):
         return plotfun(self, (-1, 1), ax=ax, **kwargs)
-    setattr(Chebtech, 'plot', plot)
+
+    setattr(Chebtech, "plot", plot)
 
     def plotcoeffs(self, ax=None, **kwargs):
         ax = ax or plt.gca()
         return plotfuncoeffs(abs(self.coeffs), ax=ax, **kwargs)
-    setattr(Chebtech, 'plotcoeffs', plotcoeffs)
+
+    setattr(Chebtech, "plotcoeffs", plotcoeffs)
 
 
 class Chebtech2(Chebtech):
-    '''Second-Kind Chebyshev technology'''
-    
+    """Second-Kind Chebyshev technology"""
+
     @staticmethod
     def _chebpts(n):
-        '''Return n Chebyshev points of the second-kind'''
+        """Return n Chebyshev points of the second-kind"""
         return chebpts2(n)
 
     @staticmethod
     def _barywts(n):
-        '''Barycentric weights for Chebyshev points of 2nd kind'''
+        """Barycentric weights for Chebyshev points of 2nd kind"""
         return barywts2(n)
-    
+
     @staticmethod
     def _vals2coeffs(vals):
-        '''Map function values at Chebyshev points of 2nd kind to
-        first-kind Chebyshev polynomial coefficients'''
+        """Map function values at Chebyshev points of 2nd kind to
+        first-kind Chebyshev polynomial coefficients"""
         return vals2coeffs2(vals)
 
     @staticmethod
     def _coeffs2vals(coeffs):
-        '''Map first-kind Chebyshev polynomial coefficients to
-        function values at Chebyshev points of 2nd kind'''
+        """Map first-kind Chebyshev polynomial coefficients to
+        function values at Chebyshev points of 2nd kind"""
         return coeffs2vals2(coeffs)

--- a/chebpy/core/classicfun.py
+++ b/chebpy/core/classicfun.py
@@ -12,7 +12,7 @@ from .plotting import import_plt, plotfun
 
 
 techdict = {
-    'Chebtech2': Chebtech2,
+    "Chebtech2": Chebtech2,
 }
 
 
@@ -23,38 +23,40 @@ class Classicfun(Fun, ABC):
     # --------------------------
     @classmethod
     def initempty(cls):
-        '''Adaptive initialisation of a Classicfun from a callable
+        """Adaptive initialisation of a Classicfun from a callable
         function f and a Interval object. The interval's interval has no
         relevance to the emptiness status of a Classicfun so we
-        arbitrarily set this to be DefaultPreferences.interval'''
+        arbitrarily set this to be DefaultPreferences.interval"""
         interval = Interval()
         onefun = techdict[prefs.tech].initempty(interval=interval)
         return cls(onefun, interval)
 
     @classmethod
     def initconst(cls, c, interval):
-        '''Classicfun representation of a constant on the supplied interval'''
+        """Classicfun representation of a constant on the supplied interval"""
         onefun = techdict[prefs.tech].initconst(c, interval=interval)
         return cls(onefun, interval)
 
     @classmethod
     def initidentity(cls, interval):
-        '''Classicfun representation of f(x) = x on the supplied interval'''
-        onefun = techdict[prefs.tech].initvalues(np.asarray(interval), interval=interval)
+        """Classicfun representation of f(x) = x on the supplied interval"""
+        onefun = techdict[prefs.tech].initvalues(
+            np.asarray(interval), interval=interval
+        )
         return cls(onefun, interval)
 
     @classmethod
     def initfun_adaptive(cls, f, interval):
-        '''Adaptive initialisation of a BndFun from a callable function f
-        and a Interval object'''
+        """Adaptive initialisation of a BndFun from a callable function f
+        and a Interval object"""
         uifunc = lambda y: f(interval(y))
         onefun = techdict[prefs.tech].initfun(uifunc, interval=interval)
         return cls(onefun, interval)
 
     @classmethod
     def initfun_fixedlen(cls, f, interval, n):
-        '''Fixed length initialisation of a BndFun from a callable
-        function f and a Interval object'''
+        """Fixed length initialisation of a BndFun from a callable
+        function f and a Interval object"""
         uifunc = lambda y: f(interval(y))
         onefun = techdict[prefs.tech].initfun(uifunc, n, interval=interval)
         return cls(onefun, interval)
@@ -62,19 +64,20 @@ class Classicfun(Fun, ABC):
     # -------------------
     #  'private' methods
     # -------------------
-    def __call__(self, x, how='clenshaw'):
+    def __call__(self, x, how="clenshaw"):
         y = self.interval.invmap(x)
         return self.onefun(y, how)
 
     def __init__(self, onefun, interval):
-        '''Initialise a Classicfun from its two defining properties: a
-        Interval object and a Onefun object'''
+        """Initialise a Classicfun from its two defining properties: a
+        Interval object and a Onefun object"""
         self.onefun = onefun
         self._interval = interval
 
     def __repr__(self):
-        out = '{0}([{2}, {3}], {1})'.format(
-            self.__class__.__name__, self.size, *self.support)
+        out = "{0}([{2}, {3}], {1})".format(
+            self.__class__.__name__, self.size, *self.support
+        )
         return out
 
     # ------------
@@ -82,47 +85,47 @@ class Classicfun(Fun, ABC):
     # ------------
     @property
     def coeffs(self):
-        '''Return the coeffs property of the underlying onefun'''
+        """Return the coeffs property of the underlying onefun"""
         return self.onefun.coeffs
 
     @property
     def endvalues(self):
-        '''Return a 2-array of endpointvalues taken from the interval'''
+        """Return a 2-array of endpointvalues taken from the interval"""
         return self.__call__(self.support)
 
     @property
     def interval(self):
-        '''Return the Interval object associated with the Classicfun'''
+        """Return the Interval object associated with the Classicfun"""
         return self._interval
 
     @property
     def isconst(self):
-        '''Return the isconst property of the underlying onefun'''
+        """Return the isconst property of the underlying onefun"""
         return self.onefun.isconst
 
     @property
     def iscomplex(self):
-        '''Determine whether the underlying onefun is complex or real valued'''
+        """Determine whether the underlying onefun is complex or real valued"""
         return self.onefun.iscomplex
 
     @property
     def isempty(self):
-        '''Return the isempty property of the underlying onefun'''
+        """Return the isempty property of the underlying onefun"""
         return self.onefun.isempty
 
     @property
     def size(self):
-        '''Return the size property of the underlying onefun'''
+        """Return the size property of the underlying onefun"""
         return self.onefun.size
 
     @property
     def support(self):
-        '''Return a 2-array of endpoints taken from the interval'''
+        """Return a 2-array of endpoints taken from the interval"""
         return np.asarray(self.interval)
 
     @property
     def vscale(self):
-        '''Return the vscale property of the underlying onefun'''
+        """Return the vscale property of the underlying onefun"""
         return self.onefun.vscale
 
     # -----------
@@ -142,9 +145,9 @@ class Classicfun(Fun, ABC):
             return self
 
     def restrict(self, subinterval):
-        '''Return a Classicfun that matches self on a subinterval of its
+        """Return a Classicfun that matches self on a subinterval of its
         interval of definition. The output is formed using a fixed length
-        construction using same number of degrees of freedom as self.'''
+        construction using same number of degrees of freedom as self."""
         if subinterval not in self.interval:
             raise NotSubinterval(self.interval, subinterval)
         if self.interval == subinterval:
@@ -153,8 +156,8 @@ class Classicfun(Fun, ABC):
             return self.__class__.initfun_fixedlen(self, subinterval, self.size)
 
     def translate(self, c):
-        '''Translate a fun by c, i.e., return f(x-c)'''
-        return self.__class__(self.onefun, self.interval+c)
+        """Translate a fun by c, i.e., return f(x-c)"""
+        return self.__class__(self.onefun, self.interval + c)
 
     # -------------
     #  rootfinding
@@ -168,17 +171,17 @@ class Classicfun(Fun, ABC):
     # ----------
     def cumsum(self):
         a, b = self.support
-        onefun = .5*(b-a) * self.onefun.cumsum()
+        onefun = 0.5 * (b - a) * self.onefun.cumsum()
         return self.__class__(onefun, self.interval)
 
     def diff(self):
         a, b = self.support
-        onefun = 2./(b-a) * self.onefun.diff()
+        onefun = 2.0 / (b - a) * self.onefun.diff()
         return self.__class__(onefun, self.interval)
 
     def sum(self):
         a, b = self.support
-        return .5*(b-a) * self.onefun.sum()
+        return 0.5 * (b - a) * self.onefun.sum()
 
 
 # ----------
@@ -187,25 +190,30 @@ class Classicfun(Fun, ABC):
 
 plt = import_plt()
 if plt:
+
     def plot(self, ax=None, **kwds):
         return plotfun(self, self.support, ax=ax, **kwds)
-    setattr(Classicfun, 'plot', plot)
+
+    setattr(Classicfun, "plot", plot)
 
 # ----------------------------------------------------------------
 #  methods that execute the corresponding onefun method as is
 # ----------------------------------------------------------------
 
-methods_onefun_other = ('values', 'plotcoeffs')
+methods_onefun_other = ("values", "plotcoeffs")
+
 
 def addUtility(methodname):
     def method(self, *args, **kwds):
         return getattr(self.onefun, methodname)(*args, **kwds)
+
     method.__name__ = methodname
-    method.__doc__ = 'TODO: CHANGE THIS TO SOMETHING MEANINGFUL'
+    method.__doc__ = "TODO: CHANGE THIS TO SOMETHING MEANINGFUL"
     setattr(Classicfun, methodname, method)
 
+
 for methodname in methods_onefun_other:
-    if methodname[:4] == 'plot' and plt is None:
+    if methodname[:4] == "plot" and plt is None:
         continue
     addUtility(methodname)
 
@@ -214,15 +222,18 @@ for methodname in methods_onefun_other:
 #  unary operators and zero-argument utlity methods returning a onefun
 # -----------------------------------------------------------------------
 
-methods_onefun_zeroargs = ('__pos__', '__neg__', 'copy', 'simplify')
+methods_onefun_zeroargs = ("__pos__", "__neg__", "copy", "simplify")
+
 
 def addZeroArgOp(methodname):
     def method(self, *args, **kwds):
         onefun = getattr(self.onefun, methodname)(*args, **kwds)
         return self.__class__(onefun, self.interval)
+
     method.__name__ = methodname
-    method.__doc__ = 'TODO: CHANGE THIS TO SOMETHING MEANINGFUL'
+    method.__doc__ = "TODO: CHANGE THIS TO SOMETHING MEANINGFUL"
     setattr(Classicfun, methodname, method)
+
 
 for methodname in methods_onefun_zeroargs:
     addZeroArgOp(methodname)
@@ -232,9 +243,21 @@ for methodname in methods_onefun_zeroargs:
 # -----------------------------------------
 
 # ToDo: change these to operator module methods
-methods_onefun_binary = ('__add__', '__div__', '__mul__', '__pow__',
-                         '__radd__', '__rdiv__', '__rmul__', '__rpow__',
-                         '__rsub__', '__rtruediv__', '__sub__', '__truediv__')
+methods_onefun_binary = (
+    "__add__",
+    "__div__",
+    "__mul__",
+    "__pow__",
+    "__radd__",
+    "__rdiv__",
+    "__rmul__",
+    "__rpow__",
+    "__rsub__",
+    "__rtruediv__",
+    "__sub__",
+    "__truediv__",
+)
+
 
 def addBinaryOp(methodname):
     @self_empty()
@@ -253,9 +276,11 @@ def addBinaryOp(methodname):
             g = f
         onefun = getattr(self.onefun, methodname)(g, *args, **kwds)
         return cls(onefun, self.interval)
+
     method.__name__ = methodname
-    method.__doc__ = 'TODO: CHANGE THIS TO SOMETHING MEANINGFUL'
+    method.__doc__ = "TODO: CHANGE THIS TO SOMETHING MEANINGFUL"
     setattr(Classicfun, methodname, method)
+
 
 for methodname in methods_onefun_binary:
     addBinaryOp(methodname)
@@ -264,21 +289,43 @@ for methodname in methods_onefun_binary:
 #  numpy universal functions
 # ---------------------------
 
+
 def addUfunc(op):
     @self_empty()
     def method(self):
         cls = self.__class__
         fun = lambda x: op(self(x))
         return cls.initfun_adaptive(fun, self.interval)
+
     name = op.__name__
     method.__name__ = name
-    method.__doc__ = 'TODO: CHANGE THIS TO SOMETHING MEANINGFUL'
+    method.__doc__ = "TODO: CHANGE THIS TO SOMETHING MEANINGFUL"
     setattr(Classicfun, name, method)
 
-ufuncs = (np.absolute, np.arccos, np.arccosh, np.arcsin, np.arcsinh, np.arctan,
-          np.arctanh, np.cos, np.cosh, np.exp, np.exp2, np.expm1, np.log,
-          np.log2, np.log10, np.log1p, np.sinh, np.sin, np.tan, np.tanh,
-          np.sqrt)
+
+ufuncs = (
+    np.absolute,
+    np.arccos,
+    np.arccosh,
+    np.arcsin,
+    np.arcsinh,
+    np.arctan,
+    np.arctanh,
+    np.cos,
+    np.cosh,
+    np.exp,
+    np.exp2,
+    np.expm1,
+    np.log,
+    np.log2,
+    np.log10,
+    np.log1p,
+    np.sinh,
+    np.sin,
+    np.tan,
+    np.tanh,
+    np.sqrt,
+)
 
 for op in ufuncs:
     addUfunc(op)

--- a/chebpy/core/decorators.py
+++ b/chebpy/core/decorators.py
@@ -4,12 +4,12 @@ import numpy as np
 
 
 def cache(f):
-    '''Object method output caching mechanism. Particularly useful for speeding
+    """Object method output caching mechanism. Particularly useful for speeding
     up repeated execution of relatively expensive zero-argument operations such
     as .roots(). Cached computations are stored in a dictionary called _cache
     which is bound to self using keys corresponding to the method name.
-    Can be used in principle on arbitrary objects.'''
-    #TODO: look into replacing this with one of the functools cache decorators
+    Can be used in principle on arbitrary objects."""
+    # TODO: look into replacing this with one of the functools cache decorators
     @wraps(f)
     def wrapper(self):
         try:
@@ -23,12 +23,14 @@ def cache(f):
             # f has not been executed previously, but self._cache exists
             out = self._cache[f.__name__] = f(self)
         return out
+
     return wrapper
 
+
 def self_empty(resultif=None):
-    '''Factory method to produce a decorator that checks whether the object
+    """Factory method to produce a decorator that checks whether the object
     whose classmethod is being wrapped is empty, returning the object if
-    so, but returning the supplied resultif if not. (Used in chebtech.py)'''
+    so, but returning the supplied resultif if not. (Used in chebtech.py)"""
     # TODO: add unit test for this
     def decorator(f):
         @wraps(f)
@@ -40,27 +42,30 @@ def self_empty(resultif=None):
                     return self.copy()
             else:
                 return f(self, *args, **kwargs)
+
         return wrapper
+
     return decorator
 
 
 def preandpostprocess(f):
-    '''Pre- and post-processing tasks common to bary and clenshaw'''
+    """Pre- and post-processing tasks common to bary and clenshaw"""
+
     @wraps(f)
     def thewrapper(*args, **kwargs):
         xx, akfk = args[:2]
         # are any of the first two arguments empty arrays?
-        if (np.asarray(xx).size==0) | (np.asarray(akfk).size==0):
+        if (np.asarray(xx).size == 0) | (np.asarray(akfk).size == 0):
             return np.array([])
         # is the function constant?
         elif akfk.size == 1:
             if np.isscalar(xx):
                 return akfk[0]
             else:
-                return akfk*np.ones(xx.size)
+                return akfk * np.ones(xx.size)
         # are there any NaNs in the second argument?
         elif np.any(np.isnan(akfk)):
-            return np.nan*np.ones(xx.size)
+            return np.nan * np.ones(xx.size)
         # convert first argument to an array if it is a scalar and then
         # return the first (and only) element of the result if so
         else:
@@ -68,11 +73,14 @@ def preandpostprocess(f):
             args[0] = np.array([xx]) if np.isscalar(xx) else args[0]
             out = f(*args, **kwargs)
             return out[0] if np.isscalar(xx) else out
+
     return thewrapper
 
+
 def float_argument(f):
-    '''Chebfun classmethod wrapper for __call__: ensure that we provide
-    float output for float input and array output otherwise'''
+    """Chebfun classmethod wrapper for __call__: ensure that we provide
+    float output for float input and array output otherwise"""
+
     @wraps(f)
     def thewrapper(self, *args, **kwargs):
         x = args[0]
@@ -87,11 +95,14 @@ def float_argument(f):
         args[0] = xx
         out = f(self, *args, **kwargs)
         return out[0] if np.isscalar(x) else out
+
     return thewrapper
 
+
 def cast_arg_to_chebfun(f):
-    '''Attempt to cast the first argument to chebfun if is not so already.
-    The only castable type at this point is a numeric type'''
+    """Attempt to cast the first argument to chebfun if is not so already.
+    The only castable type at this point is a numeric type"""
+
     @wraps(f)
     def wrapper(self, *args, **kwargs):
         other = args[0]
@@ -100,17 +111,21 @@ def cast_arg_to_chebfun(f):
             args = list(args)
             args[0] = fun
         return f(self, *args, **kwargs)
+
     return wrapper
+
 
 def cast_other(f):
     """Generic wrapper to be applied to binary operator type class methods and
     whose purpose is to cast the second positional argument to the type self"""
+
     @wraps(f)
     def wrapper(self, *args, **kwargs):
-        cls   = self.__class__
+        cls = self.__class__
         other = args[0]
         if not isinstance(other, cls):
             args = list(args)
             args[0] = cls(other)
         return f(self, *args, **kwargs)
+
     return wrapper

--- a/chebpy/core/exceptions.py
+++ b/chebpy/core/exceptions.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 
 
 class ChebpyBaseException(Exception, ABC):
-
     def __init__(self, *args):
         if args:
             self.message = args[0]
@@ -24,40 +23,45 @@ class ChebpyBaseException(Exception, ABC):
 
 
 IntervalOverlap = type(
-    'IntervalOverlap',
-    (ChebpyBaseException, ),
-    {'default_message': 'The supplied Interval objects overlap'},
+    "IntervalOverlap",
+    (ChebpyBaseException,),
+    {"default_message": "The supplied Interval objects overlap"},
 )
 
-
 IntervalGap = type(
-    'IntervalGap',
-    (ChebpyBaseException, ),
-    {'default_message': 'The supplied Interval objects do not form a complete '
-                        'partition of the approximation interval'},
+    "IntervalGap",
+    (ChebpyBaseException,),
+    {
+        "default_message": "The supplied Interval objects do not form a complete "
+        "partition of the approximation interval"
+    },
 )
 
 
 IntervalMismatch = type(
-    'IntervalMismatch',
-    (ChebpyBaseException, ),
-    {'default_message': 'This operation can only be performed for Fun objects '
-                        'defined on identical intervals'},
+    "IntervalMismatch",
+    (ChebpyBaseException,),
+    {
+        "default_message": "This operation can only be performed for Fun objects "
+        "defined on identical intervals"
+    },
 )
 
 
 NotSubinterval = type(
-    'NotSubinterval',
-    (ChebpyBaseException, ),
-    {'default_message': 'Not a subinterval'},
+    "NotSubinterval",
+    (ChebpyBaseException,),
+    {"default_message": "Not a subinterval"},
 )
 
 
 IntervalValues = type(
-    'IntervalValues',
-    (ChebpyBaseException, ),
-    {'default_message': 'The defining values of a Interval object must be '
-                        'strictly increasing'},
+    "IntervalValues",
+    (ChebpyBaseException,),
+    {
+        "default_message": "The defining values of a Interval object must be "
+        "strictly increasing"
+    },
 )
 
 
@@ -67,35 +71,43 @@ IntervalValues = type(
 
 
 InvalidDomain = type(
-    'InvalidDomain',
-    (ChebpyBaseException, ),
-    {'default_message': 'Domain objects must be initialised from an iterable '
-                        'collection of at least two monotonically increasing '
-                        'scalars'},
+    "InvalidDomain",
+    (ChebpyBaseException,),
+    {
+        "default_message": "Domain objects must be initialised from an iterable "
+        "collection of at least two monotonically increasing "
+        "scalars"
+    },
 )
 
 
 NotSubdomain = type(
-    'NotSubdomain',
-    (ChebpyBaseException, ),
-    {'default_message': 'The support of the target Domain object is required '
-                        'to define a subinterval of the support of the '
-                        'original'},
+    "NotSubdomain",
+    (ChebpyBaseException,),
+    {
+        "default_message": "The support of the target Domain object is required "
+        "to define a subinterval of the support of the "
+        "original"
+    },
 )
 
 
 SupportMismatch = type(
-    'SupportMismatch',
-    (ChebpyBaseException, ),
-    {'default_message': 'Both objects are required to be supported on the '
-                        'same interval'},
+    "SupportMismatch",
+    (ChebpyBaseException,),
+    {
+        "default_message": "Both objects are required to be supported on the "
+        "same interval"
+    },
 )
 
 
 BadFunLengthArgument = type(
-    'BadFunLengthArgument',
-    (ChebpyBaseException, ),
-    {'default_message': 'The \'n\' argument must be either a single numeric '
-                        'value, or iterable thereof posessing one fewer '
-                        'elements than the size of the domain'},
+    "BadFunLengthArgument",
+    (ChebpyBaseException,),
+    {
+        "default_message": "The 'n' argument must be either a single numeric "
+        "value, or iterable thereof posessing one fewer "
+        "elements than the size of the domain"
+    },
 )

--- a/chebpy/core/ffts.py
+++ b/chebpy/core/ffts.py
@@ -5,8 +5,7 @@ from .importing import import_optional
 
 
 # import the requested FFT module
-_fft = import_optional('pyfftw.interfaces.numpy_fft', 'PYFFTW',
-                       fallback='numpy.fft')
+_fft = import_optional("pyfftw.interfaces.numpy_fft", "PYFFTW", fallback="numpy.fft")
 
 # assign the interfaces for import from other modules
 fft, ifft = _fft.fft, _fft.ifft

--- a/chebpy/core/fun.py
+++ b/chebpy/core/fun.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod, abstractclassmethod
 
+
 class Fun(ABC):
 
     # --------------------------

--- a/chebpy/core/importing.py
+++ b/chebpy/core/importing.py
@@ -1,17 +1,18 @@
 from importlib import import_module
 import os
 
+
 def import_optional(name, envvarname, fallback=None):
     """Attempt to import the specified module.
     Either returns the module, or None.
 
     See https://github.com/pandas-dev/pandas/blob/master/pandas/compat/_optional.py
     """
-    use_module = os.environ.get('CHEBPY_USE_'+envvarname.upper(), '1')
-    if use_module.lower() in ['true', '1']:
+    use_module = os.environ.get("CHEBPY_USE_" + envvarname.upper(), "1")
+    if use_module.lower() in ["true", "1"]:
         try:
             return import_module(name)
-        except ImportError: # pragma: no cover
+        except ImportError:  # pragma: no cover
             pass
     if fallback is not None:
         return import_module(fallback)

--- a/chebpy/core/onefun.py
+++ b/chebpy/core/onefun.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod, abstractclassmethod
 
+
 class Onefun(ABC):
 
     # --------------------------

--- a/chebpy/core/plotting.py
+++ b/chebpy/core/plotting.py
@@ -9,7 +9,7 @@ def import_plt():
     No fallback option exists, because the plot* functions
     are not added if module import return None.
     """
-    return import_optional('matplotlib.pyplot', 'MPL')
+    return import_optional("matplotlib.pyplot", "MPL")
 
 
 def plotfun(fun, support, ax=None, N=None, **kwds):
@@ -19,8 +19,8 @@ def plotfun(fun, support, ax=None, N=None, **kwds):
     ff = fun(xx)
     if fun.iscomplex:
         ax.plot(np.real(ff), np.imag(ff), **kwds)
-        ax.set_xlabel(kwds.pop('ylabel', 'real'))
-        ax.set_ylabel(kwds.pop('xlabel', 'imag'))
+        ax.set_xlabel(kwds.pop("ylabel", "real"))
+        ax.set_ylabel(kwds.pop("xlabel", "imag"))
     else:
         ax.plot(xx, ff, **kwds)
     return ax
@@ -28,7 +28,7 @@ def plotfun(fun, support, ax=None, N=None, **kwds):
 
 def plotfuncoeffs(abscoeffs, ax=None, **kwds):
     ax = ax or import_plt().gca()
-    ax.set_ylabel(kwds.pop('xlabel', 'coefficient magnitude'))
-    ax.set_xlabel(kwds.pop('ylabel', 'polynomial degree'))
-    ax.semilogy(abscoeffs, '.', **kwds)
+    ax.set_ylabel(kwds.pop("xlabel", "coefficient magnitude"))
+    ax.set_xlabel(kwds.pop("ylabel", "polynomial degree"))
+    ax.semilogy(abscoeffs, ".", **kwds)
     return ax

--- a/chebpy/core/settings.py
+++ b/chebpy/core/settings.py
@@ -6,7 +6,7 @@ class DefaultPreferences:
 
     eps = np.finfo(float).eps
     tech = "Chebtech2"
-    domain = np.array([-1., 1.])  #TODO: should this be .utilities.Domain?
+    domain = np.array([-1.0, 1.0])  # TODO: should this be .utilities.Domain?
     N_plot = 2001
     maxpow2 = 16
     maxiter = 10
@@ -35,6 +35,7 @@ class ChebPreferences(DefaultPreferences):
 
     # Singleton
     _instance = None  # persistent reference for the singleton object
+
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super(DefaultPreferences, cls).__new__(cls)
@@ -42,10 +43,11 @@ class ChebPreferences(DefaultPreferences):
 
     # Context manager
     _stash = []  # persistent stash for old prefs when entering context(s)
+
     def __enter__(self):
-        self._stash.append({
-            k: getattr(self, k) for k in DefaultPreferences._defaults().keys()
-        })
+        self._stash.append(
+            {k: getattr(self, k) for k in DefaultPreferences._defaults().keys()}
+        )
         return self._instance
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/chebpy/core/smoothfun.py
+++ b/chebpy/core/smoothfun.py
@@ -2,5 +2,6 @@ from abc import ABC
 
 from .onefun import Onefun
 
+
 class Smoothfun(Onefun, ABC):
     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,8 @@ report.exclude_lines = [
     # we don't want to test this, usually abc methods
     "raise NotImplementedError",
 ]
+
+# Black style
+[tool.black]
+
+target-version = ['py37']

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -8,8 +8,7 @@ from chebpy.core.settings import DefaultPreferences
 from chebpy.core.chebtech import Chebtech2
 from chebpy.core.algorithms import bary, clenshaw, coeffmult
 
-from .utilities import (testfunctions, scaled_tol, infNormLessThanTol,
-                             infnorm)
+from .utilities import testfunctions, scaled_tol, infNormLessThanTol, infnorm
 
 # aliases
 pi = np.pi
@@ -22,7 +21,7 @@ np.random.seed(0)
 
 # turn off 'divide' and 'invalid' Runtimewarnings: these are invoked in the
 # barycentric formula and the warned-of behaviour is actually required
-np.seterr(divide='ignore', invalid='ignore')
+np.seterr(divide="ignore", invalid="ignore")
 
 
 class Evaluation(unittest.TestCase):
@@ -34,51 +33,51 @@ class Evaluation(unittest.TestCase):
         self.vk = Chebtech2._barywts(npts)
         self.fk = np.random.rand(npts)
         self.ak = np.random.rand(11)
-        self.xx = -1 + 2*np.random.rand(9)
-        self.pts = -1 + 2*np.random.rand(1001)
+        self.xx = -1 + 2 * np.random.rand(9)
+        self.pts = -1 + 2 * np.random.rand(1001)
 
     # check an empty array is returned whenever either or both of the first
     # two arguments are themselves empty arrays
     def test_bary__empty(self):
         null = (None, None)
         self.assertEquals(bary(np.array([]), np.array([]), *null).size, 0)
-        self.assertEquals(bary(np.array([.1]), np.array([]), *null).size, 0)
-        self.assertEquals(bary(np.array([]), np.array([.1]), *null).size, 0)
+        self.assertEquals(bary(np.array([0.1]), np.array([]), *null).size, 0)
+        self.assertEquals(bary(np.array([]), np.array([0.1]), *null).size, 0)
         self.assertEquals(bary(self.pts, np.array([]), *null).size, 0)
         self.assertEquals(bary(np.array([]), self.pts, *null).size, 0)
-        self.assertNotEquals(bary(np.array([.1]), np.array([.1]), *null).size, 0)
+        self.assertNotEquals(bary(np.array([0.1]), np.array([0.1]), *null).size, 0)
 
     def test_clenshaw__empty(self):
         self.assertEquals(clenshaw(np.array([]), np.array([])).size, 0)
-        self.assertEquals(clenshaw(np.array([]), np.array([1.])).size, 0)
-        self.assertEquals(clenshaw(np.array([1.]), np.array([])).size, 0)
+        self.assertEquals(clenshaw(np.array([]), np.array([1.0])).size, 0)
+        self.assertEquals(clenshaw(np.array([1.0]), np.array([])).size, 0)
         self.assertEquals(clenshaw(self.pts, np.array([])).size, 0)
         self.assertEquals(clenshaw(np.array([]), self.pts).size, 0)
-        self.assertNotEquals(clenshaw(np.array([.1]), np.array([.1])).size, 0)
+        self.assertNotEquals(clenshaw(np.array([0.1]), np.array([0.1])).size, 0)
 
     # check that scalars get evaluated to scalars (not arrays)
     def test_clenshaw__scalar_input(self):
         for x in self.xx:
-            self.assertTrue(np.isscalar(clenshaw(x,self.ak)))
-        self.assertFalse(np.isscalar(clenshaw(xx,self.ak)))
+            self.assertTrue(np.isscalar(clenshaw(x, self.ak)))
+        self.assertFalse(np.isscalar(clenshaw(xx, self.ak)))
 
     def test_bary__scalar_input(self):
         for x in self.xx:
-            self.assertTrue(np.isscalar(bary(x,self.fk,self.xk,self.vk)))
-        self.assertFalse(np.isscalar(bary(xx,self.fk,self.xk,self.vk)))
+            self.assertTrue(np.isscalar(bary(x, self.fk, self.xk, self.vk)))
+        self.assertFalse(np.isscalar(bary(xx, self.fk, self.xk, self.vk)))
 
-    # Check that we always get float output for constant Chebtechs, even 
+    # Check that we always get float output for constant Chebtechs, even
     # when passing in an integer input.
     # TODO: Move these tests elsewhere?
     def test_bary__float_output(self):
         ff = Chebtech2.initconst(1)
-        gg = Chebtech2.initconst(1.)
+        gg = Chebtech2.initconst(1.0)
         self.assertTrue(isinstance(ff(0, "bary"), float))
         self.assertTrue(isinstance(gg(0, "bary"), float))
 
     def test_clenshaw__float_output(self):
         ff = Chebtech2.initconst(1)
-        gg = Chebtech2.initconst(1.)
+        gg = Chebtech2.initconst(1.0)
         self.assertTrue(isinstance(ff(0, "clenshaw"), float))
         self.assertTrue(isinstance(gg(0, "clenshaw"), float))
 
@@ -86,7 +85,7 @@ class Evaluation(unittest.TestCase):
     # TODO: Move these tests elsewhere?
     def test_bary_clenshaw_consistency(self):
         coeffs = np.random.rand(3)
-        evalpts = (0.5, np.array([]), np.array([.5]), np.array([.5, .6]))
+        evalpts = (0.5, np.array([]), np.array([0.5]), np.array([0.5, 0.6]))
         for n in range(len(coeffs)):
             ff = Chebtech2(coeffs[:n])
             for xx in evalpts:
@@ -94,9 +93,11 @@ class Evaluation(unittest.TestCase):
                 fc = ff(xx, "clenshaw")
                 self.assertEquals(type(fb), type(fc))
 
-evalpts = [np.linspace(-1,1,int(n)) for n in np.array([1e2, 1e3, 1e4, 1e5])]
+
+evalpts = [np.linspace(-1, 1, int(n)) for n in np.array([1e2, 1e3, 1e4, 1e5])]
 ptsarry = [Chebtech2._chebpts(n) for n in np.array([100, 200])]
 methods = [bary, clenshaw]
+
 
 def evalTester(method, fun, evalpts, chebpts):
 
@@ -120,18 +121,19 @@ def evalTester(method, fun, evalpts, chebpts):
 
     return infNormLessThanTol(a, b, tol)
 
+
 for method in methods:
     for (fun, _, _) in testfunctions:
         for j, chebpts in enumerate(ptsarry):
             for k, xx in enumerate(evalpts):
                 testfun = evalTester(method, fun, xx, chebpts)
                 testfun.__name__ = "test_{}_{}_{:02}_{:02}".format(
-                    method.__name__, fun.__name__, j, k)
+                    method.__name__, fun.__name__, j, k
+                )
                 setattr(Evaluation, testfun.__name__, testfun)
 
 
 class CoeffMult(unittest.TestCase):
-
     def setUp(self):
         self.f = lambda x: exp(x)
         self.g = lambda x: cos(x)
@@ -142,12 +144,12 @@ class CoeffMult(unittest.TestCase):
         f, g = self.f, self.g
         fn, gn = self.fn, self.gn
         hn = fn + gn - 1
-        h  = lambda x: self.f(x) * self.g(x)
+        h = lambda x: self.f(x) * self.g(x)
         fc = Chebtech2.initfun(f, fn).prolong(hn).coeffs
         gc = Chebtech2.initfun(g, gn).prolong(hn).coeffs
         hc = coeffmult(fc, gc)
         HC = Chebtech2.initfun(h, hn).coeffs
-        self.assertLessEqual( infnorm(hc-HC), 2e1*eps)
+        self.assertLessEqual(infnorm(hc - HC), 2e1 * eps)
 
 
 # reset the testsfun variable so it doesn't get picked up by nose

--- a/tests/test_bndfun.py
+++ b/tests/test_bndfun.py
@@ -28,17 +28,18 @@ eps = DefaultPreferences.eps
 # since we have already tested the adaptive constructor in the Chebtech-level
 # tests, we just use the adaptive constructor in these tests.
 
+
 class ClassUsage(unittest.TestCase):
     """Unit-tests for miscelaneous Bndfun class usage"""
 
     def setUp(self):
-        f = lambda x: sin(30*x)
-        subinterval = Interval(-2,3)
+        f = lambda x: sin(30 * x)
+        subinterval = Interval(-2, 3)
         self.f = f
         self.ff = Bndfun.initfun_adaptive(f, subinterval)
-        self.xx = subinterval(np.linspace(-1,1,100))
+        self.xx = subinterval(np.linspace(-1, 1, 100))
         self.emptyfun = Bndfun(Chebtech2.initempty(), subinterval)
-        self.constfun = Bndfun(Chebtech2.initconst(1.), subinterval)
+        self.constfun = Bndfun(Chebtech2.initconst(1.0), subinterval)
 
     # tests for emptiness of Bndfun objects
     def test_isempty_True(self):
@@ -63,7 +64,7 @@ class ClassUsage(unittest.TestCase):
         cfs = np.random.rand(10)
         subinterval = Interval()
         b0 = Bndfun(Chebtech2(np.array([])), subinterval)
-        b1 = Bndfun(Chebtech2(np.array([1.])), subinterval)
+        b1 = Bndfun(Chebtech2(np.array([1.0])), subinterval)
         b2 = Bndfun(Chebtech2(cfs), subinterval)
         self.assertEquals(b0.size, 0)
         self.assertEquals(b1.size, 1)
@@ -77,8 +78,8 @@ class ClassUsage(unittest.TestCase):
     def test_endvalues(self):
         a, b = self.ff.support
         fa, fb = self.ff.endvalues
-        self.assertLessEqual(abs(fa-self.f(a)), 2e1*eps)
-        self.assertLessEqual(abs(fb-self.f(b)), 2e1*eps)
+        self.assertLessEqual(abs(fa - self.f(a)), 2e1 * eps)
+        self.assertLessEqual(abs(fb - self.f(b)), 2e1 * eps)
 
     # test the different permutations of self(xx, ..)
     def test_call(self):
@@ -95,14 +96,14 @@ class ClassUsage(unittest.TestCase):
     def test_call_bary_vs_clenshaw(self):
         b = self.ff(self.xx, "clenshaw")
         c = self.ff(self.xx, "bary")
-        self.assertLessEqual(infnorm(b-c), 2e2*eps)
+        self.assertLessEqual(infnorm(b - c), 2e2 * eps)
 
     def test_call_raises(self):
         self.assertRaises(ValueError, self.ff, self.xx, "notamethod")
         self.assertRaises(ValueError, self.ff, self.xx, how="notamethod")
 
     def test_vscale_empty(self):
-        self.assertEquals(self.emptyfun.vscale, 0.)
+        self.assertEquals(self.emptyfun.vscale, 0.0)
 
     def test_copy(self):
         ff = self.ff
@@ -110,56 +111,63 @@ class ClassUsage(unittest.TestCase):
         self.assertEquals(ff, ff)
         self.assertEquals(gg, gg)
         self.assertNotEquals(ff, gg)
-        self.assertEquals(infnorm(ff.coeffs-gg.coeffs), 0)
+        self.assertEquals(infnorm(ff.coeffs - gg.coeffs), 0)
 
     # check that the restricted fun matches self on the subinterval
     def test_restrict(self):
-        i1 = Interval(-1,1)
+        i1 = Interval(-1, 1)
         gg = self.ff.restrict(i1)
-        yy = np.linspace(-1,1,1000)
-        self.assertLessEqual(infnorm(self.ff(yy)-gg(yy)), 1e2*eps)
+        yy = np.linspace(-1, 1, 1000)
+        self.assertLessEqual(infnorm(self.ff(yy) - gg(yy)), 1e2 * eps)
 
     # check that the restricted fun matches self on the subinterval
     def test_simplify(self):
-        interval = Interval(-2,1)
+        interval = Interval(-2, 1)
         ff = Bndfun.initfun_fixedlen(self.f, interval, 1000)
         gg = ff.simplify()
         self.assertEqual(gg.size, standard_chop(ff.onefun.coeffs))
-        self.assertEqual(infnorm(ff.coeffs[:gg.size]-gg.coeffs), 0)
+        self.assertEqual(infnorm(ff.coeffs[: gg.size] - gg.coeffs), 0)
         self.assertEqual(ff.interval, gg.interval)
 
     def test_translate(self):
         c = -1
         shifted_interval = self.ff.interval + c
         gg = self.ff.translate(c)
-        hh = Bndfun.initfun_fixedlen(lambda x: self.ff(x-c), shifted_interval, gg.size)
-        yk = shifted_interval(np.linspace(-1,1,100))
+        hh = Bndfun.initfun_fixedlen(
+            lambda x: self.ff(x - c), shifted_interval, gg.size
+        )
+        yk = shifted_interval(np.linspace(-1, 1, 100))
         self.assertEqual(gg.interval, hh.interval)
-        self.assertLessEqual(infnorm(gg.coeffs-hh.coeffs), 2e1*eps)
-        self.assertLessEqual(infnorm(gg(yk)-hh(yk)), 1e2*eps)
+        self.assertLessEqual(infnorm(gg.coeffs - hh.coeffs), 2e1 * eps)
+        self.assertLessEqual(infnorm(gg(yk) - hh(yk)), 1e2 * eps)
+
 
 # --------------------------------------
 #          vscale estimates
 # --------------------------------------
 vscales = [
     # (function, number of points, vscale)
-    (lambda x: sin(4*pi*x),      [-2, 2],     1),
-    (lambda x: cos(x),           [-10, 1],    1),
-    (lambda x: cos(4*pi*x),      [-100, 100], 1),
-    (lambda x: exp(cos(4*pi*x)), [-1,1],      exp(1)),
-    (lambda x: cos(3244*x),      [-2,0],      1),
-    (lambda x: exp(x),           [-1,2],      exp(2)),
-    (lambda x: 1e10*exp(x),      [-1,1],      1e10*exp(1)),
-    (lambda x: 0*x+1.,           [-1e5,1e4],  1),
+    (lambda x: sin(4 * pi * x), [-2, 2], 1),
+    (lambda x: cos(x), [-10, 1], 1),
+    (lambda x: cos(4 * pi * x), [-100, 100], 1),
+    (lambda x: exp(cos(4 * pi * x)), [-1, 1], exp(1)),
+    (lambda x: cos(3244 * x), [-2, 0], 1),
+    (lambda x: exp(x), [-1, 2], exp(2)),
+    (lambda x: 1e10 * exp(x), [-1, 1], 1e10 * exp(1)),
+    (lambda x: 0 * x + 1.0, [-1e5, 1e4], 1),
 ]
+
 
 def definiteIntegralTester(fun, interval, vscale):
     subinterval = Interval(*interval)
     ff = Bndfun.initfun_adaptive(fun, subinterval)
+
     def tester(self):
-        absdiff = abs(ff.vscale-vscale)
-        self.assertLessEqual(absdiff, .1*vscale)
+        absdiff = abs(ff.vscale - vscale)
+        self.assertLessEqual(absdiff, 0.1 * vscale)
+
     return tester
+
 
 for k, args in enumerate(vscales):
     _testfun_ = definiteIntegralTester(*args)
@@ -169,12 +177,13 @@ for k, args in enumerate(vscales):
 
 plt = import_plt()
 
+
 class Plotting(unittest.TestCase):
     """Unit-tests for Bndfun plotting methods"""
 
     def setUp(self):
-        f = lambda x: sin(1*x) + 5e-1*cos(10*x) + 5e-3*sin(100*x)
-        u = lambda x: np.exp(2*np.pi*1j*x)
+        f = lambda x: sin(1 * x) + 5e-1 * cos(10 * x) + 5e-3 * sin(100 * x)
+        u = lambda x: np.exp(2 * np.pi * 1j * x)
         subinterval = Interval(-6, 10)
         self.f0 = Bndfun.initfun_fixedlen(f, subinterval, 1000)
         self.f1 = Bndfun.initfun_adaptive(f, subinterval)
@@ -189,9 +198,9 @@ class Plotting(unittest.TestCase):
     def test_plot_complex(self):
         fig, ax = plt.subplots()
         # plot Bernstein ellipses
-        joukowsky = lambda z: .5*(z+1/z)
+        joukowsky = lambda z: 0.5 * (z + 1 / z)
         for rho in np.arange(1.1, 2, 0.1):
-            (np.exp(1j*.25*np.pi)*joukowsky(rho*self.f2)).plot(ax=ax)
+            (np.exp(1j * 0.25 * np.pi) * joukowsky(rho * self.f2)).plot(ax=ax)
 
     @unittest.skipIf(plt is None, "matplotlib not installed")
     def test_plotcoeffs(self):
@@ -200,14 +209,14 @@ class Plotting(unittest.TestCase):
         self.f1.plotcoeffs(ax=ax, color="r")
 
 
-
 class Calculus(unittest.TestCase):
     """Unit-tests for Bndfun calculus operations"""
 
     def setUp(self):
         self.emptyfun = Bndfun(Chebtech2.initempty(), Interval())
-        self.yy = np.linspace(-1,1,2000)
-#        self.constfun = Bndfun(Chebtech2.initconst(1.), subinterval)
+        self.yy = np.linspace(-1, 1, 2000)
+
+    #        self.constfun = Bndfun(Chebtech2.initconst(1.), subinterval)
 
     # tests for the correct results in the empty cases
     def test_sum_empty(self):
@@ -219,29 +228,34 @@ class Calculus(unittest.TestCase):
     def test_diff_empty(self):
         self.assertTrue(self.emptyfun.diff().isempty)
 
+
 # --------------------------------------
 #           definite integrals
 # --------------------------------------
 def_integrals = [
     # (function, interval, integral, tolerance)
-    (lambda x: sin(x),           [-2,2],                        .0,    2*eps),
-    (lambda x: sin(4*pi*x),      [-.1, .7],      0.088970317927147,  1e1*eps),
-    (lambda x: cos(x),           [-100,203],     0.426944059057085,  4e2*eps),
-    (lambda x: cos(4*pi*x),      [-1e-1,-1e-3],  0.074682699182803,    2*eps),
-    (lambda x: exp(cos(4*pi*x)), [-3,1],         5.064263511008033,    4*eps),
-    (lambda x: cos(3244*x),      [0,0.4],   -3.758628487169980e-05,  5e2*eps),
-    (lambda x: exp(x),           [-2,-1],          exp(-1)-exp(-2),    2*eps),
-    (lambda x: 1e10*exp(x),      [-1,2],     1e10*(exp(2)-exp(-1)), 2e10*eps),
-    (lambda x: 0*x+1.,           [-100,300],                   400,      eps),
+    (lambda x: sin(x), [-2, 2], 0.0, 2 * eps),
+    (lambda x: sin(4 * pi * x), [-0.1, 0.7], 0.088970317927147, 1e1 * eps),
+    (lambda x: cos(x), [-100, 203], 0.426944059057085, 4e2 * eps),
+    (lambda x: cos(4 * pi * x), [-1e-1, -1e-3], 0.074682699182803, 2 * eps),
+    (lambda x: exp(cos(4 * pi * x)), [-3, 1], 5.064263511008033, 4 * eps),
+    (lambda x: cos(3244 * x), [0, 0.4], -3.758628487169980e-05, 5e2 * eps),
+    (lambda x: exp(x), [-2, -1], exp(-1) - exp(-2), 2 * eps),
+    (lambda x: 1e10 * exp(x), [-1, 2], 1e10 * (exp(2) - exp(-1)), 2e10 * eps),
+    (lambda x: 0 * x + 1.0, [-100, 300], 400, eps),
 ]
+
 
 def definiteIntegralTester(fun, interval, integral, tol):
     subinterval = Interval(*interval)
     ff = Bndfun.initfun_adaptive(fun, subinterval)
+
     def tester(self):
-        absdiff = abs(ff.sum()-integral)
+        absdiff = abs(ff.sum() - integral)
         self.assertLessEqual(absdiff, tol)
+
     return tester
+
 
 for k, (fun, n, integral, tol) in enumerate(def_integrals):
     _testfun_ = definiteIntegralTester(fun, n, integral, tol)
@@ -253,28 +267,32 @@ for k, (fun, n, integral, tol) in enumerate(def_integrals):
 # --------------------------------------
 indef_integrals = [
     # (function, indefinite integral, interval, tolerance)
-    (lambda x: 0*x+1.,      lambda x: x,             [-2,3],         eps),
-    (lambda x: x,           lambda x: 1/2*x**2,      [-5,0],       4*eps),
-    (lambda x: x**2,        lambda x: 1/3*x**3,      [1,10],     2e2*eps),
-    (lambda x: x**3,        lambda x: 1/4*x**4,      [-1e-2,4e-1], 2*eps),
-    (lambda x: x**4,        lambda x: 1/5*x**5,      [-3,-2],    3e2*eps),
-    (lambda x: x**5,        lambda x: 1/6*x**6,      [-1e-10,1],   4*eps),
-    (lambda x: sin(x),      lambda x: -cos(x),       [-10,22],   3e1*eps),
-    (lambda x: cos(3*x),    lambda x: 1./3*sin(3*x), [-3,4],       2*eps),
-    (lambda x: exp(x),      lambda x: exp(x),        [-60,1],    1e1*eps),
-    (lambda x: 1e10*exp(x), lambda x: 1e10*exp(x),   [-1,1], 1e10*(3*eps)),
+    (lambda x: 0 * x + 1.0, lambda x: x, [-2, 3], eps),
+    (lambda x: x, lambda x: 1 / 2 * x ** 2, [-5, 0], 4 * eps),
+    (lambda x: x ** 2, lambda x: 1 / 3 * x ** 3, [1, 10], 2e2 * eps),
+    (lambda x: x ** 3, lambda x: 1 / 4 * x ** 4, [-1e-2, 4e-1], 2 * eps),
+    (lambda x: x ** 4, lambda x: 1 / 5 * x ** 5, [-3, -2], 3e2 * eps),
+    (lambda x: x ** 5, lambda x: 1 / 6 * x ** 6, [-1e-10, 1], 4 * eps),
+    (lambda x: sin(x), lambda x: -cos(x), [-10, 22], 3e1 * eps),
+    (lambda x: cos(3 * x), lambda x: 1.0 / 3 * sin(3 * x), [-3, 4], 2 * eps),
+    (lambda x: exp(x), lambda x: exp(x), [-60, 1], 1e1 * eps),
+    (lambda x: 1e10 * exp(x), lambda x: 1e10 * exp(x), [-1, 1], 1e10 * (3 * eps)),
 ]
+
 
 def indefiniteIntegralTester(fun, ifn, interval, tol):
     subinterval = Interval(*interval)
     ff = Bndfun.initfun_adaptive(fun, subinterval)
-    gg = Bndfun.initfun_fixedlen(ifn, subinterval, ff.size+1)
+    gg = Bndfun.initfun_fixedlen(ifn, subinterval, ff.size + 1)
     coeffs = gg.coeffs
     coeffs[0] = coeffs[0] - ifn(np.array([interval[0]]))
+
     def tester(self):
         absdiff = infnorm(ff.cumsum().coeffs - coeffs)
         self.assertLessEqual(absdiff, tol)
+
     return tester
+
 
 for k, (fun, dfn, n, tol) in enumerate(indef_integrals):
     _testfun_ = indefiniteIntegralTester(fun, dfn, n, tol)
@@ -285,27 +303,31 @@ for k, (fun, dfn, n, tol) in enumerate(indef_integrals):
 #            derivatives
 # --------------------------------------
 derivatives = [
-#     (function, derivative, number of points, tolerance)
-    (lambda x: 0*x+1.,      lambda x: 0*x+0,       [-2,3],           eps),
-    (lambda x: x,           lambda x: 0*x+1,       [-5,0],       2e1*eps),
-    (lambda x: x**2,        lambda x: 2*x,         [1,10],       2e2*eps),
-    (lambda x: x**3,        lambda x: 3*x**2,      [-1e-2,4e-1],   3*eps),
-    (lambda x: x**4,        lambda x: 4*x**3,      [-3,-2],      1e3*eps),
-    (lambda x: x**5,        lambda x: 5*x**4,      [-1e-10,1],   4e1*eps),
-    (lambda x: sin(x),      lambda x: cos(x),      [-10,22],     5e2*eps),
-    (lambda x: cos(3*x),    lambda x: -3*sin(3*x), [-3,4],       5e2*eps),
-    (lambda x: exp(x),      lambda x: exp(x),      [-60,1],      2e2*eps),
-    (lambda x: 1e10*exp(x), lambda x: 1e10*exp(x), [-1,1],  1e10*2e2*eps),
+    #     (function, derivative, number of points, tolerance)
+    (lambda x: 0 * x + 1.0, lambda x: 0 * x + 0, [-2, 3], eps),
+    (lambda x: x, lambda x: 0 * x + 1, [-5, 0], 2e1 * eps),
+    (lambda x: x ** 2, lambda x: 2 * x, [1, 10], 2e2 * eps),
+    (lambda x: x ** 3, lambda x: 3 * x ** 2, [-1e-2, 4e-1], 3 * eps),
+    (lambda x: x ** 4, lambda x: 4 * x ** 3, [-3, -2], 1e3 * eps),
+    (lambda x: x ** 5, lambda x: 5 * x ** 4, [-1e-10, 1], 4e1 * eps),
+    (lambda x: sin(x), lambda x: cos(x), [-10, 22], 5e2 * eps),
+    (lambda x: cos(3 * x), lambda x: -3 * sin(3 * x), [-3, 4], 5e2 * eps),
+    (lambda x: exp(x), lambda x: exp(x), [-60, 1], 2e2 * eps),
+    (lambda x: 1e10 * exp(x), lambda x: 1e10 * exp(x), [-1, 1], 1e10 * 2e2 * eps),
 ]
+
 
 def derivativeTester(fun, ifn, interval, tol):
     subinterval = Interval(*interval)
     ff = Bndfun.initfun_adaptive(fun, subinterval)
-    gg = Bndfun.initfun_fixedlen(ifn, subinterval, max(ff.size-1,1))
+    gg = Bndfun.initfun_fixedlen(ifn, subinterval, max(ff.size - 1, 1))
+
     def tester(self):
         absdiff = infnorm(ff.diff().coeffs - gg.coeffs)
         self.assertLessEqual(absdiff, tol)
+
     return tester
+
 
 for k, (fun, der, n, tol) in enumerate(derivatives):
     _testfun_ = derivativeTester(fun, der, n, tol)
@@ -314,36 +336,37 @@ for k, (fun, der, n, tol) in enumerate(derivatives):
 
 
 class Complex(unittest.TestCase):
-
     def setUp(self):
-        self.z = Bndfun.initfun_adaptive(lambda x: np.exp(np.pi*1j*x), Interval(-1, 1))
+        self.z = Bndfun.initfun_adaptive(
+            lambda x: np.exp(np.pi * 1j * x), Interval(-1, 1)
+        )
 
     def test_init_empty(self):
         Bndfun.initempty()
 
     def test_roots(self):
         r0 = self.z.roots()
-        r1 = (self.z-1).roots()
-        r2 = (self.z-1j).roots()
-        r3 = (self.z+1).roots()
-        r4 = (self.z+1j).roots()
+        r1 = (self.z - 1).roots()
+        r2 = (self.z - 1j).roots()
+        r3 = (self.z + 1).roots()
+        r4 = (self.z + 1j).roots()
         self.assertEqual(r0.size, 0)
         self.assertTrue(np.allclose(r1, [0]))
-        self.assertTrue(np.allclose(r2, [.5]))
+        self.assertTrue(np.allclose(r2, [0.5]))
         self.assertTrue(np.allclose(r3, [-1, 1]))
-        self.assertTrue(np.allclose(r4, [-.5]))
+        self.assertTrue(np.allclose(r4, [-0.5]))
 
     def test_rho_ellipse_construction(self):
         zz = 1.2 * self.z
-        e = .5 * (zz + 1/zz)
-        self.assertAlmostEqual(e(1)-e(-1), 0, places=14)
-        self.assertAlmostEqual(e(0)+e(-1), 0, places=14)
-        self.assertAlmostEqual(e(0)+e(1), 0, places=14)
+        e = 0.5 * (zz + 1 / zz)
+        self.assertAlmostEqual(e(1) - e(-1), 0, places=14)
+        self.assertAlmostEqual(e(0) + e(-1), 0, places=14)
+        self.assertAlmostEqual(e(0) + e(1), 0, places=14)
 
     def test_calculus(self):
         self.assertTrue(np.allclose([self.z.sum()], [0]))
-        self.assertTrue((self.z.cumsum().diff()-self.z).size, 1)
-        self.assertTrue((self.z-self.z.cumsum().diff()).size, 1)
+        self.assertTrue((self.z.cumsum().diff() - self.z).size, 1)
+        self.assertTrue((self.z - self.z.cumsum().diff()).size, 1)
 
     def test_real_imag(self):
         # ceck definition of real and imaginary
@@ -352,10 +375,10 @@ class Complex(unittest.TestCase):
         np.testing.assert_equal(zreal.coeffs, np.real(self.z.coeffs))
         np.testing.assert_equal(zimag.coeffs, np.imag(self.z.coeffs))
         # check real part of real chebtech is the same chebtech
-        self.assertTrue(zreal.real()==zreal)
+        self.assertTrue(zreal.real() == zreal)
         # check imaginary part of real chebtech is the zero chebtech
         self.assertTrue(zreal.imag().isconst)
-        self.assertTrue(zreal.imag().coeffs[0]==0)
+        self.assertTrue(zreal.imag().coeffs[0] == 0)
 
 
 class Construction(unittest.TestCase):
@@ -367,54 +390,61 @@ class Construction(unittest.TestCase):
         onefun = Chebtech2(coeffs)
         f = Bndfun(onefun, subinterval)
         self.assertIsInstance(f, Bndfun)
-        self.assertLess(infnorm(f.coeffs-coeffs), eps)
+        self.assertLess(infnorm(f.coeffs - coeffs), eps)
 
     def test_const_construction(self):
         subinterval = Interval()
-        ff = Bndfun.initconst(1., subinterval)
+        ff = Bndfun.initconst(1.0, subinterval)
         self.assertEquals(ff.size, 1)
         self.assertTrue(ff.isconst)
         self.assertFalse(ff.isempty)
-        self.assertRaises(ValueError, Bndfun.initconst, [1.], subinterval)
+        self.assertRaises(ValueError, Bndfun.initconst, [1.0], subinterval)
 
     def test_empty_construction(self):
         ff = Bndfun.initempty()
         self.assertEquals(ff.size, 0)
         self.assertFalse(ff.isconst)
         self.assertTrue(ff.isempty)
-        self.assertRaises(TypeError, Bndfun.initempty, [1.])
+        self.assertRaises(TypeError, Bndfun.initempty, [1.0])
 
     def test_identity_construction(self):
-        for (a,b) in [(-1,1), (-10,-2), (-2.3, 1.24), (20,2000)]:
-            itvl = Interval(a,b)
+        for (a, b) in [(-1, 1), (-10, -2), (-2.3, 1.24), (20, 2000)]:
+            itvl = Interval(a, b)
             ff = Bndfun.initidentity(itvl)
             self.assertEquals(ff.size, 2)
-            xx = np.linspace(a,b,1001)
+            xx = np.linspace(a, b, 1001)
             tol = eps * abs(itvl).max()
-            self.assertLessEqual(infnorm(ff(xx)-xx), tol)
+            self.assertLessEqual(infnorm(ff(xx) - xx), tol)
+
 
 def adaptiveTester(fun, subinterval, funlen):
     ff = Bndfun.initfun_adaptive(fun, subinterval)
+
     def tester(self):
         self.assertEquals(ff.size, funlen)
+
     return tester
+
 
 def fixedlenTester(fun, subinterval, n):
     ff = Bndfun.initfun_fixedlen(fun, subinterval, n)
+
     def tester(self):
         self.assertEquals(ff.size, n)
+
     return tester
+
 
 funs = []
 fun_details = [
     # (function, name for the test printouts,
     #  Matlab chebfun adaptive degree on [-2,3])
-    (lambda x: x**3 + x**2 + x + 1, "poly3(x)", [-2,3],  4),
-    (lambda x: exp(x),              "exp(x)",   [-2,3], 20),
-    (lambda x: sin(x),              "sin(x)",   [-2,3], 20),
-    (lambda x: cos(20*x),           "cos(20x)", [-2,3], 90),
-    (lambda x: 0.*x+1.,             "constfun", [-2,3],  1),
-    (lambda x: 0.*x,                "zerofun",  [-2,3],  1),
+    (lambda x: x ** 3 + x ** 2 + x + 1, "poly3(x)", [-2, 3], 4),
+    (lambda x: exp(x), "exp(x)", [-2, 3], 20),
+    (lambda x: sin(x), "sin(x)", [-2, 3], 20),
+    (lambda x: cos(20 * x), "cos(20x)", [-2, 3], 90),
+    (lambda x: 0.0 * x + 1.0, "constfun", [-2, 3], 1),
+    (lambda x: 0.0 * x, "zerofun", [-2, 3], 1),
 ]
 
 for k, (fun, name, interval, funlen) in enumerate(fun_details):
@@ -430,30 +460,30 @@ for k, (fun, name, interval, funlen) in enumerate(fun_details):
     # add the fixedlen tests
     for n in np.array([100]):
         _testfun_ = fixedlenTester(fun, subinterval, n)
-        _testfun_.__name__ = \
-            "test_fixedlen_{}_{:003}pts".format(fun.__name__, n)
+        _testfun_.__name__ = "test_fixedlen_{}_{:003}pts".format(fun.__name__, n)
         setattr(Construction, _testfun_.__name__, _testfun_)
 
 
 class Algebra(unittest.TestCase):
     """Unit-tests for Bndfun algebraic operations"""
+
     def setUp(self):
-        self.yy = np.linspace(-1,1,1000)
+        self.yy = np.linspace(-1, 1, 1000)
         self.emptyfun = Bndfun.initempty()
 
     # check (empty Bndfun) + (Bndfun) = (empty Bndfun)
     #   and (Bndfun) + (empty Bndfun) = (empty Bndfun)
     def test__add__radd__empty(self):
-        subinterval = Interval(-2,3)
+        subinterval = Interval(-2, 3)
         for (fun, _, _) in testfunctions:
             chebtech = Bndfun.initfun_adaptive(fun, subinterval)
-            self.assertTrue((self.emptyfun+chebtech).isempty)
-            self.assertTrue((chebtech+self.emptyfun).isempty)
+            self.assertTrue((self.emptyfun + chebtech).isempty)
+            self.assertTrue((chebtech + self.emptyfun).isempty)
 
     # check the output of (constant + Bndfun)
     #                 and (Bndfun + constant)
     def test__add__radd__constant(self):
-        subinterval = Interval(-.5,.9)
+        subinterval = Interval(-0.5, 0.9)
         xx = subinterval(self.yy)
         for (fun, _, _) in testfunctions:
             for const in (-1, 1, 10, -1e5):
@@ -462,22 +492,22 @@ class Algebra(unittest.TestCase):
                 f1 = const + bndfun
                 f2 = bndfun + const
                 tol = 4e1 * eps * abs(const)
-                self.assertLessEqual(infnorm(f(xx)-f1(xx)), tol)
-                self.assertLessEqual(infnorm(f(xx)-f2(xx)), tol)
+                self.assertLessEqual(infnorm(f(xx) - f1(xx)), tol)
+                self.assertLessEqual(infnorm(f(xx) - f2(xx)), tol)
 
     # check (empty Bndfun) - (Bndfun) = (empty Bndfun)
     #   and (Bndfun) - (empty Bndfun) = (empty Bndfun)
     def test__sub__rsub__empty(self):
-        subinterval = Interval(-2,3)
+        subinterval = Interval(-2, 3)
         for (fun, _, _) in testfunctions:
             chebtech = Bndfun.initfun_adaptive(fun, subinterval)
-            self.assertTrue((self.emptyfun-chebtech).isempty)
-            self.assertTrue((chebtech-self.emptyfun).isempty)
+            self.assertTrue((self.emptyfun - chebtech).isempty)
+            self.assertTrue((chebtech - self.emptyfun).isempty)
 
     # check the output of constant - Bndfun
     #                 and Bndfun - constant
     def test__sub__rsub__constant(self):
-        subinterval = Interval(-.5,.9)
+        subinterval = Interval(-0.5, 0.9)
         xx = subinterval(self.yy)
         for (fun, _, _) in testfunctions:
             for const in (-1, 1, 10, -1e5):
@@ -487,22 +517,22 @@ class Algebra(unittest.TestCase):
                 ff = const - bndfun
                 gg = bndfun - const
                 tol = 5e1 * eps * abs(const)
-                self.assertLessEqual(infnorm(f(xx)-ff(xx)), tol)
-                self.assertLessEqual(infnorm(g(xx)-gg(xx)), tol)
+                self.assertLessEqual(infnorm(f(xx) - ff(xx)), tol)
+                self.assertLessEqual(infnorm(g(xx) - gg(xx)), tol)
 
     # check (empty Bndfun) * (Bndfun) = (empty Bndfun)
     #   and (Bndfun) * (empty Bndfun) = (empty Bndfun)
     def test__mul__rmul__empty(self):
-        subinterval = Interval(-2,3)
+        subinterval = Interval(-2, 3)
         for (fun, _, _) in testfunctions:
             chebtech = Bndfun.initfun_adaptive(fun, subinterval)
-            self.assertTrue((self.emptyfun*chebtech).isempty)
-            self.assertTrue((chebtech*self.emptyfun).isempty)
+            self.assertTrue((self.emptyfun * chebtech).isempty)
+            self.assertTrue((chebtech * self.emptyfun).isempty)
 
     # check the output of constant * Bndfun
     #                 and Bndfun * constant
     def test__mul__rmul__constant(self):
-        subinterval = Interval(-.5,.9)
+        subinterval = Interval(-0.5, 0.9)
         xx = subinterval(self.yy)
         for (fun, _, _) in testfunctions:
             for const in (-1, 1, 10, -1e5):
@@ -512,25 +542,25 @@ class Algebra(unittest.TestCase):
                 ff = const * bndfun
                 gg = bndfun * const
                 tol = 4e1 * eps * abs(const)
-                self.assertLessEqual(infnorm(f(xx)-ff(xx)), tol)
-                self.assertLessEqual(infnorm(g(xx)-gg(xx)), tol)
+                self.assertLessEqual(infnorm(f(xx) - ff(xx)), tol)
+                self.assertLessEqual(infnorm(g(xx) - gg(xx)), tol)
 
     # check (empty Bndfun) / (Bndfun) = (empty Bndfun)
     #   and (Bndfun) / (empty Bndfun) = (empty Bndfun)
     def test_truediv_empty(self):
-        subinterval = Interval(-2,3)
+        subinterval = Interval(-2, 3)
         for (fun, _, _) in testfunctions:
             bndfun = Bndfun.initfun_adaptive(fun, subinterval)
             self.assertTrue(operator.truediv(self.emptyfun, bndfun).isempty)
             self.assertTrue(operator.truediv(self.emptyfun, bndfun).isempty)
             # __truediv__
-            self.assertTrue((self.emptyfun/bndfun).isempty)
-            self.assertTrue((bndfun/self.emptyfun).isempty)
+            self.assertTrue((self.emptyfun / bndfun).isempty)
+            self.assertTrue((bndfun / self.emptyfun).isempty)
 
     # check the output of constant / Bndfun
     #                 and Bndfun / constant
     def test_truediv_constant(self):
-        subinterval = Interval(-.5,.9)
+        subinterval = Interval(-0.5, 0.9)
         xx = subinterval(self.yy)
         for (fun, _, hasRoots) in testfunctions:
             for const in (-1, 1, 10, -1e5):
@@ -539,12 +569,12 @@ class Algebra(unittest.TestCase):
                 bndfun = Bndfun.initfun_adaptive(fun, subinterval)
                 g = lambda x: fun(x) / const
                 gg = bndfun / const
-                self.assertLessEqual(infnorm(g(xx)-gg(xx)), 3*gg.size*tol)
+                self.assertLessEqual(infnorm(g(xx) - gg(xx)), 3 * gg.size * tol)
                 # don't do the following test for functions with roots
                 if not hasRoots:
                     f = lambda x: const / fun(x)
                     ff = const / bndfun
-                    self.assertLessEqual(infnorm(f(xx)-ff(xx)), 2*ff.size*tol)
+                    self.assertLessEqual(infnorm(f(xx) - ff(xx)), 2 * ff.size * tol)
 
     # check    +(empty Bndfun) = (empty Bndfun)
     def test__pos__empty(self):
@@ -557,34 +587,35 @@ class Algebra(unittest.TestCase):
     # check (empty Bndfun) ** c = (empty Bndfun)
     def test_pow_empty(self):
         for c in range(10):
-            self.assertTrue((self.emptyfun**c).isempty)
+            self.assertTrue((self.emptyfun ** c).isempty)
 
     # check c ** (empty Bndfun) = (empty Bndfun)
     def test_rpow_empty(self):
         for c in range(10):
-            self.assertTrue((c**self.emptyfun).isempty)
+            self.assertTrue((c ** self.emptyfun).isempty)
 
     # check the output of Bndfun ** constant
     def test_pow_const(self):
-        subinterval = Interval(-.5,.9)
+        subinterval = Interval(-0.5, 0.9)
         xx = subinterval(self.yy)
         for func in (np.sin, np.exp, np.cos):
             for c in (1, 2):
                 f = lambda x: func(x) ** c
                 ff = Bndfun.initfun_adaptive(func, subinterval) ** c
                 tol = 2e1 * eps * abs(c)
-                self.assertLessEqual(infnorm(f(xx)-ff(xx)), tol)
+                self.assertLessEqual(infnorm(f(xx) - ff(xx)), tol)
 
     # check the output of constant ** Bndfun
     def test_rpow_const(self):
-        subinterval = Interval(-.5,.9)
+        subinterval = Interval(-0.5, 0.9)
         xx = subinterval(self.yy)
         for func in (np.sin, np.exp, np.cos):
             for c in (1, 2):
                 f = lambda x: c ** func(x)
                 ff = c ** Bndfun.initfun_adaptive(func, subinterval)
                 tol = 1e1 * eps * abs(c)
-                self.assertLessEqual(infnorm(f(xx)-ff(xx)), tol)
+                self.assertLessEqual(infnorm(f(xx) - ff(xx)), tol)
+
 
 binops = (operator.add, operator.mul, operator.sub, operator.truediv)
 
@@ -592,21 +623,24 @@ binops = (operator.add, operator.mul, operator.sub, operator.truediv)
 def binaryOpTester(f, g, subinterval, binop):
     ff = Bndfun.initfun_adaptive(f, subinterval)
     gg = Bndfun.initfun_adaptive(g, subinterval)
-    FG = lambda x: binop(f(x),g(x))
+    FG = lambda x: binop(f(x), g(x))
     fg = binop(ff, gg)
+
     def tester(self):
         vscl = max([ff.vscale, gg.vscale])
         lscl = max([ff.size, gg.size])
         xx = subinterval(self.yy)
-        self.assertLessEqual(infnorm(fg(xx)-FG(xx)), 6*vscl*lscl*eps)
+        self.assertLessEqual(infnorm(fg(xx) - FG(xx)), 6 * vscl * lscl * eps)
+
     return tester
+
 
 # Note: defining __radd__(a,b) = __add__(b,a) and feeding this into the
 # test will not in fact test the __radd__ functionality of the class.
 # These tests will need to be added manually.
 
 subintervals = (
-    Interval(-.5,.9),
+    Interval(-0.5, 0.9),
     Interval(-1.2, 1.3),
     Interval(-2.2, -1.9),
     Interval(0.4, 1.3),
@@ -614,8 +648,7 @@ subintervals = (
 
 for binop in binops:
     # add the generic binary operator tests
-    for (f, _, _), (g, _, denomRoots) in \
-            itertools.combinations(testfunctions, 2):
+    for (f, _, _), (g, _, denomRoots) in itertools.combinations(testfunctions, 2):
         for subinterval in subintervals:
             if binop is operator.truediv and denomRoots:
                 # skip truediv test if denominator has roots on the real line
@@ -623,24 +656,24 @@ for binop in binops:
             else:
                 _testfun_ = binaryOpTester(f, g, subinterval, binop)
                 a, b = subinterval
-                _testfun_.__name__ = \
-                    "test_{}_{}_{}_[{:.1f},{:.1f}]".format(
-                        binop.__name__, f.__name__,  g.__name__, a, b)
+                _testfun_.__name__ = "test_{}_{}_{}_[{:.1f},{:.1f}]".format(
+                    binop.__name__, f.__name__, g.__name__, a, b
+                )
                 setattr(Algebra, _testfun_.__name__, _testfun_)
 
 powtestfuns = (
-    [(np.exp, 'exp'), (np.sin, 'sin')],
-    [(np.exp, 'exp'), (lambda x: 2-x, 'linear')],
-    [(lambda x: 2-x, 'linear'), (np.exp, 'exp')],
+    [(np.exp, "exp"), (np.sin, "sin")],
+    [(np.exp, "exp"), (lambda x: 2 - x, "linear")],
+    [(lambda x: 2 - x, "linear"), (np.exp, "exp")],
 )
 # add operator.power tests
 for (f, namef), (g, nameg) in powtestfuns:
     for subinterval in subintervals:
         _testfun_ = binaryOpTester(f, g, subinterval, operator.pow)
         a, b = subinterval
-        _testfun_.__name__ = \
-            "test_{}_{}_{}_[{:.1f},{:.1f}]".format(
-                'pow', namef, nameg, a, b)
+        _testfun_.__name__ = "test_{}_{}_{}_[{:.1f},{:.1f}]".format(
+            "pow", namef, nameg, a, b
+        )
         setattr(Algebra, _testfun_.__name__, _testfun_)
 
 unaryops = (operator.pos, operator.neg)
@@ -650,36 +683,61 @@ def unaryOpTester(unaryop, f, subinterval):
     ff = Bndfun.initfun_adaptive(f, subinterval)
     gg = lambda x: unaryop(f(x))
     GG = unaryop(ff)
+
     def tester(self):
         xx = subinterval(self.yy)
-        self.assertLessEqual(infnorm(gg(xx)-GG(xx)), 4e1*eps)
+        self.assertLessEqual(infnorm(gg(xx) - GG(xx)), 4e1 * eps)
+
     return tester
+
 
 for unaryop in unaryops:
     for (f, _, _) in testfunctions:
-        subinterval = Interval(-.5,.9)
+        subinterval = Interval(-0.5, 0.9)
         _testfun_ = unaryOpTester(unaryop, f, subinterval)
-        _testfun_.__name__ = \
-            "test_{}_{}".format(unaryop.__name__, f.__name__)
+        _testfun_.__name__ = "test_{}_{}".format(unaryop.__name__, f.__name__)
         setattr(Algebra, _testfun_.__name__, _testfun_)
 
 
 class Ufuncs(unittest.TestCase):
     """Unit-tests for Bndfun numpy ufunc overloads"""
+
     def setUp(self):
-        self.yy = np.linspace(-1,1,1000)
+        self.yy = np.linspace(-1, 1, 1000)
         self.emptyfun = Bndfun.initempty()
 
-ufuncs = (np.absolute, np.arccos, np.arccosh, np.arcsin, np.arcsinh, np.arctan,
-          np.arctanh, np.cos, np.cosh, np.exp, np.exp2, np.expm1, np.log,
-          np.log2, np.log10, np.log1p, np.sinh, np.sin, np.tan, np.tanh,
-          np.sqrt)
+
+ufuncs = (
+    np.absolute,
+    np.arccos,
+    np.arccosh,
+    np.arcsin,
+    np.arcsinh,
+    np.arctan,
+    np.arctanh,
+    np.cos,
+    np.cosh,
+    np.exp,
+    np.exp2,
+    np.expm1,
+    np.log,
+    np.log2,
+    np.log10,
+    np.log1p,
+    np.sinh,
+    np.sin,
+    np.tan,
+    np.tanh,
+    np.sqrt,
+)
 
 # empty-case tests
 def ufuncEmptyCaseTester(ufunc):
     def tester(self):
         self.assertTrue(getattr(self.emptyfun, ufunc.__name__)().isempty)
+
     return tester
+
 
 for ufunc in ufuncs:
     _testfun_ = ufuncEmptyCaseTester(ufunc)
@@ -692,102 +750,297 @@ for ufunc in ufuncs:
 
 uf1 = lambda x: x
 uf1.__name__ = "x"
-uf2 = lambda x: sin(x-.5)
+uf2 = lambda x: sin(x - 0.5)
 uf2.__name__ = "sin(x-.5)"
-uf3 = lambda x: sin(25*x-1)
+uf3 = lambda x: sin(25 * x - 1)
 uf3.__name__ = "sin(25*x-1)"
 
 ufunc_test_params = [
-    (np.absolute, [([uf1, (-3,-.5)], eps), ]),
-    (np.arccos,   [([uf1, (-.8,.8)], eps), ]),
-    (np.arccosh,  [([uf1, (2,3)   ], eps), ]),
-    (np.arcsin,   [([uf1, (-.8,.8)], eps), ]),
-    (np.arcsinh,  [([uf1, (2,3)   ], eps), ]),
-    (np.arctan,   [([uf1, (-.8,.8)], eps), ]),
-    (np.arctanh,  [([uf1, (-.8,.8)], eps), ]),
-    (np.cos,      [([uf1, (-3,3)  ], eps), ]),
-    (np.cosh,     [([uf1, (-3,3)  ], eps), ]),
-    (np.exp,      [([uf1, (-3,3)  ], eps), ]),
-    (np.exp2,     [([uf1, (-3,3)  ], eps), ]),
-    (np.expm1,    [([uf1, (-3,3)  ], eps), ]),
-    (np.log,      [([uf1, (2,3)   ], eps), ]),
-    (np.log2,     [([uf1, (2,3)   ], eps), ]),
-    (np.log10,    [([uf1, (2,3)   ], eps), ]),
-    (np.log1p,    [([uf1, (-.8,.8)], eps), ]),
-    (np.sinh,     [([uf1, (-3,3)  ], eps), ]),
-    (np.sin,      [([uf1, (-3,3)  ], eps), ]),
-    (np.tan,      [([uf1, (-.8,.8)], eps), ]),
-    (np.tanh,     [([uf1, (-3,3)  ], eps), ]),
-    (np.sqrt,     [([uf1, (2,3)   ], eps), ]),
-
-    (np.cos,      [([uf2, (-3,3)  ], eps), ]),
-    (np.cosh,     [([uf2, (-3,3)  ], eps), ]),
-    (np.exp,      [([uf2, (-3,3)  ], eps), ]),
-    (np.expm1,    [([uf2, (-3,3)  ], eps), ]),
-    (np.sinh,     [([uf2, (-3,3)  ], eps), ]),
-    (np.sin,      [([uf2, (-3,3)  ], eps), ]),
-    (np.tan,      [([uf2, (-.8,.8)], eps), ]),
-    (np.tanh,     [([uf2, (-3,3)  ], eps), ]),
-
-    (np.cos,      [([uf3, (-3,3)  ], eps), ]),
-    (np.cosh,     [([uf3, (-3,3)  ], eps), ]),
-    (np.exp,      [([uf3, (-3,3)  ], eps), ]),
-    (np.expm1,    [([uf3, (-3,3)  ], eps), ]),
-    (np.sinh,     [([uf3, (-3,3)  ], eps), ]),
-    (np.sin,      [([uf3, (-3,3)  ], eps), ]),
-    (np.tan,      [([uf3, (-.8,.8)], eps), ]),
-    (np.tanh,     [([uf3, (-3,3)  ], eps), ]),
+    (
+        np.absolute,
+        [
+            ([uf1, (-3, -0.5)], eps),
+        ],
+    ),
+    (
+        np.arccos,
+        [
+            ([uf1, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.arccosh,
+        [
+            ([uf1, (2, 3)], eps),
+        ],
+    ),
+    (
+        np.arcsin,
+        [
+            ([uf1, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.arcsinh,
+        [
+            ([uf1, (2, 3)], eps),
+        ],
+    ),
+    (
+        np.arctan,
+        [
+            ([uf1, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.arctanh,
+        [
+            ([uf1, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.cos,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.cosh,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.exp,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.exp2,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.expm1,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.log,
+        [
+            ([uf1, (2, 3)], eps),
+        ],
+    ),
+    (
+        np.log2,
+        [
+            ([uf1, (2, 3)], eps),
+        ],
+    ),
+    (
+        np.log10,
+        [
+            ([uf1, (2, 3)], eps),
+        ],
+    ),
+    (
+        np.log1p,
+        [
+            ([uf1, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.sinh,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.sin,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.tan,
+        [
+            ([uf1, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.tanh,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.sqrt,
+        [
+            ([uf1, (2, 3)], eps),
+        ],
+    ),
+    (
+        np.cos,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.cosh,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.exp,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.expm1,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.sinh,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.sin,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.tan,
+        [
+            ([uf2, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.tanh,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.cos,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.cosh,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.exp,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.expm1,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.sinh,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.sin,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.tan,
+        [
+            ([uf3, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.tanh,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
 ]
+
 
 def ufuncTester(ufunc, f, interval, tol):
     ff = Bndfun.initfun_adaptive(f, interval)
     gg = lambda x: ufunc(f(x))
     GG = getattr(ff, ufunc.__name__)()
+
     def tester(self):
         xx = interval(self.yy)
         vscl = GG.vscale
         lscl = GG.size
-        self.assertLessEqual(infnorm(gg(xx)-GG(xx)), vscl*lscl*tol)
+        self.assertLessEqual(infnorm(gg(xx) - GG(xx)), vscl * lscl * tol)
+
     return tester
 
-for (ufunc,  [([f, intvl], tol), ]) in ufunc_test_params:
+
+for (
+    ufunc,
+    [
+        ([f, intvl], tol),
+    ],
+) in ufunc_test_params:
     interval = Interval(*intvl)
     _testfun_ = ufuncTester(ufunc, f, interval, tol)
-    _testfun_.__name__ = \
-        "test_{}_{}_[{:.1f},{:.1f}]".format(
-        ufunc.__name__, f.__name__, *intvl)
+    _testfun_.__name__ = "test_{}_{}_[{:.1f},{:.1f}]".format(
+        ufunc.__name__, f.__name__, *intvl
+    )
     setattr(Ufuncs, _testfun_.__name__, _testfun_)
 
 
 class Roots(unittest.TestCase):
-
     def test_empty(self):
         ff = Bndfun.initempty()
         self.assertEquals(ff.roots().size, 0)
 
     def test_const(self):
-        ff = Bndfun.initconst(0., Interval(-2,3))
-        gg = Bndfun.initconst(2., Interval(-2,3))
+        ff = Bndfun.initconst(0.0, Interval(-2, 3))
+        gg = Bndfun.initconst(2.0, Interval(-2, 3))
         self.assertEquals(ff.roots().size, 0)
         self.assertEquals(gg.roots().size, 0)
+
 
 # add tests for roots
 def rootsTester(f, interval, roots, tol):
     subinterval = Interval(*interval)
     ff = Bndfun.initfun_adaptive(f, subinterval)
     rts = ff.roots()
+
     def tester(self):
-        self.assertLessEqual(infnorm(rts-roots), tol)
+        self.assertLessEqual(infnorm(rts - roots), tol)
+
     return tester
 
+
 rootstestfuns = (
-    (lambda x: 3*x+2.,        [-2,3],     np.array([-2/3]),                  eps),
-    (lambda x: x**2+.2*x-.08, [-2,5],     np.array([-.4, .2]),           3e1*eps),
-    (lambda x: sin(x),        [-7,7],     pi*np.linspace(-2,2,5),        1e1*eps),
-    (lambda x: cos(2*pi*x),   [-20,10],   np.linspace(-19.75, 9.75, 60), 3e1*eps),
-    (lambda x: sin(100*pi*x), [-0.5,0.5], np.linspace(-.5,.5,101),           eps),
-    (lambda x: sin(5*pi/2*x), [-1,1],     np.array([-.8, -.4, 0, .4, .8]),   eps)
-    )
+    (lambda x: 3 * x + 2.0, [-2, 3], np.array([-2 / 3]), eps),
+    (lambda x: x ** 2 + 0.2 * x - 0.08, [-2, 5], np.array([-0.4, 0.2]), 3e1 * eps),
+    (lambda x: sin(x), [-7, 7], pi * np.linspace(-2, 2, 5), 1e1 * eps),
+    (lambda x: cos(2 * pi * x), [-20, 10], np.linspace(-19.75, 9.75, 60), 3e1 * eps),
+    (lambda x: sin(100 * pi * x), [-0.5, 0.5], np.linspace(-0.5, 0.5, 101), eps),
+    (lambda x: sin(5 * pi / 2 * x), [-1, 1], np.array([-0.8, -0.4, 0, 0.4, 0.8]), eps),
+)
 for k, args in enumerate(rootstestfuns):
     _testfun_ = rootsTester(*args)
     _testfun_.__name__ = "test_roots_{}".format(k)

--- a/tests/test_chebfun.py
+++ b/tests/test_chebfun.py
@@ -11,8 +11,12 @@ from chebpy.core.bndfun import Bndfun
 from chebpy.core.chebfun import Chebfun
 from chebpy.core.settings import DefaultPreferences
 from chebpy.core.utilities import Domain, Interval
-from chebpy.core.exceptions import (IntervalGap, IntervalOverlap,
-                                    InvalidDomain, BadFunLengthArgument)
+from chebpy.core.exceptions import (
+    IntervalGap,
+    IntervalOverlap,
+    InvalidDomain,
+    BadFunLengthArgument,
+)
 from chebpy.core.plotting import import_plt
 
 from .utilities import infnorm, testfunctions
@@ -36,22 +40,22 @@ eps = DefaultPreferences.eps
 
 # domain, test_tolerance
 chebfun_testdomains = [
-    ([-1,1], 2*eps),
-    ([-2,1], eps),
-    ([-1,2], eps),
-    ([-5,9], 35*eps),
+    ([-1, 1], 2 * eps),
+    ([-2, 1], eps),
+    ([-1, 2], eps),
+    ([-5, 9], 35 * eps),
 ]
 
-class Construction(unittest.TestCase):
 
+class Construction(unittest.TestCase):
     def setUp(self):
         f = lambda x: exp(x)
         self.f = f
-        self.fun0 = Bndfun.initfun_adaptive(f, Interval(-1,0))
-        self.fun1 = Bndfun.initfun_adaptive(f, Interval(0,1))
-        self.fun2 = Bndfun.initfun_adaptive(f, Interval(-.5,0.5))
-        self.fun3 = Bndfun.initfun_adaptive(f, Interval(2,2.5))
-        self.fun4 = Bndfun.initfun_adaptive(f, Interval(-3,-2))
+        self.fun0 = Bndfun.initfun_adaptive(f, Interval(-1, 0))
+        self.fun1 = Bndfun.initfun_adaptive(f, Interval(0, 1))
+        self.fun2 = Bndfun.initfun_adaptive(f, Interval(-0.5, 0.5))
+        self.fun3 = Bndfun.initfun_adaptive(f, Interval(2, 2.5))
+        self.fun4 = Bndfun.initfun_adaptive(f, Interval(-3, -2))
         self.funs_a = np.array([self.fun1, self.fun0, self.fun2])
         self.funs_b = np.array([self.fun1, self.fun2])
         self.funs_c = np.array([self.fun0, self.fun3])
@@ -74,10 +78,10 @@ class Construction(unittest.TestCase):
         self.assertEqual(emptyfun.funs.size, 0)
 
     def test_initconst(self):
-        self.assertTrue(Chebfun.initconst(1, [-1,1]).isconst)
-        self.assertTrue(Chebfun.initconst(-10, np.linspace(-1,1,11)).isconst)
-        self.assertTrue(Chebfun.initconst(3, [-2,0,1]).isconst)
-        self.assertTrue(Chebfun.initconst(3.14, np.linspace(-100,-90,11)).isconst)
+        self.assertTrue(Chebfun.initconst(1, [-1, 1]).isconst)
+        self.assertTrue(Chebfun.initconst(-10, np.linspace(-1, 1, 11)).isconst)
+        self.assertTrue(Chebfun.initconst(3, [-2, 0, 1]).isconst)
+        self.assertTrue(Chebfun.initconst(3.14, np.linspace(-100, -90, 11)).isconst)
         self.assertFalse(Chebfun([self.fun0]).isconst)
         self.assertFalse(Chebfun([self.fun1]).isconst)
         self.assertFalse(Chebfun([self.fun2]).isconst)
@@ -85,46 +89,49 @@ class Construction(unittest.TestCase):
 
     def test_initidentity(self):
         _doms = (
-            np.linspace(-1,1,2),
-            np.linspace(-1,1,11),
-            np.linspace(-10,17,351),
-            np.linspace(-9.3,-3.2,22),
-            np.linspace(2.5,144.3,2112),
+            np.linspace(-1, 1, 2),
+            np.linspace(-1, 1, 11),
+            np.linspace(-10, 17, 351),
+            np.linspace(-9.3, -3.2, 22),
+            np.linspace(2.5, 144.3, 2112),
         )
         for _dom in _doms:
             ff = Chebfun.initidentity(_dom)
             a, b = ff.support
             xx = np.linspace(a, b, 1001)
             tol = eps * ff.hscale
-            self.assertLessEqual(infnorm(ff(xx)-xx), tol)
+            self.assertLessEqual(infnorm(ff(xx) - xx), tol)
         # test the default case
         ff = Chebfun.initidentity()
         a, b = ff.support
         xx = np.linspace(a, b, 1001)
         tol = eps * ff.hscale
-        self.assertLessEqual(infnorm(ff(xx)-xx), tol)     
+        self.assertLessEqual(infnorm(ff(xx) - xx), tol)
 
     def test_initfun_adaptive_continuous_domain(self):
-        ff = Chebfun.initfun_adaptive(self.f, [-2,-1])
+        ff = Chebfun.initfun_adaptive(self.f, [-2, -1])
         self.assertEqual(ff.funs.size, 1)
         a, b = ff.breakdata.keys()
-        fa, fb, = ff.breakdata.values()
-        self.assertEqual(a,-2)
-        self.assertEqual(b,-1)
-        self.assertLessEqual(abs(fa-self.f(-2)), eps)
-        self.assertLessEqual(abs(fb-self.f(-1)), eps)
+        (
+            fa,
+            fb,
+        ) = ff.breakdata.values()
+        self.assertEqual(a, -2)
+        self.assertEqual(b, -1)
+        self.assertLessEqual(abs(fa - self.f(-2)), eps)
+        self.assertLessEqual(abs(fb - self.f(-1)), eps)
 
     def test_initfun_adaptive_piecewise_domain(self):
-        ff = Chebfun.initfun_adaptive(self.f, [-2,0,1])
+        ff = Chebfun.initfun_adaptive(self.f, [-2, 0, 1])
         self.assertEqual(ff.funs.size, 2)
         a, b, c = ff.breakdata.keys()
         fa, fb, fc = ff.breakdata.values()
-        self.assertEqual(a,-2)
+        self.assertEqual(a, -2)
         self.assertEqual(b, 0)
         self.assertEqual(c, 1)
-        self.assertLessEqual(abs(fa-self.f(-2)), eps)
-        self.assertLessEqual(abs(fb-self.f( 0)), eps)
-        self.assertLessEqual(abs(fc-self.f( 1)), 2*eps)
+        self.assertLessEqual(abs(fa - self.f(-2)), eps)
+        self.assertLessEqual(abs(fb - self.f(0)), eps)
+        self.assertLessEqual(abs(fc - self.f(1)), 2 * eps)
 
     def test_initfun_adaptive_raises(self):
         initfun = Chebfun.initfun_adaptive
@@ -137,46 +144,49 @@ class Construction(unittest.TestCase):
         self.assertTrue(f.isempty)
 
     def test_initfun_fixedlen_continuous_domain(self):
-        ff = Chebfun.initfun_fixedlen(self.f, 20, [-2,-1])
+        ff = Chebfun.initfun_fixedlen(self.f, 20, [-2, -1])
         self.assertEqual(ff.funs.size, 1)
         a, b = ff.breakdata.keys()
-        fa, fb, = ff.breakdata.values()
-        self.assertEqual(a,-2)
-        self.assertEqual(b,-1)
-        self.assertLessEqual(abs(fa-self.f(-2)), eps)
-        self.assertLessEqual(abs(fb-self.f(-1)), eps)
+        (
+            fa,
+            fb,
+        ) = ff.breakdata.values()
+        self.assertEqual(a, -2)
+        self.assertEqual(b, -1)
+        self.assertLessEqual(abs(fa - self.f(-2)), eps)
+        self.assertLessEqual(abs(fb - self.f(-1)), eps)
 
     def test_initfun_fixedlen_piecewise_domain_0(self):
-        ff = Chebfun.initfun_fixedlen(self.f, 30, [-2,0,1])
+        ff = Chebfun.initfun_fixedlen(self.f, 30, [-2, 0, 1])
         self.assertEqual(ff.funs.size, 2)
         a, b, c = ff.breakdata.keys()
         fa, fb, fc = ff.breakdata.values()
-        self.assertEqual(a,-2)
+        self.assertEqual(a, -2)
         self.assertEqual(b, 0)
         self.assertEqual(c, 1)
-        self.assertLessEqual(abs(fa-self.f(-2)), 3*eps)
-        self.assertLessEqual(abs(fb-self.f( 0)), 3*eps)
-        self.assertLessEqual(abs(fc-self.f( 1)), 3*eps)
+        self.assertLessEqual(abs(fa - self.f(-2)), 3 * eps)
+        self.assertLessEqual(abs(fb - self.f(0)), 3 * eps)
+        self.assertLessEqual(abs(fc - self.f(1)), 3 * eps)
 
     def test_initfun_fixedlen_piecewise_domain_1(self):
-        ff = Chebfun.initfun_fixedlen(self.f, [30,20], [-2,0,1])
+        ff = Chebfun.initfun_fixedlen(self.f, [30, 20], [-2, 0, 1])
         self.assertEqual(ff.funs.size, 2)
         a, b, c = ff.breakdata.keys()
         fa, fb, fc = ff.breakdata.values()
-        self.assertEqual(a,-2)
+        self.assertEqual(a, -2)
         self.assertEqual(b, 0)
         self.assertEqual(c, 1)
-        self.assertLessEqual(abs(fa-self.f(-2)), 3*eps)
-        self.assertLessEqual(abs(fb-self.f( 0)), 3*eps)
-        self.assertLessEqual(abs(fc-self.f( 1)), 6*eps)
+        self.assertLessEqual(abs(fa - self.f(-2)), 3 * eps)
+        self.assertLessEqual(abs(fb - self.f(0)), 3 * eps)
+        self.assertLessEqual(abs(fc - self.f(1)), 6 * eps)
 
     def test_initfun_fixedlen_raises(self):
         initfun = Chebfun.initfun_fixedlen
         self.assertRaises(InvalidDomain, initfun, self.f, 10, [-2])
         self.assertRaises(InvalidDomain, initfun, self.f, n=10, domain=[-2])
         self.assertRaises(InvalidDomain, initfun, self.f, n=10, domain=0)
-        self.assertRaises(BadFunLengthArgument, initfun, self.f, [30,40], [-1,1])
-        self.assertRaises(TypeError, initfun, self.f, [], [-2,-1,0])
+        self.assertRaises(BadFunLengthArgument, initfun, self.f, [30, 40], [-1, 1])
+        self.assertRaises(TypeError, initfun, self.f, [], [-2, -1, 0])
 
     def test_initfun_fixedlen_empty_domain(self):
         f = Chebfun.initfun_fixedlen(self.f, n=10, domain=[])
@@ -191,27 +201,26 @@ class Construction(unittest.TestCase):
         g2 = Chebfun.initfun_fixedlen(self.f, [None, 40], dom)
         g3 = Chebfun.initfun_fixedlen(self.f, None, dom)
         for funA, funB in zip(g1, g0):
-            self.assertEqual(sum(funA.coeffs-funB.coeffs), 0)
+            self.assertEqual(sum(funA.coeffs - funB.coeffs), 0)
         for funA, funB in zip(g3, g0):
-            self.assertEqual(sum(funA.coeffs-funB.coeffs), 0)
-        self.assertEqual(sum(g2.funs[0].coeffs-g0.funs[0].coeffs), 0)
+            self.assertEqual(sum(funA.coeffs - funB.coeffs), 0)
+        self.assertEqual(sum(g2.funs[0].coeffs - g0.funs[0].coeffs), 0)
 
 
 class Properties(unittest.TestCase):
-
     def setUp(self):
         self.f0 = Chebfun.initempty()
-        self.f1 = Chebfun.initfun_adaptive(lambda x: x**2, [-1,1])
-        self.f2 = Chebfun.initfun_adaptive(lambda x: x**2, [-1,0,1,2])
+        self.f1 = Chebfun.initfun_adaptive(lambda x: x ** 2, [-1, 1])
+        self.f2 = Chebfun.initfun_adaptive(lambda x: x ** 2, [-1, 0, 1, 2])
 
     def test_breakpoints(self):
         self.assertEqual(self.f0.breakpoints.size, 0)
-        self.assertTrue(np.equal(self.f1.breakpoints,[-1,1]).all())
-        self.assertTrue(np.equal(self.f2.breakpoints,[-1,0,1,2]).all())
+        self.assertTrue(np.equal(self.f1.breakpoints, [-1, 1]).all())
+        self.assertTrue(np.equal(self.f2.breakpoints, [-1, 0, 1, 2]).all())
 
     def test_domain(self):
-        d1 = Domain([-1,1])
-        d2 = Domain([-1,0,1,2])
+        d1 = Domain([-1, 1])
+        d2 = Domain([-1, 0, 1, 2])
         self.assertIsInstance(self.f0.domain, np.ndarray)
         self.assertIsInstance(self.f1.domain, Domain)
         self.assertIsInstance(self.f2.domain, Domain)
@@ -236,8 +245,8 @@ class Properties(unittest.TestCase):
         self.assertFalse(self.f0.isconst)
         self.assertFalse(self.f1.isconst)
         self.assertFalse(self.f2.isconst)
-        c1 = Chebfun.initfun_fixedlen(lambda x: 0*x+3, 1, [-2,-1,0,1,2,3])
-        c2 = Chebfun.initfun_fixedlen(lambda x: 0*x-1, 1, [-2,3])
+        c1 = Chebfun.initfun_fixedlen(lambda x: 0 * x + 3, 1, [-2, -1, 0, 1, 2, 3])
+        c2 = Chebfun.initfun_fixedlen(lambda x: 0 * x - 1, 1, [-2, 3])
         self.assertTrue(c1.isconst)
         self.assertTrue(c2.isconst)
 
@@ -246,8 +255,8 @@ class Properties(unittest.TestCase):
         self.assertIsInstance(self.f1.support, Domain)
         self.assertIsInstance(self.f2.support, Domain)
         self.assertEqual(self.f0.support.size, 0)
-        self.assertTrue(np.equal(self.f1.support,[-1,1]).all())
-        self.assertTrue(np.equal(self.f2.support,[-1,2]).all())
+        self.assertTrue(np.equal(self.f1.support, [-1, 1]).all())
+        self.assertTrue(np.equal(self.f2.support, [-1, 2]).all())
 
     def test_vscale(self):
         self.assertEqual(self.f0.vscale, 0)
@@ -256,11 +265,10 @@ class Properties(unittest.TestCase):
 
 
 class ClassUsage(unittest.TestCase):
-
     def setUp(self):
         self.f0 = Chebfun.initempty()
-        self.f1 = Chebfun.initfun_adaptive(lambda x: x**2, [-1,1])
-        self.f2 = Chebfun.initfun_adaptive(lambda x: x**2, [-1,0,1,2])
+        self.f1 = Chebfun.initfun_adaptive(lambda x: x ** 2, [-1, 1])
+        self.f2 = Chebfun.initfun_adaptive(lambda x: x ** 2, [-1, 0, 1, 2])
 
     def test__str__(self):
         try:
@@ -268,7 +276,7 @@ class ClassUsage(unittest.TestCase):
             str1 = str(self.f1)
             str2 = str(self.f2)
         except:
-            self.fail('str() failed unexpectedly')
+            self.fail("str() failed unexpectedly")
 
     def test__repr__(self):
         try:
@@ -276,7 +284,7 @@ class ClassUsage(unittest.TestCase):
             repr1 = repr(self.f1)
             repr2 = repr(self.f2)
         except:
-            self.fail('repr() failed unexpectedly')
+            self.fail("repr() failed unexpectedly")
 
     def test_copy(self):
         f0_copy = self.f0.copy()
@@ -288,24 +296,24 @@ class ClassUsage(unittest.TestCase):
             fun = self.f1.funs[k]
             funcopy = f1_copy.funs[k]
             self.assertNotEqual(fun, funcopy)
-            self.assertEquals(sum(fun.coeffs-funcopy.coeffs), 0)
+            self.assertEquals(sum(fun.coeffs - funcopy.coeffs), 0)
         for k in range(self.f2.funs.size):
             fun = self.f2.funs[k]
             funcopy = f2_copy.funs[k]
             self.assertNotEqual(fun, funcopy)
-            self.assertEquals(sum(fun.coeffs-funcopy.coeffs), 0)
+            self.assertEquals(sum(fun.coeffs - funcopy.coeffs), 0)
 
     def test__iter__(self):
         for f in [self.f0, self.f1, self.f2]:
             a1 = [x for x in f]
             a2 = [x for x in f.funs]
-            self.assertTrue(np.equal(a1,a2).all())
+            self.assertTrue(np.equal(a1, a2).all())
 
     def test_x_property(self):
         _doms = (
-            np.linspace(-1,1,2),
-            np.linspace(-1,1,11),
-            np.linspace(-9.3,-3.2,22),
+            np.linspace(-1, 1, 2),
+            np.linspace(-1, 1, 11),
+            np.linspace(-9.3, -3.2, 22),
         )
         for _dom in _doms:
             f = Chebfun.initfun_fixedlen(sin, 1000, _dom)
@@ -313,12 +321,12 @@ class ClassUsage(unittest.TestCase):
             a, b = x.support
             pts = np.linspace(a, b, 1001)
             tol = eps * f.hscale
-            self.assertLessEqual(infnorm(x(pts)-pts), tol)
+            self.assertLessEqual(infnorm(x(pts) - pts), tol)
 
     def test_restrict_(self):
-        '''Tests the ._restrict operator'''
+        """Tests the ._restrict operator"""
         # test a variety of domains with breaks
-        doms = [(-4,4), (-4,0,4), (-2,-1, 0.3, 1, 2.5)]
+        doms = [(-4, 4), (-4, 0, 4), (-2, -1, 0.3, 1, 2.5)]
         for dom in doms:
             ff = Chebfun.initfun_fixedlen(cos, 25, domain=dom)
             # define some arbitrary subdomains
@@ -330,34 +338,34 @@ class ClassUsage(unittest.TestCase):
                 vscl = ff.vscale
                 hscl = ff.hscale
                 lscl = max([fun.size for fun in ff])
-                tol = vscl*hscl*lscl*eps
+                tol = vscl * hscl * lscl * eps
                 # sample the restricted function and comapre with original
-                self.assertLessEqual(infnorm(ff(xx)-gg(xx)), tol)
+                self.assertLessEqual(infnorm(ff(xx) - gg(xx)), tol)
                 # check there are at least as many funs as subdom elements
-                self.assertGreaterEqual(len(gg.funs), len(subdom)-1)
+                self.assertGreaterEqual(len(gg.funs), len(subdom) - 1)
                 for fun in gg:
                     # chec each fun has length 25
                     self.assertEqual(fun.size, 25)
 
     def test_restrict__empty(self):
-        self.assertTrue(self.f0._restrict([-1,1]).isempty)
+        self.assertTrue(self.f0._restrict([-1, 1]).isempty)
 
     def test_simplify(self):
-        dom = np.linspace(-2,1.5,13)
+        dom = np.linspace(-2, 1.5, 13)
         f = chebfun(cos, dom, 70).simplify()
         g = chebfun(cos, dom)
         self.assertEquals(f.domain, g.domain)
         for n, fun in enumerate(f):
             # we allow one degree of freedom difference
             # TODO: check this
-            self.assertLessEqual(fun.size-g.funs[n].size, 1)
+            self.assertLessEqual(fun.size - g.funs[n].size, 1)
 
     def test_simplify_empty(self):
         self.assertTrue(self.f0.simplify().isempty)
 
     def test_restrict(self):
-        dom1 = Domain(np.linspace(-2,1.5,13))
-        dom2 = Domain(np.linspace(-1.7,0.93,17))
+        dom1 = Domain(np.linspace(-2, 1.5, 13))
+        dom2 = Domain(np.linspace(-1.7, 0.93, 17))
         dom3 = dom1.merge(dom2).restrict(dom2)
         f = chebfun(cos, dom1).restrict(dom2)
         g = chebfun(cos, dom3)
@@ -365,35 +373,35 @@ class ClassUsage(unittest.TestCase):
         for n, fun in enumerate(f):
             # we allow two degrees of freedom difference either way
             # TODO: once standard chop is fixed, may be able to reduce 4 to 0
-            self.assertLessEqual(fun.size-g.funs[n].size, 4)
+            self.assertLessEqual(fun.size - g.funs[n].size, 4)
 
     def test_restrict_empty(self):
-        self.assertTrue(self.f0.restrict([-1,1]).isempty)
+        self.assertTrue(self.f0.restrict([-1, 1]).isempty)
 
     def test_translate(self):
         c = -1.5
         g1 = self.f1.translate(c)
         g2 = self.f2.translate(c)
         # check domains match
-        self.assertEqual(self.f1.domain+c, g1.domain)
-        self.assertEqual(self.f2.domain+c, g2.domain)
+        self.assertEqual(self.f1.domain + c, g1.domain)
+        self.assertEqual(self.f2.domain + c, g2.domain)
         # check fun lengths match
         self.assertEqual(self.f1.funs.size, g1.funs.size)
         self.assertEqual(self.f2.funs.size, g2.funs.size)
         # check coefficients match on each fun
         for f1k, g1k in zip(self.f1, g1):
-            self.assertLessEqual(infnorm(f1k.coeffs-g1k.coeffs), tol)
+            self.assertLessEqual(infnorm(f1k.coeffs - g1k.coeffs), tol)
         for f2k, g2k in zip(self.f2, g2):
-            self.assertLessEqual(infnorm(f2k.coeffs-g2k.coeffs), tol)
+            self.assertLessEqual(infnorm(f2k.coeffs - g2k.coeffs), tol)
 
     def test_translate_empty(self):
         self.assertTrue(self.f0.translate(3))
 
-class Algebra(unittest.TestCase):
 
+class Algebra(unittest.TestCase):
     def setUp(self):
         self.emptyfun = Chebfun.initempty()
-        self.yy = np.linspace(-1,1,2000)
+        self.yy = np.linspace(-1, 1, 2000)
 
     # check  +(empty Chebfun) = (empty Chebfun)
     def test__pos__empty(self):
@@ -410,8 +418,8 @@ class Algebra(unittest.TestCase):
             for dom, _ in chebfun_testdomains:
                 a, b = dom
                 ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, 13))
-                self.assertTrue((self.emptyfun+ff).isempty)
-                self.assertTrue((ff+self.emptyfun).isempty)
+                self.assertTrue((self.emptyfun + ff).isempty)
+                self.assertTrue((ff + self.emptyfun).isempty)
 
     # check the output of (constant + Chebfun)
     #                 and (Chebfun + constant)
@@ -428,9 +436,9 @@ class Algebra(unittest.TestCase):
                     vscl = ff.vscale
                     hscl = ff.hscale
                     lscl = max([fun.size for fun in ff])
-                    tol = 2*abs(c)*vscl*hscl*lscl*eps
-                    self.assertLessEqual(infnorm(g(xx)-gg1(xx)), tol)
-                    self.assertLessEqual(infnorm(g(xx)-gg2(xx)), tol)
+                    tol = 2 * abs(c) * vscl * hscl * lscl * eps
+                    self.assertLessEqual(infnorm(g(xx) - gg1(xx)), tol)
+                    self.assertLessEqual(infnorm(g(xx) - gg2(xx)), tol)
 
     # check (empty Chebfun) - (Chebfun) = (empty Chebfun)
     #   and (Chebfun) - (empty Chebfun) = (empty Chebfun)
@@ -439,8 +447,8 @@ class Algebra(unittest.TestCase):
             for dom, _ in chebfun_testdomains:
                 a, b = dom
                 ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, 13))
-                self.assertTrue((self.emptyfun-ff).isempty)
-                self.assertTrue((ff-self.emptyfun).isempty)
+                self.assertTrue((self.emptyfun - ff).isempty)
+                self.assertTrue((ff - self.emptyfun).isempty)
 
     # check the output of (constant - Chebfun)
     #                 and (Chebfun - constant)
@@ -457,9 +465,9 @@ class Algebra(unittest.TestCase):
                     vscl = ff.vscale
                     hscl = ff.hscale
                     lscl = max([fun.size for fun in ff])
-                    tol = 2*abs(c)*vscl*hscl*lscl*eps
-                    self.assertLessEqual(infnorm(g(xx)-gg1(xx)), tol)
-                    self.assertLessEqual(infnorm(-g(xx)-gg2(xx)), tol)
+                    tol = 2 * abs(c) * vscl * hscl * lscl * eps
+                    self.assertLessEqual(infnorm(g(xx) - gg1(xx)), tol)
+                    self.assertLessEqual(infnorm(-g(xx) - gg2(xx)), tol)
 
     # check (empty Chebfun) * (Chebfun) = (empty Chebfun)
     #   and (Chebfun) * (empty Chebfun) = (empty Chebfun)
@@ -468,8 +476,8 @@ class Algebra(unittest.TestCase):
             for dom, _ in chebfun_testdomains:
                 a, b = dom
                 ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, 13))
-                self.assertTrue((self.emptyfun*ff).isempty)
-                self.assertTrue((ff*self.emptyfun).isempty)
+                self.assertTrue((self.emptyfun * ff).isempty)
+                self.assertTrue((ff * self.emptyfun).isempty)
 
     # check the output of (constant * Chebfun)
     #                 and (Chebfun * constant)
@@ -477,7 +485,7 @@ class Algebra(unittest.TestCase):
         for (f, _, _) in testfunctions:
             for c in (-1, 1, 10, -1e5):
                 for dom, _ in chebfun_testdomains:
-                    a,b = dom
+                    a, b = dom
                     xx = np.linspace(a, b, 1001)
                     ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, 11))
                     g = lambda x: c * f(x)
@@ -486,9 +494,9 @@ class Algebra(unittest.TestCase):
                     vscl = ff.vscale
                     hscl = ff.hscale
                     lscl = max([fun.size for fun in ff])
-                    tol = 2*abs(c)*vscl*hscl*lscl*eps
-                    self.assertLessEqual(infnorm(g(xx)-gg1(xx)), tol)
-                    self.assertLessEqual(infnorm(g(xx)-gg2(xx)), tol)
+                    tol = 2 * abs(c) * vscl * hscl * lscl * eps
+                    self.assertLessEqual(infnorm(g(xx) - gg1(xx)), tol)
+                    self.assertLessEqual(infnorm(g(xx) - gg2(xx)), tol)
 
     # check (empty Chebfun) / (Chebfun) = (empty Chebfun)
     #   and (Chebfun) / (empty Chebfun) = (empty Chebfun)
@@ -497,8 +505,8 @@ class Algebra(unittest.TestCase):
             for dom, _ in chebfun_testdomains:
                 a, b = dom
                 ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, 13))
-                self.assertTrue((self.emptyfun/ff).isempty)
-                self.assertTrue((ff/self.emptyfun).isempty)
+                self.assertTrue((self.emptyfun / ff).isempty)
+                self.assertTrue((ff / self.emptyfun).isempty)
 
     # check the output of (constant / Chebfun)
     #                 and (Chebfun / constant)
@@ -506,7 +514,7 @@ class Algebra(unittest.TestCase):
         for (f, _, hasRoots) in testfunctions:
             for c in (-1, 1, 10, -1e5):
                 for dom, _ in chebfun_testdomains:
-                    a,b = dom
+                    a, b = dom
                     xx = np.linspace(a, b, 1001)
                     ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, 11))
                     g = lambda x: f(x) / c
@@ -514,8 +522,8 @@ class Algebra(unittest.TestCase):
                     vscl = gg.vscale
                     hscl = gg.hscale
                     lscl = max([fun.size for fun in gg])
-                    tol = 2*abs(c)*vscl*hscl*lscl*eps
-                    self.assertLessEqual(infnorm(g(xx)-gg(xx)), tol)
+                    tol = 2 * abs(c) * vscl * hscl * lscl * eps
+                    self.assertLessEqual(infnorm(g(xx) - gg(xx)), tol)
                     # don't do the following test for functions with roots
                     if not hasRoots:
                         h = lambda x: c / f(x)
@@ -523,8 +531,8 @@ class Algebra(unittest.TestCase):
                         vscl = hh.vscale
                         hscl = hh.hscale
                         lscl = max([fun.size for fun in hh])
-                        tol = 2*abs(c)*vscl*hscl*lscl*eps
-                        self.assertLessEqual(infnorm(h(xx)-hh(xx)), tol)
+                        tol = 2 * abs(c) * vscl * hscl * lscl * eps
+                        self.assertLessEqual(infnorm(h(xx) - hh(xx)), tol)
 
     # check (empty Chebfun) ** (Chebfun) = (empty Chebfun)
     def test_pow_empty(self):
@@ -532,22 +540,22 @@ class Algebra(unittest.TestCase):
             for dom, _ in chebfun_testdomains:
                 a, b = dom
                 ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, 13))
-                self.assertTrue((self.emptyfun**ff).isempty)
+                self.assertTrue((self.emptyfun ** ff).isempty)
 
-   # chec (Chebfun) ** (empty Chebfun) = (empty Chebfun)
+    # chec (Chebfun) ** (empty Chebfun) = (empty Chebfun)
     def test_rpow_empty(self):
         for (f, _, _) in testfunctions:
             for dom, _ in chebfun_testdomains:
                 a, b = dom
                 ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, 13))
-                self.assertTrue((ff**self.emptyfun).isempty)
+                self.assertTrue((ff ** self.emptyfun).isempty)
 
     # check the output of (Chebfun) ** (constant)
     def test_pow_constant(self):
-        for ((_,_), (f, _)) in powtestfuns:
+        for ((_, _), (f, _)) in powtestfuns:
             for c in (1, 2, 3):
                 for dom, _ in powtestdomains:
-                    a,b = dom
+                    a, b = dom
                     xx = np.linspace(a, b, 1001)
                     ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, 11))
                     g = lambda x: f(x) ** c
@@ -555,15 +563,15 @@ class Algebra(unittest.TestCase):
                     vscl = gg.vscale
                     hscl = gg.hscale
                     lscl = max([fun.size for fun in gg])
-                    tol = 2*abs(c)*vscl*hscl*lscl*eps
-                    self.assertLessEqual(infnorm(g(xx)-gg(xx)), tol)
+                    tol = 2 * abs(c) * vscl * hscl * lscl * eps
+                    self.assertLessEqual(infnorm(g(xx) - gg(xx)), tol)
 
     # check the output of (constant) ** (Chebfun)
     def test_rpow_constant(self):
-        for ((_,_), (f, _)) in powtestfuns:
+        for ((_, _), (f, _)) in powtestfuns:
             for c in (1, 2, 3):
                 for dom, _ in powtestdomains:
-                    a,b = dom
+                    a, b = dom
                     xx = np.linspace(a, b, 1001)
                     ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, 11))
                     g = lambda x: c ** f(x)
@@ -571,59 +579,60 @@ class Algebra(unittest.TestCase):
                     vscl = gg.vscale
                     hscl = gg.hscale
                     lscl = max([fun.size for fun in gg])
-                    tol = 2*abs(c)*vscl*hscl*lscl*eps
-                    self.assertLessEqual(infnorm(g(xx)-gg(xx)), tol)
+                    tol = 2 * abs(c) * vscl * hscl * lscl * eps
+                    self.assertLessEqual(infnorm(g(xx) - gg(xx)), tol)
 
 
 # add tests for the binary operators
 def binaryOpTester(f, g, binop, dom, tol):
     a, b = dom
-    xx = np.linspace(a,b,1001)
+    xx = np.linspace(a, b, 1001)
     n, m = 3, 8
-    ff = Chebfun.initfun_adaptive(f, np.linspace(a,b,n+1))
-    gg = Chebfun.initfun_adaptive(g, np.linspace(a,b,m+1))
+    ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, n + 1))
+    gg = Chebfun.initfun_adaptive(g, np.linspace(a, b, m + 1))
     FG = lambda x: binop(f(x), g(x))
     fg = binop(ff, gg)
+
     def tester(self):
         vscl = max([ff.vscale, gg.vscale])
         hscl = max([ff.hscale, gg.hscale])
         lscl = max([fun.size for fun in np.append(ff.funs, gg.funs)])
         self.assertEqual(ff.funs.size, n)
         self.assertEqual(gg.funs.size, m)
-        self.assertEqual(fg.funs.size, n+m-1)
-        self.assertLessEqual(infnorm(fg(xx)-FG(xx)), vscl*hscl*lscl*tol)
+        self.assertEqual(fg.funs.size, n + m - 1)
+        self.assertLessEqual(infnorm(fg(xx) - FG(xx)), vscl * hscl * lscl * tol)
+
     return tester
 
 
 for binop in binops:
-    for (f, _, _), (g, _, denomHasRoots) in \
-            itertools.combinations(testfunctions, 2):
+    for (f, _, _), (g, _, denomHasRoots) in itertools.combinations(testfunctions, 2):
         for dom, tol in chebfun_testdomains:
             if binop in div_binops and denomHasRoots:
                 # skip truediv test if denominator has roots on the real line
                 pass
             else:
-                _testfun_ = binaryOpTester(f, g, binop, dom, 2*tol)
+                _testfun_ = binaryOpTester(f, g, binop, dom, 2 * tol)
                 a, b = dom
                 binopname = binop.__name__
                 # case of truediv: add leading and trailing underscores
-                if binopname[0] != '_':
-                    binopname = '_' + binopname
-                if binopname[-1] != '_':
-                    binopname = binopname + '_'
-                _testfun_.__name__ = \
-                    "test_{}_{}_{}_[{:.0f},..,{:.0f}]".format(
-                        binopname, f.__name__,  g.__name__, a, b)
+                if binopname[0] != "_":
+                    binopname = "_" + binopname
+                if binopname[-1] != "_":
+                    binopname = binopname + "_"
+                _testfun_.__name__ = "test_{}_{}_{}_[{:.0f},..,{:.0f}]".format(
+                    binopname, f.__name__, g.__name__, a, b
+                )
                 setattr(Algebra, _testfun_.__name__, _testfun_)
 
 powtestfuns = (
-    [(np.exp, 'exp'), (np.sin, 'sin')],
-    [(np.exp, 'exp'), (lambda x: 2-x, 'linear')],
-    [(lambda x: 2-x, 'linear'), (np.exp, 'exp')],
+    [(np.exp, "exp"), (np.sin, "sin")],
+    [(np.exp, "exp"), (lambda x: 2 - x, "linear")],
+    [(lambda x: 2 - x, "linear"), (np.exp, "exp")],
 )
 
 powtestdomains = [
-    ([-.5,.9], eps),
+    ([-0.5, 0.9], eps),
     ([-1.2, 1.3], eps),
     ([-2.2, -1.9], eps),
     ([0.4, 1.3], eps),
@@ -632,59 +641,82 @@ powtestdomains = [
 # add operator.pow tests
 for (f, namef), (g, nameg) in powtestfuns:
     for dom, tol in powtestdomains:
-        _testfun_ = binaryOpTester(f, g, operator.pow, dom, 3*tol)
-        _testfun_.__name__ = \
-            "test_{}_{}_{}_[{:.1f},..,{:.1f}]".format(
-                'pow', namef, nameg, *dom)
+        _testfun_ = binaryOpTester(f, g, operator.pow, dom, 3 * tol)
+        _testfun_.__name__ = "test_{}_{}_{}_[{:.1f},..,{:.1f}]".format(
+            "pow", namef, nameg, *dom
+        )
         setattr(Algebra, _testfun_.__name__, _testfun_)
 
 
 # add tests for the unary operators
 def unaryOpTester(f, unaryop, dom, tol):
     a, b = dom
-    xx = np.linspace(a,b,1001)
-    ff = Chebfun.initfun_adaptive(f, np.linspace(a,b,9))
+    xx = np.linspace(a, b, 1001)
+    ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, 9))
     GG = lambda x: unaryop(f(x))
     gg = unaryop(ff)
+
     def tester(self):
         vscl = ff.vscale
         hscl = ff.hscale
         lscl = max([fun.size for fun in ff])
         self.assertEqual(ff.funs.size, gg.funs.size)
-        self.assertLessEqual(infnorm(gg(xx)-GG(xx)), vscl*hscl*lscl*tol)
+        self.assertLessEqual(infnorm(gg(xx) - GG(xx)), vscl * hscl * lscl * tol)
+
     return tester
+
 
 unaryops = (operator.pos, operator.neg)
 for unaryop in unaryops:
     for (f, _, _) in testfunctions:
         for dom, tol in chebfun_testdomains:
             _testfun_ = unaryOpTester(f, unaryop, dom, tol)
-            _testfun_.__name__ = \
-                "test_{}_{}_[{:.0f},..,{:.0f}]".format(
-                    unaryop.__name__, f.__name__, dom[0], dom[1])
+            _testfun_.__name__ = "test_{}_{}_[{:.0f},..,{:.0f}]".format(
+                unaryop.__name__, f.__name__, dom[0], dom[1]
+            )
             setattr(Algebra, _testfun_.__name__, _testfun_)
 
 
-
 class Ufuncs(unittest.TestCase):
-
     def setUp(self):
         self.emptyfun = Chebfun.initempty()
-        self.yy = np.linspace(-1,1,2000)
+        self.yy = np.linspace(-1, 1, 2000)
 
     def test_abs_absolute_alias(self):
         self.assertEqual(Chebfun.abs, Chebfun.absolute)
 
-ufuncs = (np.absolute, np.arccos, np.arccosh, np.arcsin, np.arcsinh, np.arctan,
-          np.arctanh, np.cos, np.cosh, np.exp, np.exp2, np.expm1, np.log,
-          np.log2, np.log10, np.log1p, np.sinh, np.sin, np.tan, np.tanh,
-          np.sqrt)
+
+ufuncs = (
+    np.absolute,
+    np.arccos,
+    np.arccosh,
+    np.arcsin,
+    np.arcsinh,
+    np.arctan,
+    np.arctanh,
+    np.cos,
+    np.cosh,
+    np.exp,
+    np.exp2,
+    np.expm1,
+    np.log,
+    np.log2,
+    np.log10,
+    np.log1p,
+    np.sinh,
+    np.sin,
+    np.tan,
+    np.tanh,
+    np.sqrt,
+)
 
 # empty-case tests
 def ufuncEmptyCaseTester(ufunc):
     def tester(self):
         self.assertTrue(getattr(self.emptyfun, ufunc.__name__)().isempty)
+
     return tester
+
 
 for ufunc in ufuncs:
     _testfun_ = ufuncEmptyCaseTester(ufunc)
@@ -697,86 +729,286 @@ for ufunc in ufuncs:
 
 uf1 = lambda x: x
 uf1.__name__ = "x"
-uf2 = lambda x: sin(x-.5)
+uf2 = lambda x: sin(x - 0.5)
 uf2.__name__ = "sin(x-.5)"
-uf3 = lambda x: sin(25*x-1)
+uf3 = lambda x: sin(25 * x - 1)
 uf3.__name__ = "sin(25*x-1)"
 
 ufunc_test_params = [
-    (np.absolute, [([uf1, (-3,3)  ], eps), ]),
-    (np.arccos,   [([uf1, (-.8,.8)], eps), ]),
-    (np.arccosh,  [([uf1, (2,3)   ], eps), ]),
-    (np.arcsin,   [([uf1, (-.8,.8)], eps), ]),
-    (np.arcsinh,  [([uf1, (2,3)   ], eps), ]),
-    (np.arctan,   [([uf1, (-.8,.8)], eps), ]),
-    (np.arctanh,  [([uf1, (-.8,.8)], eps), ]),
-    (np.cos,      [([uf1, (-3,3)  ], eps), ]),
-    (np.cosh,     [([uf1, (-3,3)  ], eps), ]),
-    (exp,         [([uf1, (-3,3)  ], eps), ]),
-    (np.exp2,     [([uf1, (-3,3)  ], eps), ]),
-    (np.expm1,    [([uf1, (-3,3)  ], eps), ]),
-    (np.log,      [([uf1, (2,3)   ], eps), ]),
-    (np.log2,     [([uf1, (2,3)   ], eps), ]),
-    (np.log10,    [([uf1, (2,3)   ], eps), ]),
-    (np.log1p,    [([uf1, (-.8,.8)], eps), ]),
-    (np.sinh,     [([uf1, (-3,3)  ], eps), ]),
-    (np.sin,      [([uf1, (-3,3)  ], eps), ]),
-    (np.tan,      [([uf1, (-.8,.8)], eps), ]),
-    (np.tanh,     [([uf1, (-3,3)  ], eps), ]),
-    (np.sqrt,     [([uf1, (2,3)   ], eps), ]),
-
-    (np.absolute, [([uf2, (-3,3)  ], eps), ]),
-    (np.cos,      [([uf2, (-3,3)  ], eps), ]),
-    (np.cosh,     [([uf2, (-3,3)  ], eps), ]),
-    (np.exp,      [([uf2, (-3,3)  ], eps), ]),
-    (np.expm1,    [([uf2, (-3,3)  ], eps), ]),
-    (np.sinh,     [([uf2, (-3,3)  ], eps), ]),
-    (np.sin,      [([uf2, (-3,3)  ], eps), ]),
-    (np.tan,      [([uf2, (-.8,.8)], eps), ]),
-    (np.tanh,     [([uf2, (-3,3)  ], eps), ]),
-
-    (np.absolute, [([uf3, (-3,3)  ], eps), ]),
-    (np.cos,      [([uf3, (-3,3)  ], eps), ]),
-    (np.cosh,     [([uf3, (-3,3)  ], eps), ]),
-    (np.exp,      [([uf3, (-3,3)  ], eps), ]),
-    (np.expm1,    [([uf3, (-3,3)  ], eps), ]),
-    (np.sinh,     [([uf3, (-3,3)  ], eps), ]),
-    (np.sin,      [([uf3, (-3,3)  ], eps), ]),
-    (np.tan,      [([uf3, (-.8,.8)], eps), ]),
-    (np.tanh,     [([uf3, (-3,3)  ], eps), ]),
+    (
+        np.absolute,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.arccos,
+        [
+            ([uf1, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.arccosh,
+        [
+            ([uf1, (2, 3)], eps),
+        ],
+    ),
+    (
+        np.arcsin,
+        [
+            ([uf1, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.arcsinh,
+        [
+            ([uf1, (2, 3)], eps),
+        ],
+    ),
+    (
+        np.arctan,
+        [
+            ([uf1, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.arctanh,
+        [
+            ([uf1, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.cos,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.cosh,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        exp,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.exp2,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.expm1,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.log,
+        [
+            ([uf1, (2, 3)], eps),
+        ],
+    ),
+    (
+        np.log2,
+        [
+            ([uf1, (2, 3)], eps),
+        ],
+    ),
+    (
+        np.log10,
+        [
+            ([uf1, (2, 3)], eps),
+        ],
+    ),
+    (
+        np.log1p,
+        [
+            ([uf1, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.sinh,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.sin,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.tan,
+        [
+            ([uf1, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.tanh,
+        [
+            ([uf1, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.sqrt,
+        [
+            ([uf1, (2, 3)], eps),
+        ],
+    ),
+    (
+        np.absolute,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.cos,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.cosh,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.exp,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.expm1,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.sinh,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.sin,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.tan,
+        [
+            ([uf2, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.tanh,
+        [
+            ([uf2, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.absolute,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.cos,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.cosh,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.exp,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.expm1,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.sinh,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.sin,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
+    (
+        np.tan,
+        [
+            ([uf3, (-0.8, 0.8)], eps),
+        ],
+    ),
+    (
+        np.tanh,
+        [
+            ([uf3, (-3, 3)], eps),
+        ],
+    ),
 ]
 
 
 def ufuncTester(ufunc, f, interval, tol):
-    a,b = interval
-    ff = Chebfun.initfun_adaptive(f, np.linspace(a,b,13))
+    a, b = interval
+    ff = Chebfun.initfun_adaptive(f, np.linspace(a, b, 13))
     gg = lambda x: ufunc(f(x))
     GG = getattr(ff, ufunc.__name__)()
+
     def tester(self):
         xx = interval(self.yy)
         vscl = GG.vscale
         lscl = sum([fun.size for fun in GG])
-        self.assertLessEqual(infnorm(gg(xx)-GG(xx)), vscl*lscl*tol)
+        self.assertLessEqual(infnorm(gg(xx) - GG(xx)), vscl * lscl * tol)
+
     return tester
 
-for (ufunc,  [([f, intvl], tol), ]) in ufunc_test_params:
+
+for (
+    ufunc,
+    [
+        ([f, intvl], tol),
+    ],
+) in ufunc_test_params:
     interval = Interval(*intvl)
     _testfun_ = ufuncTester(ufunc, f, interval, tol)
-    _testfun_.__name__ = \
-        "test_{}({})_[{:.1f},..,{:.1f}]".format(
-        ufunc.__name__, f.__name__, *intvl)
+    _testfun_.__name__ = "test_{}({})_[{:.1f},..,{:.1f}]".format(
+        ufunc.__name__, f.__name__, *intvl
+    )
     setattr(Ufuncs, _testfun_.__name__, _testfun_)
 
 
 class Evaluation(unittest.TestCase):
-
     def setUp(self):
         self.f0 = Chebfun.initempty()
-        self.f1 = Chebfun.initfun_adaptive(lambda x: x**2, [-1,1])
-        self.f2 = Chebfun.initfun_adaptive(lambda x: x**2, [-1,0,1,2])
+        self.f1 = Chebfun.initfun_adaptive(lambda x: x ** 2, [-1, 1])
+        self.f2 = Chebfun.initfun_adaptive(lambda x: x ** 2, [-1, 0, 1, 2])
 
     def test__call__empty_chebfun(self):
-        self.assertEqual(self.f0(np.linspace(-1,1,100)).size, 0)
+        self.assertEqual(self.f0(np.linspace(-1, 1, 100)).size, 0)
 
     def test__call__empty_array(self):
         self.assertEqual(self.f0(np.array([])).size, 0)
@@ -796,72 +1028,71 @@ class Evaluation(unittest.TestCase):
         self.assertEqual(a.size, 1)
         self.assertEqual(b.size, 1)
         self.assertEqual(c.size, 1)
-        self.assertTrue(np.equal(a,b).all())
-        self.assertTrue(np.equal(b,c).all())
-        self.assertTrue(np.equal(a,c).all())
+        self.assertTrue(np.equal(a, b).all())
+        self.assertTrue(np.equal(b, c).all())
+        self.assertTrue(np.equal(a, c).all())
 
     def test__call__breakpoints(self):
         # check we get the values at the breakpoints back
         x1 = self.f1.breakpoints
         x2 = self.f2.breakpoints
-        self.assertTrue(np.equal(self.f1(x1), [1,1]).all())
-        self.assertTrue(np.equal(self.f2(x2), [1,0,1,4]).all())
+        self.assertTrue(np.equal(self.f1(x1), [1, 1]).all())
+        self.assertTrue(np.equal(self.f2(x2), [1, 0, 1, 4]).all())
 
     def test__call__outside_interval(self):
         # check we are able to evaluate the Chebfun outside the
         # interval of definition
-        x = np.linspace(-3,3,100)
+        x = np.linspace(-3, 3, 100)
         self.assertTrue(np.isfinite(self.f1(x)).all())
         self.assertTrue(np.isfinite(self.f2(x)).all())
 
     def test__call__general_evaluation(self):
-        f = lambda x: sin(4*x) + exp(cos(14*x)) - 1.4
+        f = lambda x: sin(4 * x) + exp(cos(14 * x)) - 1.4
         npts = 50000
-        dom1 = [-1,1]
-        dom2 = [-1,0,1]
-        dom3 = [-2,-0.3,1.2]
+        dom1 = [-1, 1]
+        dom2 = [-1, 0, 1]
+        dom3 = [-2, -0.3, 1.2]
         ff1 = Chebfun.initfun_adaptive(f, dom1)
         ff2 = Chebfun.initfun_adaptive(f, dom2)
         ff3 = Chebfun.initfun_adaptive(f, dom3)
         x1 = np.linspace(dom1[0], dom1[-1], npts)
         x2 = np.linspace(dom2[0], dom2[-1], npts)
         x3 = np.linspace(dom3[0], dom3[-1], npts)
-        self.assertLessEqual(infnorm(f(x1)-ff1(x1)), 5e1*eps)
-        self.assertLessEqual(infnorm(f(x2)-ff2(x2)), 2e1*eps)
-        self.assertLessEqual(infnorm(f(x3)-ff3(x3)), 5e1*eps)
+        self.assertLessEqual(infnorm(f(x1) - ff1(x1)), 5e1 * eps)
+        self.assertLessEqual(infnorm(f(x2) - ff2(x2)), 2e1 * eps)
+        self.assertLessEqual(infnorm(f(x3) - ff3(x3)), 5e1 * eps)
 
 
 class Complex(unittest.TestCase):
-
     def setUp(self):
-        self.z = Chebfun.initfun_adaptive(lambda x: np.exp(np.pi*1j*x), [-1, 1])
+        self.z = Chebfun.initfun_adaptive(lambda x: np.exp(np.pi * 1j * x), [-1, 1])
 
     def test_init_empty(self):
         Chebfun.initempty()
 
     def test_roots(self):
         r0 = self.z.roots()
-        r1 = (self.z-1).roots()
-        r2 = (self.z-1j).roots()
-        r3 = (self.z+1).roots()
-        r4 = (self.z+1j).roots()
+        r1 = (self.z - 1).roots()
+        r2 = (self.z - 1j).roots()
+        r3 = (self.z + 1).roots()
+        r4 = (self.z + 1j).roots()
         self.assertEqual(r0.size, 0)
         self.assertTrue(np.allclose(r1, [0]))
-        self.assertTrue(np.allclose(r2, [.5]))
+        self.assertTrue(np.allclose(r2, [0.5]))
         self.assertTrue(np.allclose(r3, [-1, 1]))
-        self.assertTrue(np.allclose(r4, [-.5]))
+        self.assertTrue(np.allclose(r4, [-0.5]))
 
     def test_rho_ellipse_construction(self):
         zz = 1.2 * self.z
-        e = .5 * (zz + 1/zz)
-        self.assertAlmostEqual(e(1)-e(-1), 0, places=14)
-        self.assertAlmostEqual(e(0)+e(-1), 0, places=14)
-        self.assertAlmostEqual(e(0)+e(1), 0, places=14)
+        e = 0.5 * (zz + 1 / zz)
+        self.assertAlmostEqual(e(1) - e(-1), 0, places=14)
+        self.assertAlmostEqual(e(0) + e(-1), 0, places=14)
+        self.assertAlmostEqual(e(0) + e(1), 0, places=14)
 
     def test_calculus(self):
         self.assertTrue(np.allclose([self.z.sum()], [0]))
-        self.assertTrue((self.z.cumsum().diff()-self.z).isconst)
-        self.assertTrue((self.z-self.z.cumsum().diff()).isconst)
+        self.assertTrue((self.z.cumsum().diff() - self.z).isconst)
+        self.assertTrue((self.z - self.z.cumsum().diff()).isconst)
 
     def test_real_imag(self):
         # check definition of real and imaginary
@@ -870,52 +1101,51 @@ class Complex(unittest.TestCase):
         np.testing.assert_equal(zreal.funs[0].coeffs, np.real(self.z.funs[0].coeffs))
         np.testing.assert_equal(zimag.funs[0].coeffs, np.imag(self.z.funs[0].coeffs))
         # check real part of real chebtech is the same chebtech
-        self.assertTrue(zreal.real()==zreal)
+        self.assertTrue(zreal.real() == zreal)
         # check imaginary part of real chebtech is the zero chebtech
         self.assertTrue(zreal.imag().isconst)
-        self.assertTrue(zreal.imag().funs[0].coeffs[0]==0)
+        self.assertTrue(zreal.imag().funs[0].coeffs[0] == 0)
 
 
 class Calculus(unittest.TestCase):
-
     def setUp(self):
-        f = lambda x: sin(4*x-1.4)
+        f = lambda x: sin(4 * x - 1.4)
         g = lambda x: exp(x)
-        self.df = lambda x: 4*cos(4*x-1.4)
-        self.If = lambda x: -.25*cos(4*x-1.4)
-        self.f1 = Chebfun.initfun_adaptive(f, [-1,1])
-        self.f2 = Chebfun.initfun_adaptive(f, [-3,0,1])
-        self.f3 = Chebfun.initfun_adaptive(f, [-2,-0.3,1.2])
-        self.f4 = Chebfun.initfun_adaptive(f, np.linspace(-1,1,11))
-        self.g1 = Chebfun.initfun_adaptive(g, [-1,1])
-        self.g2 = Chebfun.initfun_adaptive(g, [-3,0,1])
-        self.g3 = Chebfun.initfun_adaptive(g, [-2,-0.3,1.2])
-        self.g4 = Chebfun.initfun_adaptive(g, np.linspace(-1,1,11))
+        self.df = lambda x: 4 * cos(4 * x - 1.4)
+        self.If = lambda x: -0.25 * cos(4 * x - 1.4)
+        self.f1 = Chebfun.initfun_adaptive(f, [-1, 1])
+        self.f2 = Chebfun.initfun_adaptive(f, [-3, 0, 1])
+        self.f3 = Chebfun.initfun_adaptive(f, [-2, -0.3, 1.2])
+        self.f4 = Chebfun.initfun_adaptive(f, np.linspace(-1, 1, 11))
+        self.g1 = Chebfun.initfun_adaptive(g, [-1, 1])
+        self.g2 = Chebfun.initfun_adaptive(g, [-3, 0, 1])
+        self.g3 = Chebfun.initfun_adaptive(g, [-2, -0.3, 1.2])
+        self.g4 = Chebfun.initfun_adaptive(g, np.linspace(-1, 1, 11))
 
     def test_sum(self):
-        self.assertLessEqual(abs(self.f1.sum()-0.372895407327895),2*eps)
-        self.assertLessEqual(abs(self.f2.sum()-0.382270459230604),2*eps)
-        self.assertLessEqual(abs(self.f3.sum()-(-0.008223712363936)),2*eps)
-        self.assertLessEqual(abs(self.f4.sum()-0.372895407327895),2*eps)
+        self.assertLessEqual(abs(self.f1.sum() - 0.372895407327895), 2 * eps)
+        self.assertLessEqual(abs(self.f2.sum() - 0.382270459230604), 2 * eps)
+        self.assertLessEqual(abs(self.f3.sum() - (-0.008223712363936)), 2 * eps)
+        self.assertLessEqual(abs(self.f4.sum() - 0.372895407327895), 2 * eps)
 
     def test_diff(self):
-        xx = np.linspace(-5,5,10000)
+        xx = np.linspace(-5, 5, 10000)
         for f in [self.f1, self.f2, self.f3, self.f4]:
             a, b = f.support
-            x = xx[(xx>a)&(xx<b)]
-            self.assertLessEqual(infnorm(f.diff()(x)-self.df(x)), 2e3*eps)
+            x = xx[(xx > a) & (xx < b)]
+            self.assertLessEqual(infnorm(f.diff()(x) - self.df(x)), 2e3 * eps)
 
     def test_cumsum(self):
-        xx = np.linspace(-5,5,10000)
+        xx = np.linspace(-5, 5, 10000)
         for f in [self.f1, self.f2, self.f3, self.f4]:
             a, b = f.support
-            x = xx[(xx>a)&(xx<b)]
+            x = xx[(xx > a) & (xx < b)]
             fa = self.If(a)
-            self.assertLessEqual(infnorm(f.cumsum()(x)-self.If(x)+fa), 3*eps)
+            self.assertLessEqual(infnorm(f.cumsum()(x) - self.If(x) + fa), 3 * eps)
 
     def test_sum_empty(self):
         f = Chebfun.initempty()
-        self.assertEqual(f.sum(), .0)
+        self.assertEqual(f.sum(), 0.0)
 
     def test_cumsum_empty(self):
         If = Chebfun.initempty().cumsum()
@@ -928,34 +1158,37 @@ class Calculus(unittest.TestCase):
         self.assertTrue(df.isempty)
 
     def test_dot(self):
-        self.assertLessEqual(self.f1.dot(self.g1)-0.66870683499839867, 3*eps)
-        self.assertLessEqual(self.f2.dot(self.g2)-0.64053327987194342, 3*eps)
-        self.assertLessEqual(self.f3.dot(self.g3)-0.67372257930409951, 3*eps)
-        self.assertLessEqual(self.f4.dot(self.g4)-0.66870683499839922, 3*eps)
+        self.assertLessEqual(self.f1.dot(self.g1) - 0.66870683499839867, 3 * eps)
+        self.assertLessEqual(self.f2.dot(self.g2) - 0.64053327987194342, 3 * eps)
+        self.assertLessEqual(self.f3.dot(self.g3) - 0.67372257930409951, 3 * eps)
+        self.assertLessEqual(self.f4.dot(self.g4) - 0.66870683499839922, 3 * eps)
         # different partitions of same interval
-        self.assertLessEqual(self.f1.dot(self.g4)-0.66870683499839867, 3*eps)
-        self.assertLessEqual(self.g1.dot(self.f4)-0.66870683499839867, 3*eps)
+        self.assertLessEqual(self.f1.dot(self.g4) - 0.66870683499839867, 3 * eps)
+        self.assertLessEqual(self.g1.dot(self.f4) - 0.66870683499839867, 3 * eps)
 
     def test_dot_commute(self):
-        self.assertLessEqual(self.g1.dot(self.f1)-0.66870683499839867, 3*eps)
-        self.assertLessEqual(self.g2.dot(self.f2)-0.64053327987194342, 3*eps)
-        self.assertLessEqual(self.g3.dot(self.f3)-0.67372257930409951, 3*eps)
-        self.assertLessEqual(self.g4.dot(self.f4)-0.66870683499839922, 3*eps)
+        self.assertLessEqual(self.g1.dot(self.f1) - 0.66870683499839867, 3 * eps)
+        self.assertLessEqual(self.g2.dot(self.f2) - 0.64053327987194342, 3 * eps)
+        self.assertLessEqual(self.g3.dot(self.f3) - 0.67372257930409951, 3 * eps)
+        self.assertLessEqual(self.g4.dot(self.f4) - 0.66870683499839922, 3 * eps)
 
     def test_dot_empty(self):
         emptyfun = Chebfun.initempty()
         self.assertEqual(self.f1.dot(emptyfun), 0)
         self.assertEqual(emptyfun.dot(self.f1), 0)
 
-class Roots(unittest.TestCase):
 
+class Roots(unittest.TestCase):
     def setUp(self):
-        self.f1 = Chebfun.initfun_adaptive(lambda x: cos(4*pi*x),
-                                           np.linspace(-10,10,101))
-        self.f2 = Chebfun.initfun_adaptive(lambda x: sin(2*pi*x),
-                                           np.linspace(-1,1,5))
-        self.f3 = Chebfun.initfun_adaptive(lambda x: sin(4*pi*x),
-                                           np.linspace(-10,10,101))
+        self.f1 = Chebfun.initfun_adaptive(
+            lambda x: cos(4 * pi * x), np.linspace(-10, 10, 101)
+        )
+        self.f2 = Chebfun.initfun_adaptive(
+            lambda x: sin(2 * pi * x), np.linspace(-1, 1, 5)
+        )
+        self.f3 = Chebfun.initfun_adaptive(
+            lambda x: sin(4 * pi * x), np.linspace(-10, 10, 101)
+        )
 
     def test_empty(self):
         rts = Chebfun.initempty().roots()
@@ -965,38 +1198,39 @@ class Roots(unittest.TestCase):
     def test_multiple_pieces(self):
         rts = self.f1.roots()
         self.assertEqual(rts.size, 80)
-        self.assertLessEqual(infnorm(rts-np.arange(-9.875,10,.25)), 10*eps)
+        self.assertLessEqual(infnorm(rts - np.arange(-9.875, 10, 0.25)), 10 * eps)
 
     # check we don't get repeated roots at breakpoints
     def test_breakpoint_roots_1(self):
         rts = self.f2.roots()
         self.assertEqual(rts.size, 5)
-        self.assertLessEqual(infnorm(rts-self.f2.breakpoints), eps)
+        self.assertLessEqual(infnorm(rts - self.f2.breakpoints), eps)
 
     # check we don't get repeated roots at breakpoints
     def test_breakpoint_roots_2(self):
         rts = self.f3.roots()
         self.assertEqual(rts.size, 81)
-        self.assertLessEqual(infnorm(rts-np.arange(-10,10.25,.25)), 1e1*eps)
+        self.assertLessEqual(infnorm(rts - np.arange(-10, 10.25, 0.25)), 1e1 * eps)
 
     def test_roots_cache(self):
         # check that a _cache property is created containing the stored roots
-        ff = chebfun(sin, np.linspace(-10,10,13))
-        self.assertFalse(hasattr(ff, '_cache'))
+        ff = chebfun(sin, np.linspace(-10, 10, 13))
+        self.assertFalse(hasattr(ff, "_cache"))
         ff.roots()
-        self.assertTrue(hasattr(ff, '_cache'))
+        self.assertTrue(hasattr(ff, "_cache"))
         self.assertTrue(ff.roots.__name__ in ff._cache.keys())
+
 
 plt = import_plt()
 
-class Plotting(unittest.TestCase):
 
+class Plotting(unittest.TestCase):
     def setUp(self):
-        f = lambda x: sin(4*x) + exp(cos(14*x)) - 1.4
-        u = lambda x: np.exp(2*np.pi*1j*x)
-        self.f1 = Chebfun.initfun_adaptive(f, [-1,1])
-        self.f2 = Chebfun.initfun_adaptive(f, [-3,0,1])
-        self.f3 = Chebfun.initfun_adaptive(f, [-2,-0.3,1.2])
+        f = lambda x: sin(4 * x) + exp(cos(14 * x)) - 1.4
+        u = lambda x: np.exp(2 * np.pi * 1j * x)
+        self.f1 = Chebfun.initfun_adaptive(f, [-1, 1])
+        self.f2 = Chebfun.initfun_adaptive(f, [-3, 0, 1])
+        self.f3 = Chebfun.initfun_adaptive(f, [-2, -0.3, 1.2])
         self.f4 = Chebfun.initfun_adaptive(u, [-1, 1])
 
     @unittest.skipIf(plt is None, "matplotlib not installed")
@@ -1009,9 +1243,9 @@ class Plotting(unittest.TestCase):
     def test_plot_complex(self):
         fig, ax = plt.subplots()
         # plot Bernstein ellipses
-        joukowsky = lambda z: .5*(z+1/z)
+        joukowsky = lambda z: 0.5 * (z + 1 / z)
         for rho in np.arange(1.1, 2, 0.1):
-            (np.exp(1j*.5*np.pi)*joukowsky(rho*self.f4)).plot(ax=ax)
+            (np.exp(1j * 0.5 * np.pi) * joukowsky(rho * self.f4)).plot(ax=ax)
 
     @unittest.skipIf(plt is None, "matplotlib not installed")
     def test_plotcoeffs(self):
@@ -1021,75 +1255,75 @@ class Plotting(unittest.TestCase):
 
 
 class PrivateMethods(unittest.TestCase):
-
     def setUp(self):
-        f = lambda x: sin(x-.1)
-        self.f1 = Chebfun.initfun_adaptive(f, [-2,0,3])
-        self.f2 = Chebfun.initfun_adaptive(f, np.linspace(-2,3,5))
+        f = lambda x: sin(x - 0.1)
+        self.f1 = Chebfun.initfun_adaptive(f, [-2, 0, 3])
+        self.f2 = Chebfun.initfun_adaptive(f, np.linspace(-2, 3, 5))
 
     # in the test_break_x methods, we check that (1) the newly computed domain
     # is what it should be, and (2) the new chebfun still provides an accurate
     # approximation
     def test__break_1(self):
-        altdom = Domain([-2,-1,1,2,3])
+        altdom = Domain([-2, -1, 1, 2, 3])
         newdom = self.f1.domain.union(altdom)
         f1_new = self.f1._break(newdom)
         self.assertEqual(f1_new.domain, newdom)
         self.assertNotEqual(f1_new.domain, altdom)
         self.assertNotEqual(f1_new.domain, self.f1.domain)
-        xx = np.linspace(-2,3,1000)
-        error = infnorm(self.f1(xx)-f1_new(xx))
-        self.assertLessEqual(error, 3*eps)
+        xx = np.linspace(-2, 3, 1000)
+        error = infnorm(self.f1(xx) - f1_new(xx))
+        self.assertLessEqual(error, 3 * eps)
 
     def test__break_2(self):
-        altdom = Domain([-2,3])
+        altdom = Domain([-2, 3])
         newdom = self.f1.domain.union(altdom)
         f1_new = self.f1._break(newdom)
         self.assertEqual(f1_new.domain, newdom)
         self.assertNotEqual(f1_new.domain, altdom)
-        xx = np.linspace(-2,3,1000)
-        error = infnorm(self.f1(xx)-f1_new(xx))
-        self.assertLessEqual(error, 3*eps)
+        xx = np.linspace(-2, 3, 1000)
+        error = infnorm(self.f1(xx) - f1_new(xx))
+        self.assertLessEqual(error, 3 * eps)
 
     def test__break_3(self):
-        altdom = Domain(np.linspace(-2,3,1000))
+        altdom = Domain(np.linspace(-2, 3, 1000))
         newdom = self.f2.domain.union(altdom)
         f2_new = self.f2._break(newdom)
         self.assertEqual(f2_new.domain, newdom)
         self.assertNotEqual(f2_new.domain, altdom)
         self.assertNotEqual(f2_new.domain, self.f2.domain)
-        xx = np.linspace(-2,3,1000)
-        error = infnorm(self.f2(xx)-f2_new(xx))
-        self.assertLessEqual(error, 3*eps)
+        xx = np.linspace(-2, 3, 1000)
+        error = infnorm(self.f2(xx) - f2_new(xx))
+        self.assertLessEqual(error, 3 * eps)
+
 
 class DomainBreakingOps(unittest.TestCase):
-
     def test_maximum_multipiece(self):
-        x = chebfun('x', np.linspace(-2,3,11))
+        x = chebfun("x", np.linspace(-2, 3, 11))
         y = chebfun(2, x.domain)
-        g = (x**y).maximum(1.5)
-        t = np.linspace(-2,3,2001)
-        f = lambda x: np.maximum(x**2,1.5)
-        self.assertLessEqual(infnorm(f(t)-g(t)), 1e1*eps)
+        g = (x ** y).maximum(1.5)
+        t = np.linspace(-2, 3, 2001)
+        f = lambda x: np.maximum(x ** 2, 1.5)
+        self.assertLessEqual(infnorm(f(t) - g(t)), 1e1 * eps)
 
     def test_minimum_multipiece(self):
-        x = chebfun('x', np.linspace(-2,3,11))
+        x = chebfun("x", np.linspace(-2, 3, 11))
         y = chebfun(2, x.domain)
-        g = (x**y).minimum(1.5)
-        t = np.linspace(-2,3,2001)
-        f = lambda x: np.minimum(x**2,1.5)
-        self.assertLessEqual(infnorm(f(t)-g(t)), 1e1*eps)
+        g = (x ** y).minimum(1.5)
+        t = np.linspace(-2, 3, 2001)
+        f = lambda x: np.minimum(x ** 2, 1.5)
+        self.assertLessEqual(infnorm(f(t) - g(t)), 1e1 * eps)
+
 
 # domain, test_tolerance
 domainBreakOp_args = [
-    (lambda x: x, 0, [-1,1], eps),
-    (sin, cos, [-1,1], eps),
-    (cos, np.abs, [-1,0,1], eps),
+    (lambda x: x, 0, [-1, 1], eps),
+    (sin, cos, [-1, 1], eps),
+    (cos, np.abs, [-1, 0, 1], eps),
 ]
 
 # add tests for maximum, minimum
 def domainBreakOpTester(domainBreakOp, f, g, dom, tol):
-    xx = np.linspace(dom[0],dom[-1],1001)
+    xx = np.linspace(dom[0], dom[-1], 1001)
     ff = chebfun(f, dom)
     gg = chebfun(g, dom)
     # convert constant g to to callable
@@ -1098,12 +1332,15 @@ def domainBreakOpTester(domainBreakOp, f, g, dom, tol):
     else:
         ffgg = domainBreakOp(f(xx), g(xx))
     fg = getattr(ff, domainBreakOp.__name__)(gg)
+
     def tester(self):
         vscl = max([ff.vscale, gg.vscale])
         hscl = max([ff.hscale, gg.hscale])
         lscl = max([fun.size for fun in np.append(ff.funs, gg.funs)])
-        self.assertLessEqual(infnorm(fg(xx)-ffgg), vscl*hscl*lscl*tol)
+        self.assertLessEqual(infnorm(fg(xx) - ffgg), vscl * hscl * lscl * tol)
+
     return tester
+
 
 for domainBreakOp in (np.maximum, np.minimum):
     for n, args in enumerate(domainBreakOp_args):

--- a/tests/test_chebtech.py
+++ b/tests/test_chebtech.py
@@ -11,8 +11,7 @@ from chebpy.core.chebtech import Chebtech2
 from chebpy.core.algorithms import standard_chop
 from chebpy.core.plotting import import_plt
 
-from .utilities import (testfunctions, infnorm, scaled_tol,
-                             infNormLessThanTol)
+from .utilities import testfunctions, infnorm, scaled_tol, infNormLessThanTol
 
 np.random.seed(0)
 
@@ -31,7 +30,7 @@ class ChebyshevPoints(unittest.TestCase):
 
     def test_chebpts_0(self):
         self.assertEquals(Chebtech2._chebpts(0).size, 0)
-            
+
     def test_vals2coeffs_empty(self):
         self.assertEquals(_vals2coeffs(np.array([])).size, 0)
 
@@ -42,15 +41,16 @@ class ChebyshevPoints(unittest.TestCase):
     def test_vals2coeffs_size1(self):
         for k in np.arange(10):
             fk = np.array([k])
-            self.assertLessEqual(infnorm(_vals2coeffs(fk)-fk), eps)
+            self.assertLessEqual(infnorm(_vals2coeffs(fk) - fk), eps)
 
     # check we are returned the array for an array of size 1
     def test_coeffs2vals_size1(self):
         for k in np.arange(10):
             ak = np.array([k])
-            self.assertLessEqual(infnorm(_coeffs2vals(ak)-ak), eps)
+            self.assertLessEqual(infnorm(_coeffs2vals(ak) - ak), eps)
 
     # TODO: further checks for chepbts
+
 
 # ------------------------------------------------------------------------
 # Tests to verify the mutually inverse nature of vals2coeffs and coeffs2vals
@@ -60,18 +60,22 @@ def vals2coeffs2valsTester(n):
         values = np.random.rand(n)
         coeffs = _vals2coeffs(values)
         _values_ = _coeffs2vals(coeffs)
-        self.assertLessEqual( infnorm(values-_values_), scaled_tol(n) )
+        self.assertLessEqual(infnorm(values - _values_), scaled_tol(n))
+
     return asserter
+
 
 def coeffs2vals2coeffsTester(n):
     def asserter(self):
         coeffs = np.random.rand(n)
         values = _coeffs2vals(coeffs)
         _coeffs_ = _vals2coeffs(values)
-        self.assertLessEqual( infnorm(coeffs-_coeffs_), scaled_tol(n) )
+        self.assertLessEqual(infnorm(coeffs - _coeffs_), scaled_tol(n))
+
     return asserter
 
-for k, n in enumerate(2**np.arange(2,18,2)+1):
+
+for k, n in enumerate(2 ** np.arange(2, 18, 2) + 1):
 
     # vals2coeffs2vals
     _testfun_ = vals2coeffs2valsTester(n)
@@ -83,20 +87,24 @@ for k, n in enumerate(2**np.arange(2,18,2)+1):
     _testfun_.__name__ = "test_coeffs2vals2coeffs_{:02}".format(k)
     setattr(ChebyshevPoints, _testfun_.__name__, _testfun_)
 # ------------------------------------------------------------------------
-   
+
 # ------------------------------------------------------------------------
 # Add second-kind Chebyshev points test cases to ChebyshevPoints
 # ------------------------------------------------------------------------
 chebpts2_testlist = (
-    (Chebtech2._chebpts(1), np.array([0.]), eps),
-    (Chebtech2._chebpts(2), np.array([-1., 1.]), eps),
-    (Chebtech2._chebpts(3), np.array([-1., 0., 1.]), eps),
-    (Chebtech2._chebpts(4), np.array([-1., -.5, .5, 1.]), 2*eps),
-    (Chebtech2._chebpts(5), np.array([-1., -2.**(-.5), 0., 2.**(-.5), 1.]), eps),
+    (Chebtech2._chebpts(1), np.array([0.0]), eps),
+    (Chebtech2._chebpts(2), np.array([-1.0, 1.0]), eps),
+    (Chebtech2._chebpts(3), np.array([-1.0, 0.0, 1.0]), eps),
+    (Chebtech2._chebpts(4), np.array([-1.0, -0.5, 0.5, 1.0]), 2 * eps),
+    (
+        Chebtech2._chebpts(5),
+        np.array([-1.0, -(2.0 ** (-0.5)), 0.0, 2.0 ** (-0.5), 1.0]),
+        eps,
+    ),
 )
-for k, (a,b,tol) in enumerate(chebpts2_testlist):
-    _testfun_ = infNormLessThanTol(a,b,tol)
-    _testfun_.__name__ = "test_chebpts_{:02}".format(k+1)
+for k, (a, b, tol) in enumerate(chebpts2_testlist):
+    _testfun_ = infNormLessThanTol(a, b, tol)
+    _testfun_.__name__ = "test_chebpts_{:02}".format(k + 1)
     setattr(ChebyshevPoints, _testfun_.__name__, _testfun_)
 
 # check the output is of the correct length, the endpoint values are -1
@@ -105,13 +113,15 @@ def chebptsLenTester(k):
     def asserter(self):
         pts = Chebtech2._chebpts(k)
         self.assertEquals(pts.size, k)
-        self.assertEquals(pts[0], -1.)
-        self.assertEquals(pts[-1], 1.)
-        self.assertTrue(np.all(np.diff(pts))>0)
+        self.assertEquals(pts[0], -1.0)
+        self.assertEquals(pts[-1], 1.0)
+        self.assertTrue(np.all(np.diff(pts)) > 0)
+
     return asserter
-    
-for k, n in enumerate(2**np.arange(2,18,2)):
-    _testfun_ = chebptsLenTester(n+3)
+
+
+for k, n in enumerate(2 ** np.arange(2, 18, 2)):
+    _testfun_ = chebptsLenTester(n + 3)
     _testfun_.__name__ = "test_chebpts_len_{:02}".format(k)
     setattr(ChebyshevPoints, _testfun_.__name__, _testfun_)
 # ------------------------------------------------------------------------
@@ -121,8 +131,8 @@ class ClassUsage(unittest.TestCase):
     """Unit-tests for miscelaneous Chebtech2 class usage"""
 
     def setUp(self):
-        self.ff = Chebtech2.initfun_fixedlen(lambda x: np.sin(30*x), 100)
-        self.xx = -1 + 2*np.random.rand(100)
+        self.ff = Chebtech2.initfun_fixedlen(lambda x: np.sin(30 * x), 100)
+        self.xx = -1 + 2 * np.random.rand(100)
 
     # tests for emptiness of Chebtech2 objects
     def test_isempty_True(self):
@@ -131,13 +141,13 @@ class ClassUsage(unittest.TestCase):
         self.assertFalse(not f.isempty)
 
     def test_isempty_False(self):
-        f = Chebtech2(np.array([1.]))
+        f = Chebtech2(np.array([1.0]))
         self.assertFalse(f.isempty)
         self.assertTrue(not f.isempty)
 
     # tests for constantness of Chebtech2 objects
     def test_isconst_True(self):
-        f = Chebtech2(np.array([1.]))
+        f = Chebtech2(np.array([1.0]))
         self.assertTrue(f.isconst)
         self.assertFalse(not f.isconst)
 
@@ -150,7 +160,7 @@ class ClassUsage(unittest.TestCase):
     def test_size(self):
         cfs = np.random.rand(10)
         self.assertEquals(Chebtech2(np.array([])).size, 0)
-        self.assertEquals(Chebtech2(np.array([1.])).size, 1)
+        self.assertEquals(Chebtech2(np.array([1.0])).size, 1)
         self.assertEquals(Chebtech2(cfs).size, cfs.size)
 
     # test the different permutations of self(xx, ..)
@@ -168,7 +178,7 @@ class ClassUsage(unittest.TestCase):
     def test_call_bary_vs_clenshaw(self):
         b = self.ff(self.xx, "clenshaw")
         c = self.ff(self.xx, "bary")
-        self.assertLessEqual(infnorm(b-c), 5e1*eps)
+        self.assertLessEqual(infnorm(b - c), 5e1 * eps)
 
     def test_call_raises(self):
         self.assertRaises(ValueError, self.ff, self.xx, "notamethod")
@@ -177,10 +187,10 @@ class ClassUsage(unittest.TestCase):
     def test_prolong(self):
         for k in [0, 1, 20, self.ff.size, 200]:
             self.assertEquals(self.ff.prolong(k).size, k)
-            
+
     def test_vscale_empty(self):
         gg = Chebtech2(np.array([]))
-        self.assertEquals(gg.vscale, 0.)
+        self.assertEquals(gg.vscale, 0.0)
 
     def test_copy(self):
         ff = self.ff
@@ -188,42 +198,47 @@ class ClassUsage(unittest.TestCase):
         self.assertEquals(ff, ff)
         self.assertEquals(gg, gg)
         self.assertNotEquals(ff, gg)
-        self.assertEquals( infnorm(ff.coeffs - gg.coeffs), 0)
+        self.assertEquals(infnorm(ff.coeffs - gg.coeffs), 0)
 
     def test_simplify(self):
         gg = self.ff.simplify()
         # check that simplify is calling standard_chop underneath
         self.assertEqual(gg.size, standard_chop(self.ff.coeffs))
-        self.assertEqual(infnorm(self.ff.coeffs[:gg.size]-gg.coeffs), 0)
+        self.assertEqual(infnorm(self.ff.coeffs[: gg.size] - gg.coeffs), 0)
         # check we are returned a copy of self's coeffcients by changing
         # one entry of gg
         fcfs = self.ff.coeffs
         gcfs = gg.coeffs
-        self.assertEqual((fcfs[:gg.size]-gcfs).sum(),0)
+        self.assertEqual((fcfs[: gg.size] - gcfs).sum(), 0)
         gg.coeffs[0] = 1
-        self.assertNotEqual((fcfs[:gg.size]-gcfs).sum(),0)
+        self.assertNotEqual((fcfs[: gg.size] - gcfs).sum(), 0)
+
 
 # --------------------------------------
 #          vscale estimates
 # --------------------------------------
 vscales = [
     # (function, number of points, vscale)
-    (lambda x: sin(4*pi*x),        40, 1),
-    (lambda x: cos(x),             15, 1),
-    (lambda x: cos(4*pi*x),        39, 1),
-    (lambda x: exp(cos(4*pi*x)),  181, exp(1)),
-    (lambda x: cos(3244*x),      3389, 1),
-    (lambda x: exp(x),             15, exp(1)),
-    (lambda x: 1e10*exp(x),        15, 1e10*exp(1)),
-    (lambda x: 0*x+1.,              1, 1),
+    (lambda x: sin(4 * pi * x), 40, 1),
+    (lambda x: cos(x), 15, 1),
+    (lambda x: cos(4 * pi * x), 39, 1),
+    (lambda x: exp(cos(4 * pi * x)), 181, exp(1)),
+    (lambda x: cos(3244 * x), 3389, 1),
+    (lambda x: exp(x), 15, exp(1)),
+    (lambda x: 1e10 * exp(x), 15, 1e10 * exp(1)),
+    (lambda x: 0 * x + 1.0, 1, 1),
 ]
+
 
 def vscaleTester(fun, n, vscale):
     ff = Chebtech2.initfun_fixedlen(fun, n)
+
     def tester(self):
-        absdiff = abs(ff.vscale-vscale)
-        self.assertLessEqual(absdiff, .1*vscale)
+        absdiff = abs(ff.vscale - vscale)
+        self.assertLessEqual(absdiff, 0.1 * vscale)
+
     return tester
+
 
 for k, args in enumerate(vscales):
     _testfun_ = vscaleTester(*args)
@@ -233,12 +248,13 @@ for k, args in enumerate(vscales):
 
 plt = import_plt()
 
+
 class Plotting(unittest.TestCase):
     """Unit-tests for Chebtech2 plotting methods"""
 
     def setUp(self):
-        f = lambda x: sin(3*x) + 5e-1*cos(30*x)
-        u = lambda x: np.exp(2*np.pi*1j*x)
+        f = lambda x: sin(3 * x) + 5e-1 * cos(30 * x)
+        u = lambda x: np.exp(2 * np.pi * 1j * x)
         self.f0 = Chebtech2.initfun_fixedlen(f, 100)
         self.f1 = Chebtech2.initfun_adaptive(f)
         self.f2 = Chebtech2.initfun_adaptive(u)
@@ -252,9 +268,9 @@ class Plotting(unittest.TestCase):
     def test_plot_complex(self):
         fig, ax = plt.subplots()
         # plot Bernstein ellipses
-        joukowsky = lambda z: .5*(z+1/z)
+        joukowsky = lambda z: 0.5 * (z + 1 / z)
         for rho in np.arange(1.1, 2, 0.1):
-            joukowsky(rho*self.f2).plot(ax=ax)
+            joukowsky(rho * self.f2).plot(ax=ax)
 
     @unittest.skipIf(plt is None, "matplotlib not installed")
     def test_plotcoeffs(self):
@@ -271,7 +287,7 @@ class Calculus(unittest.TestCase):
 
     # tests for the correct results in the empty cases
     def test_sum_empty(self):
-        self.assertEqual(self.emptyfun.sum(),0)
+        self.assertEqual(self.emptyfun.sum(), 0)
 
     def test_cumsum_empty(self):
         self.assertTrue(self.emptyfun.cumsum().isempty)
@@ -281,36 +297,35 @@ class Calculus(unittest.TestCase):
 
 
 class Complex(unittest.TestCase):
-
     def setUp(self):
-        self.z = Chebtech2.initfun_adaptive(lambda x: np.exp(np.pi*1j*x))
+        self.z = Chebtech2.initfun_adaptive(lambda x: np.exp(np.pi * 1j * x))
 
     def test_init_empty(self):
         Chebtech2.initempty()
 
     def test_roots(self):
         r0 = self.z.roots()
-        r1 = (self.z-1).roots()
-        r2 = (self.z-1j).roots()
-        r3 = (self.z+1).roots()
-        r4 = (self.z+1j).roots()
+        r1 = (self.z - 1).roots()
+        r2 = (self.z - 1j).roots()
+        r3 = (self.z + 1).roots()
+        r4 = (self.z + 1j).roots()
         self.assertEqual(r0.size, 0)
         self.assertTrue(np.allclose(r1, [0]))
-        self.assertTrue(np.allclose(r2, [.5]))
+        self.assertTrue(np.allclose(r2, [0.5]))
         self.assertTrue(np.allclose(r3, [-1, 1]))
-        self.assertTrue(np.allclose(r4, [-.5]))
+        self.assertTrue(np.allclose(r4, [-0.5]))
 
     def test_rho_ellipse_construction(self):
         zz = 1.2 * self.z
-        e = .5 * (zz + 1/zz)
-        self.assertAlmostEqual(e(1)-e(-1), 0, places=14)
-        self.assertAlmostEqual(e(0)+e(-1), 0, places=14)
-        self.assertAlmostEqual(e(0)+e(1), 0, places=14)
+        e = 0.5 * (zz + 1 / zz)
+        self.assertAlmostEqual(e(1) - e(-1), 0, places=14)
+        self.assertAlmostEqual(e(0) + e(-1), 0, places=14)
+        self.assertAlmostEqual(e(0) + e(1), 0, places=14)
 
     def test_calculus(self):
         self.assertTrue(np.allclose([self.z.sum()], [0]))
-        self.assertTrue((self.z.cumsum().diff()-self.z).size, 1)
-        self.assertTrue((self.z-self.z.cumsum().diff()).size, 1)
+        self.assertTrue((self.z.cumsum().diff() - self.z).size, 1)
+        self.assertTrue((self.z - self.z.cumsum().diff()).size, 1)
 
     def test_real_imag(self):
         # ceck definition of real and imaginary
@@ -319,10 +334,10 @@ class Complex(unittest.TestCase):
         np.testing.assert_equal(zreal.coeffs, np.real(self.z.coeffs))
         np.testing.assert_equal(zimag.coeffs, np.imag(self.z.coeffs))
         # check real part of real chebtech is the same chebtech
-        self.assertTrue(zreal.real()==zreal)
+        self.assertTrue(zreal.real() == zreal)
         # check imaginary part of real chebtech is the zero chebtech
         self.assertTrue(zreal.imag().isconst)
-        self.assertTrue(zreal.imag().coeffs[0]==0)
+        self.assertTrue(zreal.imag().coeffs[0] == 0)
 
 
 # --------------------------------------
@@ -330,23 +345,27 @@ class Complex(unittest.TestCase):
 # --------------------------------------
 def_integrals = [
     # (function, number of points, integral, tolerance)
-    (lambda x: sin(x),             14,                    .0,      eps),
-    (lambda x: sin(4*pi*x),        40,                    .0,  1e1*eps),
-    (lambda x: cos(x),             15,     1.682941969615793,    2*eps),
-    (lambda x: cos(4*pi*x),        39,                    .0,    2*eps),
-    (lambda x: exp(cos(4*pi*x)),  182,     2.532131755504016,    4*eps),
-    (lambda x: cos(3244*x),      3389, 5.879599674161602e-04,  5e2*eps),
-    (lambda x: exp(x),             15,        exp(1)-exp(-1),    2*eps),
-    (lambda x: 1e10*exp(x),        15, 1e10*(exp(1)-exp(-1)), 4e10*eps),
-    (lambda x: 0*x+1.,              1,                     2,      eps),
+    (lambda x: sin(x), 14, 0.0, eps),
+    (lambda x: sin(4 * pi * x), 40, 0.0, 1e1 * eps),
+    (lambda x: cos(x), 15, 1.682941969615793, 2 * eps),
+    (lambda x: cos(4 * pi * x), 39, 0.0, 2 * eps),
+    (lambda x: exp(cos(4 * pi * x)), 182, 2.532131755504016, 4 * eps),
+    (lambda x: cos(3244 * x), 3389, 5.879599674161602e-04, 5e2 * eps),
+    (lambda x: exp(x), 15, exp(1) - exp(-1), 2 * eps),
+    (lambda x: 1e10 * exp(x), 15, 1e10 * (exp(1) - exp(-1)), 4e10 * eps),
+    (lambda x: 0 * x + 1.0, 1, 2, eps),
 ]
+
 
 def definiteIntegralTester(fun, n, integral, tol):
     ff = Chebtech2.initfun_fixedlen(fun, n)
+
     def tester(self):
-        absdiff = abs(ff.sum()-integral)
+        absdiff = abs(ff.sum() - integral)
         self.assertLessEqual(absdiff, tol)
+
     return tester
+
 
 for k, (fun, n, integral, tol) in enumerate(def_integrals):
     _testfun_ = definiteIntegralTester(fun, n, integral, tol)
@@ -358,27 +377,31 @@ for k, (fun, n, integral, tol) in enumerate(def_integrals):
 # --------------------------------------
 indef_integrals = [
     # (function, indefinite integral, number of points, tolerance)
-    (lambda x: 0*x+1.,      lambda x: x,              1,         eps),
-    (lambda x: x,           lambda x: 1/2*x**2,       2,       2*eps),
-    (lambda x: x**2,        lambda x: 1/3*x**3,       3,       2*eps),
-    (lambda x: x**3,        lambda x: 1/4*x**4,       4,       2*eps),
-    (lambda x: x**4,        lambda x: 1/5*x**5,       5,       2*eps),
-    (lambda x: x**5,        lambda x: 1/6*x**6,       6,       4*eps),
-    (lambda x: sin(x),      lambda x: -cos(x),       16,       2*eps),
-    (lambda x: cos(3*x),    lambda x: 1./3*sin(3*x), 23,       2*eps),
-    (lambda x: exp(x),      lambda x: exp(x),        16,       3*eps),
-    (lambda x: 1e10*exp(x), lambda x: 1e10*exp(x),   16, 1e10*(3*eps)),
+    (lambda x: 0 * x + 1.0, lambda x: x, 1, eps),
+    (lambda x: x, lambda x: 1 / 2 * x ** 2, 2, 2 * eps),
+    (lambda x: x ** 2, lambda x: 1 / 3 * x ** 3, 3, 2 * eps),
+    (lambda x: x ** 3, lambda x: 1 / 4 * x ** 4, 4, 2 * eps),
+    (lambda x: x ** 4, lambda x: 1 / 5 * x ** 5, 5, 2 * eps),
+    (lambda x: x ** 5, lambda x: 1 / 6 * x ** 6, 6, 4 * eps),
+    (lambda x: sin(x), lambda x: -cos(x), 16, 2 * eps),
+    (lambda x: cos(3 * x), lambda x: 1.0 / 3 * sin(3 * x), 23, 2 * eps),
+    (lambda x: exp(x), lambda x: exp(x), 16, 3 * eps),
+    (lambda x: 1e10 * exp(x), lambda x: 1e10 * exp(x), 16, 1e10 * (3 * eps)),
 ]
+
 
 def indefiniteIntegralTester(fun, dfn, n, tol):
     ff = Chebtech2.initfun_fixedlen(fun, n)
-    gg = Chebtech2.initfun_fixedlen(dfn, n+1)
+    gg = Chebtech2.initfun_fixedlen(dfn, n + 1)
     coeffs = gg.coeffs
     coeffs[0] = coeffs[0] - dfn(np.array([-1]))
+
     def tester(self):
         absdiff = infnorm(ff.cumsum().coeffs - coeffs)
         self.assertLessEqual(absdiff, tol)
+
     return tester
+
 
 for k, (fun, dfn, n, tol) in enumerate(indef_integrals):
     _testfun_ = indefiniteIntegralTester(fun, dfn, n, tol)
@@ -390,25 +413,29 @@ for k, (fun, dfn, n, tol) in enumerate(indef_integrals):
 # --------------------------------------
 derivatives = [
     # (function, derivative, number of points, tolerance)
-    (lambda x: 0*x+1.,      lambda x: 0*x+0,        1,          eps),
-    (lambda x: x,           lambda x: 0*x+1,        2,        2*eps),
-    (lambda x: x**2,        lambda x: 2*x,          3,        2*eps),
-    (lambda x: x**3,        lambda x: 3*x**2,       4,        2*eps),
-    (lambda x: x**4,        lambda x: 4*x**3,       5,        3*eps),
-    (lambda x: x**5,        lambda x: 5*x**4,       6,        4*eps),
-    (lambda x: sin(x),      lambda x: cos(x),      16,      5e1*eps),
-    (lambda x: cos(3*x),    lambda x: -3*sin(3*x), 23,      5e2*eps),
-    (lambda x: exp(x),      lambda x: exp(x),      16,      2e2*eps),
-    (lambda x: 1e10*exp(x), lambda x: 1e10*exp(x), 16, 1e10*2e2*eps),
+    (lambda x: 0 * x + 1.0, lambda x: 0 * x + 0, 1, eps),
+    (lambda x: x, lambda x: 0 * x + 1, 2, 2 * eps),
+    (lambda x: x ** 2, lambda x: 2 * x, 3, 2 * eps),
+    (lambda x: x ** 3, lambda x: 3 * x ** 2, 4, 2 * eps),
+    (lambda x: x ** 4, lambda x: 4 * x ** 3, 5, 3 * eps),
+    (lambda x: x ** 5, lambda x: 5 * x ** 4, 6, 4 * eps),
+    (lambda x: sin(x), lambda x: cos(x), 16, 5e1 * eps),
+    (lambda x: cos(3 * x), lambda x: -3 * sin(3 * x), 23, 5e2 * eps),
+    (lambda x: exp(x), lambda x: exp(x), 16, 2e2 * eps),
+    (lambda x: 1e10 * exp(x), lambda x: 1e10 * exp(x), 16, 1e10 * 2e2 * eps),
 ]
+
 
 def derivativeTester(fun, der, n, tol):
     ff = Chebtech2.initfun_fixedlen(fun, n)
-    gg = Chebtech2.initfun_fixedlen(der, max(n-1,1))
+    gg = Chebtech2.initfun_fixedlen(der, max(n - 1, 1))
+
     def tester(self):
         absdiff = infnorm(ff.diff().coeffs - gg.coeffs)
         self.assertLessEqual(absdiff, tol)
+
     return tester
+
 
 for k, (fun, der, n, tol) in enumerate(derivatives):
     _testfun_ = derivativeTester(fun, der, n, tol)
@@ -419,57 +446,64 @@ for k, (fun, der, n, tol) in enumerate(derivatives):
 class Construction(unittest.TestCase):
     """Unit-tests for construction of Chebtech2 objects"""
 
-    #TODO: expand to all the constructor variants
+    # TODO: expand to all the constructor variants
     def test_initvalues(self):
         # test n = 0 case separately
         vals = np.random.rand(0)
         fun = Chebtech2.initvalues(vals)
         cfs = Chebtech2._vals2coeffs(vals)
-        self.assertTrue(fun.coeffs.size==cfs.size==0)
+        self.assertTrue(fun.coeffs.size == cfs.size == 0)
         # now test the other cases
-        for n in range(1,10):
+        for n in range(1, 10):
             vals = np.random.rand(n)
             fun = Chebtech2.initvalues(vals)
             cfs = Chebtech2._vals2coeffs(vals)
-            self.assertEqual(infnorm(fun.coeffs-cfs), 0.)
+            self.assertEqual(infnorm(fun.coeffs - cfs), 0.0)
 
     def test_initidentity(self):
         x = Chebtech2.initidentity()
-        s = -1 + 2*np.random.rand(10000)
-        self.assertEqual(infnorm(s-x(s)), 0.)
+        s = -1 + 2 * np.random.rand(10000)
+        self.assertEqual(infnorm(s - x(s)), 0.0)
 
     def test_coeff_construction(self):
         coeffs = np.random.rand(10)
         f = Chebtech2(coeffs)
         self.assertIsInstance(f, Chebtech2)
-        self.assertLess(infnorm(f.coeffs-coeffs), eps)
+        self.assertLess(infnorm(f.coeffs - coeffs), eps)
 
     def test_const_construction(self):
-        ff = Chebtech2.initconst(1.)
+        ff = Chebtech2.initconst(1.0)
         self.assertEquals(ff.size, 1)
         self.assertTrue(ff.isconst)
         self.assertFalse(ff.isempty)
-        self.assertRaises(ValueError, Chebtech2.initconst, [1.])
+        self.assertRaises(ValueError, Chebtech2.initconst, [1.0])
 
     def test_empty_construction(self):
         ff = Chebtech2.initempty()
         self.assertEquals(ff.size, 0)
         self.assertFalse(ff.isconst)
         self.assertTrue(ff.isempty)
-        self.assertRaises(TypeError, Chebtech2.initempty, [1.])
+        self.assertRaises(TypeError, Chebtech2.initempty, [1.0])
+
 
 def adaptiveTester(fun, funlen):
     ff = Chebtech2.initfun_adaptive(fun)
+
     def tester(self):
-        self.assertLessEqual(ff.size-funlen, 2)
-        self.assertGreater(ff.size-funlen, -1)
+        self.assertLessEqual(ff.size - funlen, 2)
+        self.assertGreater(ff.size - funlen, -1)
+
     return tester
+
 
 def fixedlenTester(fun, n):
     ff = Chebtech2.initfun_fixedlen(fun, n)
+
     def tester(self):
         self.assertEquals(ff.size, n)
+
     return tester
+
 
 for (fun, funlen, _) in testfunctions:
 
@@ -481,13 +515,13 @@ for (fun, funlen, _) in testfunctions:
     # add the fixedlen tests
     for n in np.array([50, 500]):
         _testfun_ = fixedlenTester(fun, n)
-        _testfun_.__name__ = \
-            "test_fixedlen_{}_{:003}pts".format(fun.__name__, n)
+        _testfun_.__name__ = "test_fixedlen_{}_{:003}pts".format(fun.__name__, n)
         setattr(Construction, _testfun_.__name__, _testfun_)
 
 
 class Algebra(unittest.TestCase):
     """Unit-tests for Chebtech2 algebraic operations"""
+
     def setUp(self):
         self.xx = -1 + 2 * np.random.rand(1000)
         self.emptyfun = Chebtech2.initempty()
@@ -497,8 +531,8 @@ class Algebra(unittest.TestCase):
     def test__add__radd__empty(self):
         for (fun, funlen, _) in testfunctions:
             chebtech = Chebtech2.initfun_fixedlen(fun, funlen)
-            self.assertTrue((self.emptyfun+chebtech).isempty)
-            self.assertTrue((chebtech+self.emptyfun).isempty)
+            self.assertTrue((self.emptyfun + chebtech).isempty)
+            self.assertTrue((chebtech + self.emptyfun).isempty)
 
     # check the output of (constant + Chebtech)
     #                 and (Chebtech + constant)
@@ -511,8 +545,8 @@ class Algebra(unittest.TestCase):
                 f1 = const + techfun
                 f2 = techfun + const
                 tol = 5e1 * eps * abs(const)
-                self.assertLessEqual(infnorm(f(xx)-f1(xx)), tol)
-                self.assertLessEqual(infnorm(f(xx)-f2(xx)), tol)
+                self.assertLessEqual(infnorm(f(xx) - f1(xx)), tol)
+                self.assertLessEqual(infnorm(f(xx) - f2(xx)), tol)
 
     # check the output of (Chebtech - Chebtech)
     def test__add__negself(self):
@@ -528,8 +562,8 @@ class Algebra(unittest.TestCase):
     def test__sub__rsub__empty(self):
         for (fun, funlen, _) in testfunctions:
             chebtech = Chebtech2.initfun_fixedlen(fun, funlen)
-            self.assertTrue((self.emptyfun-chebtech).isempty)
-            self.assertTrue((chebtech-self.emptyfun).isempty)
+            self.assertTrue((self.emptyfun - chebtech).isempty)
+            self.assertTrue((chebtech - self.emptyfun).isempty)
 
     # check the output of constant - Chebtech
     #                 and Chebtech - constant
@@ -543,16 +577,16 @@ class Algebra(unittest.TestCase):
                 ff = const - techfun
                 gg = techfun - const
                 tol = 5e1 * eps * abs(const)
-                self.assertLessEqual(infnorm(f(xx)-ff(xx)), tol)
-                self.assertLessEqual(infnorm(g(xx)-gg(xx)), tol)
+                self.assertLessEqual(infnorm(f(xx) - ff(xx)), tol)
+                self.assertLessEqual(infnorm(g(xx) - gg(xx)), tol)
 
     # check (empty Chebtech) * (Chebtech) = (empty Chebtech)
     #   and (Chebtech) * (empty Chebtech) = (empty Chebtech)
     def test__mul__rmul__empty(self):
         for (fun, funlen, _) in testfunctions:
             chebtech = Chebtech2.initfun_fixedlen(fun, funlen)
-            self.assertTrue((self.emptyfun*chebtech).isempty)
-            self.assertTrue((chebtech*self.emptyfun).isempty)
+            self.assertTrue((self.emptyfun * chebtech).isempty)
+            self.assertTrue((chebtech * self.emptyfun).isempty)
 
     # check the output of constant * Chebtech
     #                 and Chebtech * constant
@@ -566,19 +600,19 @@ class Algebra(unittest.TestCase):
                 ff = const * techfun
                 gg = techfun * const
                 tol = 5e1 * eps * abs(const)
-                self.assertLessEqual(infnorm(f(xx)-ff(xx)), tol)
-                self.assertLessEqual(infnorm(g(xx)-gg(xx)), tol)
+                self.assertLessEqual(infnorm(f(xx) - ff(xx)), tol)
+                self.assertLessEqual(infnorm(g(xx) - gg(xx)), tol)
 
     # check (empty Chebtech) / (Chebtech) = (empty Chebtech)
     #   and (Chebtech) / (empty Chebtech) = (empty Chebtech)
     def test_truediv_empty(self):
         for (fun, funlen, _) in testfunctions:
             chebtech = Chebtech2.initfun_fixedlen(fun, funlen)
-            self.assertTrue(operator.truediv(self.emptyfun,chebtech).isempty)
-            self.assertTrue(operator.truediv(chebtech,self.emptyfun).isempty)
+            self.assertTrue(operator.truediv(self.emptyfun, chebtech).isempty)
+            self.assertTrue(operator.truediv(chebtech, self.emptyfun).isempty)
             # __truediv__
-            self.assertTrue((self.emptyfun/chebtech).isempty)
-            self.assertTrue((chebtech/self.emptyfun).isempty)
+            self.assertTrue((self.emptyfun / chebtech).isempty)
+            self.assertTrue((chebtech / self.emptyfun).isempty)
 
     # check the output of constant / Chebtech
     #                 and Chebtech / constant
@@ -589,16 +623,16 @@ class Algebra(unittest.TestCase):
         xx = self.xx
         for (fun, funlen, hasRoots) in testfunctions:
             for const in (-1, 1, 10, -1e5):
-                tol = eps*abs(const)
+                tol = eps * abs(const)
                 techfun = Chebtech2.initfun_fixedlen(fun, funlen)
                 g = lambda x: fun(x) / const
                 gg = techfun / const
-                self.assertLessEqual(infnorm(g(xx)-gg(xx)), 2*gg.size*tol)
+                self.assertLessEqual(infnorm(g(xx) - gg(xx)), 2 * gg.size * tol)
                 # don't do the following test for functions with roots
                 if not hasRoots:
                     f = lambda x: const / fun(x)
                     ff = const / techfun
-                    self.assertLessEqual(infnorm(f(xx)-ff(xx)), 3*ff.size*tol)
+                    self.assertLessEqual(infnorm(f(xx) - ff(xx)), 3 * ff.size * tol)
 
     # check    +(empty Chebtech) = (empty Chebtech)
     def test__pos__empty(self):
@@ -610,48 +644,52 @@ class Algebra(unittest.TestCase):
 
     def test_pow_empty(self):
         for c in range(10):
-            self.assertTrue((self.emptyfun**c).isempty)
+            self.assertTrue((self.emptyfun ** c).isempty)
 
     def test_rpow_empty(self):
         for c in range(10):
-            self.assertTrue((c**self.emptyfun).isempty)
+            self.assertTrue((c ** self.emptyfun).isempty)
 
     # check the output of Chebtech ** constant
     #                 and constant ** Chebtech
     def test_pow_const(self):
         xx = self.xx
-        for (fun, funlen) in [(np.sin, 15), (np.exp,15)]:
+        for (fun, funlen) in [(np.sin, 15), (np.exp, 15)]:
             for c in (1, 2):
                 techfun = Chebtech2.initfun_fixedlen(fun, funlen)
                 f = lambda x: fun(x) ** c
                 ff = techfun ** c
                 tol = 2e1 * eps * abs(c)
-                self.assertLessEqual(infnorm(f(xx)-ff(xx)), tol)
+                self.assertLessEqual(infnorm(f(xx) - ff(xx)), tol)
 
     def test_rpow_const(self):
         xx = self.xx
-        for (fun, funlen) in [(np.sin, 15), (np.exp,15)]:
+        for (fun, funlen) in [(np.sin, 15), (np.exp, 15)]:
             for c in (1, 2):
                 techfun = Chebtech2.initfun_fixedlen(fun, funlen)
                 g = lambda x: c ** fun(x)
                 gg = c ** techfun
                 tol = 2e1 * eps * abs(c)
-                self.assertLessEqual(infnorm(g(xx)-gg(xx)), tol)
+                self.assertLessEqual(infnorm(g(xx) - gg(xx)), tol)
+
 
 # add tests for the binary operators
 def binaryOpTester(f, g, binop, nf, ng):
     ff = Chebtech2.initfun_fixedlen(f, nf)
     gg = Chebtech2.initfun_fixedlen(g, ng)
-    FG = lambda x: binop(f(x),g(x)) 
+    FG = lambda x: binop(f(x), g(x))
     fg = binop(ff, gg)
+
     def tester(self):
         vscl = max([ff.vscale, gg.vscale])
         lscl = max([ff.size, gg.size])
-        self.assertLessEqual(infnorm(fg(self.xx)-FG(self.xx)), 3*vscl*lscl*eps)
+        self.assertLessEqual(infnorm(fg(self.xx) - FG(self.xx)), 3 * vscl * lscl * eps)
         if binop is operator.mul:
             # check simplify is not being called in __mul__
-            self.assertEqual(fg.size, ff.size+gg.size-1)
+            self.assertEqual(fg.size, ff.size + gg.size - 1)
+
     return tester
+
 
 # note: defining __radd__(a,b) = operator.add(b,a) and feeding this into the
 # test will not in fact test the __radd__ functionality of the class. These
@@ -659,27 +697,26 @@ def binaryOpTester(f, g, binop, nf, ng):
 binops = (operator.add, operator.mul, operator.sub, operator.truediv)
 for binop in binops:
     # add generic binary operator tests
-    for (f, nf, _), (g, ng, denomRoots) in \
-            itertools.combinations(testfunctions, 2):
+    for (f, nf, _), (g, ng, denomRoots) in itertools.combinations(testfunctions, 2):
         if binop is operator.truediv and denomRoots:
             # skip truediv test if the denominator has roots
             pass
         else:
             _testfun_ = binaryOpTester(f, g, binop, nf, ng)
-            _testfun_.__name__ = \
-                "test_{}_{}_{}".format(binop.__name__, f.__name__,  g.__name__)
+            _testfun_.__name__ = "test_{}_{}_{}".format(
+                binop.__name__, f.__name__, g.__name__
+            )
             setattr(Algebra, _testfun_.__name__, _testfun_)
 
 powtestfuns = (
-    [(np.exp, 15, 'exp'), (np.sin, 15, 'sin')],
-    [(np.exp, 15, 'exp'), (lambda x: 2-x, 2, 'linear')],
-    [(lambda x: 2-x, 2, 'linear'), (np.exp, 15, 'exp')],
+    [(np.exp, 15, "exp"), (np.sin, 15, "sin")],
+    [(np.exp, 15, "exp"), (lambda x: 2 - x, 2, "linear")],
+    [(lambda x: 2 - x, 2, "linear"), (np.exp, 15, "exp")],
 )
 # add operator.power tests
 for (f, nf, namef), (g, ng, nameg) in powtestfuns:
     _testfun_ = binaryOpTester(f, g, operator.pow, nf, ng)
-    _testfun_.__name__ = \
-        "test_{}_{}_{}".format('pow', namef,  nameg)
+    _testfun_.__name__ = "test_{}_{}_{}".format("pow", namef, nameg)
     setattr(Algebra, _testfun_.__name__, _testfun_)
 
 # add tests for the unary operators
@@ -687,47 +724,53 @@ def unaryOpTester(unaryop, f, nf):
     ff = Chebtech2.initfun_fixedlen(f, nf)
     gg = lambda x: unaryop(f(x))
     GG = unaryop(ff)
+
     def tester(self):
-        self.assertLessEqual(infnorm(gg(self.xx)-GG(self.xx)), 4e1*eps)
+        self.assertLessEqual(infnorm(gg(self.xx) - GG(self.xx)), 4e1 * eps)
+
     return tester
+
 
 unaryops = (operator.pos, operator.neg)
 for unaryop in unaryops:
     for (f, nf, _) in testfunctions:
         _testfun_ = unaryOpTester(unaryop, f, nf)
-        _testfun_.__name__ = \
-            "test_{}_{}".format(unaryop.__name__, f.__name__)
+        _testfun_.__name__ = "test_{}_{}".format(unaryop.__name__, f.__name__)
         setattr(Algebra, _testfun_.__name__, _testfun_)
 
-class Roots(unittest.TestCase):
 
+class Roots(unittest.TestCase):
     def test_empty(self):
         ff = Chebtech2.initempty()
         self.assertEquals(ff.roots().size, 0)
 
     def test_const(self):
-        ff = Chebtech2.initconst(0.)
-        gg = Chebtech2.initconst(2.)
+        ff = Chebtech2.initconst(0.0)
+        gg = Chebtech2.initconst(2.0)
         self.assertEquals(ff.roots().size, 0)
         self.assertEquals(gg.roots().size, 0)
+
 
 # add tests for roots
 def rootsTester(f, roots, tol):
     ff = Chebtech2.initfun_adaptive(f)
     rts = ff.roots()
+
     def tester(self):
-        self.assertLessEqual(infnorm(rts-roots), tol)
+        self.assertLessEqual(infnorm(rts - roots), tol)
+
     return tester
 
+
 rootstestfuns = (
-    (lambda x: 3*x+2.,        np.array([-2/3]),                       1*eps),
-    (lambda x: x**2,          np.array([0.,0.]),                      1*eps),
-    (lambda x: x**2+.2*x-.08, np.array([-.4, .2]),                    1*eps),
-    (lambda x: sin(x),        np.array([0]),                          1*eps),
-    (lambda x: cos(2*pi*x),   np.array([-0.75, -0.25,  0.25,  0.75]), 1*eps),
-    (lambda x: sin(100*pi*x), np.linspace(-1,1,201),                  1*eps),
-    (lambda x: sin(5*pi/2*x), np.array([-.8, -.4, 0, .4, .8]),        1*eps)
-    )
+    (lambda x: 3 * x + 2.0, np.array([-2 / 3]), 1 * eps),
+    (lambda x: x ** 2, np.array([0.0, 0.0]), 1 * eps),
+    (lambda x: x ** 2 + 0.2 * x - 0.08, np.array([-0.4, 0.2]), 1 * eps),
+    (lambda x: sin(x), np.array([0]), 1 * eps),
+    (lambda x: cos(2 * pi * x), np.array([-0.75, -0.25, 0.25, 0.75]), 1 * eps),
+    (lambda x: sin(100 * pi * x), np.linspace(-1, 1, 201), 1 * eps),
+    (lambda x: sin(5 * pi / 2 * x), np.array([-0.8, -0.4, 0, 0.4, 0.8]), 1 * eps),
+)
 
 for k, args in enumerate(rootstestfuns):
     _testfun_ = rootsTester(*args)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,31 +3,33 @@ import unittest
 from chebpy import UserPreferences
 from chebpy.core.settings import _preferences
 
+
 def userPref(name):
     """Get the current preference value for name.
     This is how chebpy core modules access these."""
     return getattr(_preferences, name)
 
-class Settings(unittest.TestCase):
 
+class Settings(unittest.TestCase):
     def test_update_pref(self):
         eps_new = 1e-3
-        eps_old = userPref('eps')
+        eps_old = userPref("eps")
         with UserPreferences() as prefs:
             prefs.eps = eps_new
-            self.assertEqual(eps_new, userPref('eps'))
-        self.assertEqual(eps_old, userPref('eps'))
+            self.assertEqual(eps_new, userPref("eps"))
+        self.assertEqual(eps_old, userPref("eps"))
 
     def test_reset(self):
         def change(reset_named=False):
             prefs = UserPreferences()
             prefs.eps = 99
             if reset_named:
-                prefs.reset('eps')
+                prefs.reset("eps")
             else:
                 prefs.reset()
-        eps_bak = userPref('eps')
+
+        eps_bak = userPref("eps")
         change(False)
-        self.assertEqual(eps_bak, userPref('eps'))
+        self.assertEqual(eps_bak, userPref("eps"))
         change(True)
-        self.assertEqual(eps_bak, userPref('eps'))
+        self.assertEqual(eps_bak, userPref("eps"))

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -6,60 +6,60 @@ import numpy as np
 from chebpy import chebfun, pwc
 from chebpy.core.settings import DefaultPreferences
 
-class Constructors(unittest.TestCase):
 
+class Constructors(unittest.TestCase):
     def test_chebfun_null_args(self):
         self.assertTrue(chebfun().isempty)
-        
+
     def test_chebfun_callable(self):
         n = 100
-        d = np.array([-2,0,1])
+        d = np.array([-2, 0, 1])
         f1 = chebfun(np.sin)
         f2 = chebfun(np.sin, d)
         f3 = chebfun(np.sin, n=n)
         f4 = chebfun(np.sin, d, n)
-        
+
         # check domains
-        self.assertTrue(f1.domain==DefaultPreferences.domain)
-        self.assertTrue(f2.domain==d)
-        self.assertTrue(f3.domain==DefaultPreferences.domain)
-        self.assertTrue(f4.domain==d)
-        
+        self.assertTrue(f1.domain == DefaultPreferences.domain)
+        self.assertTrue(f2.domain == d)
+        self.assertTrue(f3.domain == DefaultPreferences.domain)
+        self.assertTrue(f4.domain == d)
+
         # check lengths of f3 and f4
         self.assertEqual(f3.funs[0].size, n)
-        self.assertTrue(np.all([fun.size==n for fun in f4]))
+        self.assertTrue(np.all([fun.size == n for fun in f4]))
 
     def test_chebfun_alphanum_char(self):
         n = 100
-        d = np.array([-2,0,1])
-        f1 = chebfun('x')
-        f2 = chebfun('y', d)
-        f3 = chebfun('z', n=n)
-        f4 = chebfun('a', d, n)
-        
+        d = np.array([-2, 0, 1])
+        f1 = chebfun("x")
+        f2 = chebfun("y", d)
+        f3 = chebfun("z", n=n)
+        f4 = chebfun("a", d, n)
+
         # check domains
-        self.assertTrue(f1.domain==DefaultPreferences.domain)
-        self.assertTrue(f2.domain==d)
-        self.assertTrue(f3.domain==DefaultPreferences.domain)
-        self.assertTrue(f4.domain==d)
-        
+        self.assertTrue(f1.domain == DefaultPreferences.domain)
+        self.assertTrue(f2.domain == d)
+        self.assertTrue(f3.domain == DefaultPreferences.domain)
+        self.assertTrue(f4.domain == d)
+
         # check lengths of f3 and f4
         self.assertEqual(np.sum([fun.size for fun in f3]), n)
-        self.assertTrue(np.all([fun.size==n for fun in f4]))
-        
+        self.assertTrue(np.all([fun.size == n for fun in f4]))
+
     def test_chebfun_float_arg(self):
-        d = np.array([-2,0,1])
+        d = np.array([-2, 0, 1])
         f1 = chebfun(3.14)
-        f2 = chebfun('3.14')
+        f2 = chebfun("3.14")
         f3 = chebfun(2.72, d)
-        f4 = chebfun('2.72', d)
-        
+        f4 = chebfun("2.72", d)
+
         # check domains
-        self.assertTrue(f1.domain==DefaultPreferences.domain)
-        self.assertTrue(f2.domain==DefaultPreferences.domain)
-        self.assertTrue(f3.domain==d)
-        self.assertTrue(f4.domain==d)
-        
+        self.assertTrue(f1.domain == DefaultPreferences.domain)
+        self.assertTrue(f2.domain == DefaultPreferences.domain)
+        self.assertTrue(f3.domain == d)
+        self.assertTrue(f4.domain == d)
+
         # check all are constant
         self.assertTrue(f1.isconst)
         self.assertTrue(f2.isconst)
@@ -67,19 +67,19 @@ class Constructors(unittest.TestCase):
         self.assertTrue(f4.isconst)
 
     def test_chebfun_raises(self):
-        self.assertRaises(ValueError, chebfun, 'asdfasdf')
+        self.assertRaises(ValueError, chebfun, "asdfasdf")
 
     def test_pwc(self):
-        dom = [-1,0,1]
-        vals = [0,1]
+        dom = [-1, 0, 1]
+        vals = [0, 1]
         f = pwc(dom, vals)
         self.assertEqual(f.funs.size, 2)
-        for fun, val in zip(f,vals):
+        for fun, val in zip(f, vals):
             self.assertTrue(fun.isconst)
             self.assertEqual(fun.coeffs[0], val)
 
-class Pickling(unittest.TestCase):
 
+class Pickling(unittest.TestCase):
     def setUp(self):
         self.f0 = chebfun(np.sin, [-2, 0, 1])
         self.f1 = pickle.loads(pickle.dumps(self.f0))
@@ -88,6 +88,6 @@ class Pickling(unittest.TestCase):
         x = -1
         self.assertEqual(self.f0(x), self.f1(x))
 
-    #TODO: implement test for equality once objects can be compared
-    #def test_equality(self):
-        #self.assertEqual(vars(self.f0), vars(self.f1))
+    # TODO: implement test for equality once objects can be compared
+    # def test_equality(self):
+    # self.assertEqual(vars(self.f0), vars(self.f1))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -7,11 +7,15 @@ import numpy as np
 from chebpy import chebfun
 from chebpy.core.bndfun import Bndfun
 from chebpy.core.settings import DefaultPreferences
-from chebpy.core.utilities import (HTOL, Interval, Domain, compute_breakdata,
-                                   check_funs)
-from chebpy.core.exceptions import (IntervalGap, IntervalOverlap,
-                                    IntervalValues, InvalidDomain,
-                                    SupportMismatch, NotSubdomain)
+from chebpy.core.utilities import HTOL, Interval, Domain, compute_breakdata, check_funs
+from chebpy.core.exceptions import (
+    IntervalGap,
+    IntervalOverlap,
+    IntervalValues,
+    InvalidDomain,
+    SupportMismatch,
+    NotSubdomain,
+)
 
 from .utilities import infnorm
 
@@ -23,34 +27,33 @@ HTOL = HTOL()
 
 # tests for usage of the Interval class
 class TestInterval(unittest.TestCase):
-
     def setUp(self):
-        self.i1 = Interval(-2,3)
-        self.i2 = Interval(-2,3)
-        self.i3 = Interval(-1,1)
-        self.i4 = Interval(-1,2)
+        self.i1 = Interval(-2, 3)
+        self.i2 = Interval(-2, 3)
+        self.i3 = Interval(-1, 1)
+        self.i4 = Interval(-1, 2)
 
     def test_init(self):
-        Interval(-1,1)
-        self.assertTrue((np.asarray(Interval())==np.array([-1,1])).all())
+        Interval(-1, 1)
+        self.assertTrue((np.asarray(Interval()) == np.array([-1, 1])).all())
 
     def test_init_disallow(self):
         self.assertRaises(IntervalValues, Interval, 2, 0)
         self.assertRaises(IntervalValues, Interval, 0, 0)
 
     def test__eq__(self):
-        self.assertTrue(Interval()==Interval())
-        self.assertTrue(self.i1==self.i2)
-        self.assertTrue(self.i2==self.i1)
-        self.assertFalse(self.i3==self.i1)
-        self.assertFalse(self.i2==self.i3)
+        self.assertTrue(Interval() == Interval())
+        self.assertTrue(self.i1 == self.i2)
+        self.assertTrue(self.i2 == self.i1)
+        self.assertFalse(self.i3 == self.i1)
+        self.assertFalse(self.i2 == self.i3)
 
     def test__ne__(self):
-        self.assertFalse(Interval()!=Interval())
-        self.assertFalse(self.i1!=self.i2)
-        self.assertFalse(self.i2!=self.i1)
-        self.assertTrue(self.i3!=self.i1)
-        self.assertTrue(self.i2!=self.i3)
+        self.assertFalse(Interval() != Interval())
+        self.assertFalse(self.i1 != self.i2)
+        self.assertFalse(self.i2 != self.i1)
+        self.assertTrue(self.i3 != self.i1)
+        self.assertTrue(self.i2 != self.i3)
 
     def test__contains__(self):
         self.assertTrue(self.i1 in self.i2)
@@ -64,40 +67,40 @@ class TestInterval(unittest.TestCase):
         self.assertTrue(self.i1 not in self.i3)
         self.assertTrue(self.i1 not in self.i4)
 
-# Interval objects used to have tolerance-sensitive definitions of __eq__ and
-# __contains__, though these were removed in the commit following
-# 9eaf1c5e0674dab1a676d04a02ceda329beec2ea.
-#    def test__eq__close(self):
-#        tol = .8*HTOL
-#        i4 = Interval(-2,5)
-#        i5 = Interval(-2*(1+tol),5*(1-tol))
-#        i6 = Interval(-2*(1+2*tol),5*(1-2*tol))
-#        self.assertEqual(i4,i5)
-#        self.assertNotEqual(i4,i6)
+    # Interval objects used to have tolerance-sensitive definitions of __eq__ and
+    # __contains__, though these were removed in the commit following
+    # 9eaf1c5e0674dab1a676d04a02ceda329beec2ea.
+    #    def test__eq__close(self):
+    #        tol = .8*HTOL
+    #        i4 = Interval(-2,5)
+    #        i5 = Interval(-2*(1+tol),5*(1-tol))
+    #        i6 = Interval(-2*(1+2*tol),5*(1-2*tol))
+    #        self.assertEqual(i4,i5)
+    #        self.assertNotEqual(i4,i6)
 
-#    def test__contains__close(self):
-#        tol = .8*HTOL
-#        i1 = Interval(-1,2)
-#        i2 = Interval(-1-tol,2+2*tol)
-#        i3 = Interval(-1-2*tol,2+4*tol)
-#        self.assertTrue(i1 in i2)
-#        self.assertTrue(i2 in i1)
-#        self.assertFalse(i3 in i1)
+    #    def test__contains__close(self):
+    #        tol = .8*HTOL
+    #        i1 = Interval(-1,2)
+    #        i2 = Interval(-1-tol,2+2*tol)
+    #        i3 = Interval(-1-2*tol,2+4*tol)
+    #        self.assertTrue(i1 in i2)
+    #        self.assertTrue(i2 in i1)
+    #        self.assertFalse(i3 in i1)
 
     def test_maps(self):
         yy = -1 + 2 * np.random.rand(1000)
-        interval = Interval(-2,3)
+        interval = Interval(-2, 3)
         vals = interval.invmap(interval(yy)) - yy
         self.assertLessEqual(infnorm(vals), eps)
 
     def test_isinterior(self):
         npts = 1000
-        x1 = np.linspace(-2, 3,npts)
-        x2 = np.linspace(-3,-2,npts)
-        x3 = np.linspace(3,4,npts)
-        x4 = np.linspace(5,6,npts)
-        interval = Interval(-2,3)
-        self.assertEquals(interval.isinterior(x1).sum(), npts-2)
+        x1 = np.linspace(-2, 3, npts)
+        x2 = np.linspace(-3, -2, npts)
+        x3 = np.linspace(3, 4, npts)
+        x4 = np.linspace(5, 6, npts)
+        interval = Interval(-2, 3)
+        self.assertEquals(interval.isinterior(x1).sum(), npts - 2)
         self.assertEquals(interval.isinterior(x2).sum(), 0)
         self.assertEquals(interval.isinterior(x3).sum(), 0)
         self.assertEquals(interval.isinterior(x4).sum(), 0)
@@ -105,13 +108,12 @@ class TestInterval(unittest.TestCase):
 
 # tests for usage of the Domain class
 class TestDomain(unittest.TestCase):
-
     def test__init__(self):
-        Domain([-2,1])
-        Domain([-2,0,1])
-        Domain(np.array([-2,1]))
-        Domain(np.array([-2,0,1]))
-        Domain(np.linspace(-10,10,51))
+        Domain([-2, 1])
+        Domain([-2, 0, 1])
+        Domain(np.array([-2, 1]))
+        Domain(np.array([-2, 0, 1]))
+        Domain(np.linspace(-10, 10, 51))
 
     def test__init__disallow(self):
         self.assertRaises(InvalidDomain, Domain, [1])
@@ -120,35 +122,44 @@ class TestDomain(unittest.TestCase):
         self.assertRaises(ValueError, Domain, ["a", "b"])
 
     def test__iter__(self):
-        dom_a = Domain([-2,1])
-        dom_b = Domain([-2,0,1])
-        dom_c = Domain([-1,0,1,2])
+        dom_a = Domain([-2, 1])
+        dom_b = Domain([-2, 0, 1])
+        dom_c = Domain([-1, 0, 1, 2])
         res_a = (-2, 1)
         res_b = (-2, 0, 1)
         res_c = (-1, 0, 1, 2)
-        self.assertTrue(all([x==y for x,y in zip(dom_a, res_a)]))
-        self.assertTrue(all([x==y for x,y in zip(dom_b, res_b)]))
-        self.assertTrue(all([x==y for x,y in zip(dom_c, res_c)]))
+        self.assertTrue(all([x == y for x, y in zip(dom_a, res_a)]))
+        self.assertTrue(all([x == y for x, y in zip(dom_b, res_b)]))
+        self.assertTrue(all([x == y for x, y in zip(dom_c, res_c)]))
 
     def test_intervals(self):
-        dom_a = Domain([-2,1])
-        dom_b = Domain([-2,0,1])
-        dom_c = Domain([-1,0,1,2])
-        res_a = [(-2,1)]
-        res_b = [(-2,0), (0,1)]
-        res_c = [(-1,0), (0,1), (1,2)]
-        self.assertTrue(all([itvl==Interval(a,b)
-            for itvl, (a,b) in zip(dom_a.intervals, res_a)]))
-        self.assertTrue(all([itvl==Interval(a,b)
-            for itvl, (a,b) in zip(dom_b.intervals, res_b)]))
-        self.assertTrue(all([itvl==Interval(a,b)
-            for itvl, (a,b) in zip(dom_c.intervals, res_c)]))
+        dom_a = Domain([-2, 1])
+        dom_b = Domain([-2, 0, 1])
+        dom_c = Domain([-1, 0, 1, 2])
+        res_a = [(-2, 1)]
+        res_b = [(-2, 0), (0, 1)]
+        res_c = [(-1, 0), (0, 1), (1, 2)]
+        self.assertTrue(
+            all(
+                [itvl == Interval(a, b) for itvl, (a, b) in zip(dom_a.intervals, res_a)]
+            )
+        )
+        self.assertTrue(
+            all(
+                [itvl == Interval(a, b) for itvl, (a, b) in zip(dom_b.intervals, res_b)]
+            )
+        )
+        self.assertTrue(
+            all(
+                [itvl == Interval(a, b) for itvl, (a, b) in zip(dom_c.intervals, res_c)]
+            )
+        )
 
     def test__contains__(self):
-        d1 = Domain([-2,0,1,3,5])
-        d2 = Domain([-1,2])
-        d3 = Domain(np.linspace(-10,10,1000))
-        d4 = Domain([-1,0,1,2])
+        d1 = Domain([-2, 0, 1, 3, 5])
+        d2 = Domain([-1, 2])
+        d3 = Domain(np.linspace(-10, 10, 1000))
+        d4 = Domain([-1, 0, 1, 2])
         self.assertTrue(d2 in d1)
         self.assertTrue(d1 in d3)
         self.assertTrue(d2 in d3)
@@ -160,57 +171,65 @@ class TestDomain(unittest.TestCase):
         self.assertFalse(d3 in d2)
 
     def test__contains__close(self):
-        tol = .8*HTOL
-        d1 = Domain([-1,2])
-        d2 = Domain([-1-tol,2+2*tol])
-        d3 = Domain([-1-2*tol,2+4*tol])
+        tol = 0.8 * HTOL
+        d1 = Domain([-1, 2])
+        d2 = Domain([-1 - tol, 2 + 2 * tol])
+        d3 = Domain([-1 - 2 * tol, 2 + 4 * tol])
         self.assertTrue(d1 in d2)
         self.assertTrue(d2 in d1)
         self.assertFalse(d3 in d1)
 
     def test__eq__(self):
-        d1 = Domain([-2,0,1,3,5])
-        d2 = Domain([-2,0,1,3,5])
-        d3 = Domain([-1,1])
-        self.assertEqual(d1,d2)
-        self.assertNotEqual(d1,d3)
+        d1 = Domain([-2, 0, 1, 3, 5])
+        d2 = Domain([-2, 0, 1, 3, 5])
+        d3 = Domain([-1, 1])
+        self.assertEqual(d1, d2)
+        self.assertNotEqual(d1, d3)
 
     def test__eq___result_type(self):
-        d1 = Domain([-2,0,1,3,5])
-        d2 = Domain([-2,0,1,3,5])
-        d3 = Domain([-1,1])
-        self.assertIsInstance(d1==d2, bool)
-        self.assertIsInstance(d1==d3, bool)
+        d1 = Domain([-2, 0, 1, 3, 5])
+        d2 = Domain([-2, 0, 1, 3, 5])
+        d3 = Domain([-1, 1])
+        self.assertIsInstance(d1 == d2, bool)
+        self.assertIsInstance(d1 == d3, bool)
 
     def test__eq__close(self):
-        tol = .8*HTOL
-        d4 = Domain([-2,0,1,3,5])
-        d5 = Domain([-2*(1+tol),0-tol,1+tol,3*(1+tol),5*(1-tol)])
-        d6 = Domain([-2*(1+2*tol),0-2*tol,1+2*tol,3*(1+2*tol),5*(1-2*tol)])
-        self.assertEqual(d4,d5)
-        self.assertNotEqual(d4,d6)
+        tol = 0.8 * HTOL
+        d4 = Domain([-2, 0, 1, 3, 5])
+        d5 = Domain([-2 * (1 + tol), 0 - tol, 1 + tol, 3 * (1 + tol), 5 * (1 - tol)])
+        d6 = Domain(
+            [
+                -2 * (1 + 2 * tol),
+                0 - 2 * tol,
+                1 + 2 * tol,
+                3 * (1 + 2 * tol),
+                5 * (1 - 2 * tol),
+            ]
+        )
+        self.assertEqual(d4, d5)
+        self.assertNotEqual(d4, d6)
 
     def test__ne__(self):
-        d1 = Domain([-2,0,1,3,5])
-        d2 = Domain([-2,0,1,3,5])
-        d3 = Domain([-1,1])
-        self.assertFalse(d1!=d2)
-        self.assertTrue(d1!=d3)
+        d1 = Domain([-2, 0, 1, 3, 5])
+        d2 = Domain([-2, 0, 1, 3, 5])
+        d3 = Domain([-1, 1])
+        self.assertFalse(d1 != d2)
+        self.assertTrue(d1 != d3)
 
     def test__ne___result_type(self):
-        d1 = Domain([-2,0,1,3,5])
-        d2 = Domain([-2,0,1,3,5])
-        d3 = Domain([-1,1])
-        self.assertIsInstance(d1!=d2, bool)
-        self.assertIsInstance(d1!=d3, bool)
+        d1 = Domain([-2, 0, 1, 3, 5])
+        d2 = Domain([-2, 0, 1, 3, 5])
+        d3 = Domain([-1, 1])
+        self.assertIsInstance(d1 != d2, bool)
+        self.assertIsInstance(d1 != d3, bool)
 
     def test_from_chebfun(self):
-        ff = chebfun(lambda x: np.cos(x), np.linspace(-10,10,11))
+        ff = chebfun(lambda x: np.cos(x), np.linspace(-10, 10, 11))
         Domain.from_chebfun(ff)
 
     def test_breakpoints_in(self):
-        d1 = Domain([-1,0,1])
-        d2 = Domain([-2,0.5,1,3])
+        d1 = Domain([-1, 0, 1])
+        d2 = Domain([-2, 0.5, 1, 3])
 
         result1 = d1.breakpoints_in(d2)
         self.assertIsInstance(result1, np.ndarray)
@@ -229,78 +248,78 @@ class TestDomain(unittest.TestCase):
 
         self.assertTrue(d1.breakpoints_in(d1).all())
         self.assertTrue(d2.breakpoints_in(d2).all())
-        self.assertFalse(d1.breakpoints_in(Domain([-5,5])).any())
-        self.assertFalse(d2.breakpoints_in(Domain([-5,5])).any())
+        self.assertFalse(d1.breakpoints_in(Domain([-5, 5])).any())
+        self.assertFalse(d2.breakpoints_in(Domain([-5, 5])).any())
 
     def test_breakpoints_in_close(self):
-        tol = .8*HTOL
+        tol = 0.8 * HTOL
         d1 = Domain([-1, 0, 1])
-        d2 = Domain([-2, 0-tol, 1+tol, 3])
+        d2 = Domain([-2, 0 - tol, 1 + tol, 3])
         result = d1.breakpoints_in(d2)
         self.assertFalse(result[0])
         self.assertTrue(result[1])
         self.assertTrue(result[2])
 
     def test_support(self):
-        dom_a = Domain([-2,1])
-        dom_b = Domain([-2,0,1])
-        dom_c = Domain(np.linspace(-10,10,51))
-        self.assertTrue(np.all(dom_a.support.view(np.ndarray)==[-2,1]))
-        self.assertTrue(np.all(dom_b.support.view(np.ndarray)==[-2,1]))
-        self.assertTrue(np.all(dom_c.support.view(np.ndarray)==[-10,10]))
+        dom_a = Domain([-2, 1])
+        dom_b = Domain([-2, 0, 1])
+        dom_c = Domain(np.linspace(-10, 10, 51))
+        self.assertTrue(np.all(dom_a.support.view(np.ndarray) == [-2, 1]))
+        self.assertTrue(np.all(dom_b.support.view(np.ndarray) == [-2, 1]))
+        self.assertTrue(np.all(dom_c.support.view(np.ndarray) == [-10, 10]))
 
     def test_size(self):
-        dom_a = Domain([-2,1])
-        dom_b = Domain([-2,0,1])
-        dom_c = Domain(np.linspace(-10,10,51))
+        dom_a = Domain([-2, 1])
+        dom_b = Domain([-2, 0, 1])
+        dom_c = Domain(np.linspace(-10, 10, 51))
         self.assertEqual(dom_a.size, 2)
         self.assertEqual(dom_b.size, 3)
         self.assertEqual(dom_c.size, 51)
 
     def test_restrict(self):
-        dom_a = Domain([-2,-1,0,1])
-        dom_b = Domain([-1.5,-.5,0.5])
-        dom_c = Domain(np.linspace(-2,1,16))
-        self.assertEqual(dom_a.restrict(dom_b), Domain([-1.5,-1,-.5,0,.5]))
+        dom_a = Domain([-2, -1, 0, 1])
+        dom_b = Domain([-1.5, -0.5, 0.5])
+        dom_c = Domain(np.linspace(-2, 1, 16))
+        self.assertEqual(dom_a.restrict(dom_b), Domain([-1.5, -1, -0.5, 0, 0.5]))
         self.assertEqual(dom_a.restrict(dom_c), dom_c)
         self.assertEqual(dom_a.restrict(dom_a), dom_a)
         self.assertEqual(dom_b.restrict(dom_b), dom_b)
         self.assertEqual(dom_c.restrict(dom_c), dom_c)
         # tests to check if catch breakpoints that are different by eps
         # (linspace introduces these effects)
-        dom_d = Domain(np.linspace(-.4,.4,2))
-        self.assertEqual(dom_c.restrict(dom_d), Domain([-.4,-.2,0,.2,.4]))
+        dom_d = Domain(np.linspace(-0.4, 0.4, 2))
+        self.assertEqual(dom_c.restrict(dom_d), Domain([-0.4, -0.2, 0, 0.2, 0.4]))
 
     def test_restrict_raises(self):
-        dom_a = Domain([-2,-1,0,1])
-        dom_b = Domain([-1.5,-.5,0.5])
-        dom_c = Domain(np.linspace(-2,1,16))
+        dom_a = Domain([-2, -1, 0, 1])
+        dom_b = Domain([-1.5, -0.5, 0.5])
+        dom_c = Domain(np.linspace(-2, 1, 16))
         self.assertRaises(NotSubdomain, dom_b.restrict, dom_a)
         self.assertRaises(NotSubdomain, dom_b.restrict, dom_c)
 
     def test_merge(self):
-        dom_a = Domain([-2,-1,0,1])
-        dom_b = Domain([-1.5,-.5,0.5])
-        self.assertEqual(dom_b.merge(dom_a), Domain([-2,-1.5,-1,-.5,0,.5,1]))
+        dom_a = Domain([-2, -1, 0, 1])
+        dom_b = Domain([-1.5, -0.5, 0.5])
+        self.assertEqual(dom_b.merge(dom_a), Domain([-2, -1.5, -1, -0.5, 0, 0.5, 1]))
 
     def test_union(self):
-        dom_a = Domain([-2,0,2])
-        dom_b = Domain([-2,-1,1,2])
+        dom_a = Domain([-2, 0, 2])
+        dom_b = Domain([-2, -1, 1, 2])
         self.assertNotEqual(dom_a.union(dom_b), dom_a)
         self.assertNotEqual(dom_a.union(dom_b), dom_b)
-        self.assertEqual(dom_a.union(dom_b), Domain([-2,-1,0,1,2]))
-        self.assertEqual(dom_b.union(dom_a), Domain([-2,-1,0,1,2]))
+        self.assertEqual(dom_a.union(dom_b), Domain([-2, -1, 0, 1, 2]))
+        self.assertEqual(dom_b.union(dom_a), Domain([-2, -1, 0, 1, 2]))
 
     def test_union_close(self):
-        tol = .8*HTOL
-        dom_a = Domain([-2,0,2])
-        dom_c = Domain([-2-2*tol,-1+tol,1+tol,2+2*tol])
-        self.assertEqual(dom_a.union(dom_c), Domain([-2,-1,0,1,2]))
-        self.assertEqual(dom_c.union(dom_a), Domain([-2,-1,0,1,2]))
+        tol = 0.8 * HTOL
+        dom_a = Domain([-2, 0, 2])
+        dom_c = Domain([-2 - 2 * tol, -1 + tol, 1 + tol, 2 + 2 * tol])
+        self.assertEqual(dom_a.union(dom_c), Domain([-2, -1, 0, 1, 2]))
+        self.assertEqual(dom_c.union(dom_a), Domain([-2, -1, 0, 1, 2]))
 
     def test_union_raises(self):
-        dom_a = Domain([-2,0])
-        dom_b = Domain([-2,3])
+        dom_a = Domain([-2, 0])
+        dom_b = Domain([-2, 3])
         self.assertRaises(SupportMismatch, dom_a.union, dom_b)
         self.assertRaises(SupportMismatch, dom_b.union, dom_a)
 
@@ -310,11 +329,11 @@ class CheckFuns(unittest.TestCase):
 
     def setUp(self):
         f = lambda x: np.exp(x)
-        self.fun0 = Bndfun.initfun_adaptive(f, Interval(-1,0))
-        self.fun1 = Bndfun.initfun_adaptive(f, Interval(0,1))
-        self.fun2 = Bndfun.initfun_adaptive(f, Interval(-.5,0.5))
-        self.fun3 = Bndfun.initfun_adaptive(f, Interval(2,2.5))
-        self.fun4 = Bndfun.initfun_adaptive(f, Interval(-3,-2))
+        self.fun0 = Bndfun.initfun_adaptive(f, Interval(-1, 0))
+        self.fun1 = Bndfun.initfun_adaptive(f, Interval(0, 1))
+        self.fun2 = Bndfun.initfun_adaptive(f, Interval(-0.5, 0.5))
+        self.fun3 = Bndfun.initfun_adaptive(f, Interval(2, 2.5))
+        self.fun4 = Bndfun.initfun_adaptive(f, Interval(-3, -2))
         self.funs_a = np.array([self.fun1, self.fun0, self.fun2])
         self.funs_b = np.array([self.fun1, self.fun2])
         self.funs_c = np.array([self.fun0, self.fun3])
@@ -322,17 +341,17 @@ class CheckFuns(unittest.TestCase):
 
     def test_verify_empty(self):
         funs = check_funs(np.array([]))
-        self.assertTrue(funs.size==0)
+        self.assertTrue(funs.size == 0)
 
     def test_verify_contiguous(self):
         funs = check_funs(np.array([self.fun0, self.fun1]))
-        self.assertTrue(funs[0]==self.fun0)
-        self.assertTrue(funs[1]==self.fun1)
+        self.assertTrue(funs[0] == self.fun0)
+        self.assertTrue(funs[1] == self.fun1)
 
     def test_verify_sort(self):
         funs = check_funs(np.array([self.fun1, self.fun0]))
-        self.assertTrue(funs[0]==self.fun0)
-        self.assertTrue(funs[1]==self.fun1)
+        self.assertTrue(funs[0] == self.fun0)
+        self.assertTrue(funs[1] == self.fun1)
 
     def test_verify_overlapping(self):
         self.assertRaises(IntervalOverlap, check_funs, self.funs_a)
@@ -345,32 +364,32 @@ class CheckFuns(unittest.TestCase):
 
 # tests for the chebpy.core.utilities compute_breakdata function
 class ComputeBreakdata(unittest.TestCase):
-
     def setUp(self):
         f = lambda x: np.exp(x)
-        self.fun0 = Bndfun.initfun_adaptive(f, Interval(-1,0) )
-        self.fun1 = Bndfun.initfun_adaptive(f, Interval(0,1) )
+        self.fun0 = Bndfun.initfun_adaptive(f, Interval(-1, 0))
+        self.fun1 = Bndfun.initfun_adaptive(f, Interval(0, 1))
 
     def test_compute_breakdata_empty(self):
         breaks = compute_breakdata(np.array([]))
         # list(...) for Python 2/3 compatibility
-        self.assertTrue(np.array(list(breaks.items())).size==0)
+        self.assertTrue(np.array(list(breaks.items())).size == 0)
 
     def test_compute_breakdata_1(self):
         funs = np.array([self.fun0])
         breaks = compute_breakdata(funs)
         x, y = list(breaks.keys()), list(breaks.values())
-        self.assertLessEqual(infnorm(x-np.array([-1,0])), eps)
-        self.assertLessEqual(infnorm(y-np.array([np.exp(-1),
-                                                 np.exp(0)])), 2*eps)
+        self.assertLessEqual(infnorm(x - np.array([-1, 0])), eps)
+        self.assertLessEqual(infnorm(y - np.array([np.exp(-1), np.exp(0)])), 2 * eps)
 
     def test_compute_breakdata_2(self):
         funs = np.array([self.fun0, self.fun1])
         breaks = compute_breakdata(funs)
         x, y = list(breaks.keys()), list(breaks.values())
-        self.assertLessEqual(infnorm(x-np.array([-1,0,1])), eps)
-        self.assertLessEqual(infnorm(y-np.array([np.exp(-1),np.exp(0),
-                                                 np.exp(1)])), 2*eps)
+        self.assertLessEqual(infnorm(x - np.array([-1, 0, 1])), eps)
+        self.assertLessEqual(
+            infnorm(y - np.array([np.exp(-1), np.exp(0), np.exp(1)])), 2 * eps
+        )
+
 
 # reset the testsfun variable so it doesn't get picked up by nose
 testfun = None

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -2,18 +2,23 @@ import numpy as np
 
 eps = np.finfo(float).eps
 
+
 def infnorm(x):
     return np.linalg.norm(x, np.inf)
 
+
 def scaled_tol(n):
-    tol = 5e1*eps if n < 20 else np.log(n)**2.5*eps
+    tol = 5e1 * eps if n < 20 else np.log(n) ** 2.5 * eps
     return tol
+
 
 # bespoke test generators
 def infNormLessThanTol(a, b, tol):
     def asserter(self):
-        self.assertLessEqual(infnorm(a-b), tol)
+        self.assertLessEqual(infnorm(a - b), tol)
+
     return asserter
+
 
 # test functions
 testfunctions = []
@@ -24,13 +29,13 @@ fun_details = [
     #  Matlab chebfun adaptive degree on [-1,1],
     #  Any roots on the real line?
     # )
-    (lambda x: x**3 + x**2 + x + 1.1, 'poly3(x)',        4, True),
-    (lambda x: np.exp(x),             'exp(x)',         15, False),
-    (lambda x: np.sin(x),             'sin(x)',         14, True),
-    (lambda x: .2+.1*np.sin(x),       '(.2+.1*sin(x))', 14, False),
-    (lambda x: np.cos(20*x),          'cos(20x)',       51, True),
-    (lambda x: 0.*x+1.,               'constfun',        1, False),
-    (lambda x: 0.*x,                  'zerofun',         1, True),
+    (lambda x: x ** 3 + x ** 2 + x + 1.1, "poly3(x)", 4, True),
+    (lambda x: np.exp(x), "exp(x)", 15, False),
+    (lambda x: np.sin(x), "sin(x)", 14, True),
+    (lambda x: 0.2 + 0.1 * np.sin(x), "(.2+.1*sin(x))", 14, False),
+    (lambda x: np.cos(20 * x), "cos(20x)", 51, True),
+    (lambda x: 0.0 * x + 1.0, "constfun", 1, False),
+    (lambda x: 0.0 * x, "zerofun", 1, True),
 ]
 for k, items in enumerate(fun_details):
     fun = items[0]
@@ -39,4 +44,3 @@ for k, items in enumerate(fun_details):
 
 # TODO: check these lengths against Chebfun
 # TODO: more examples
-


### PR DESCRIPTION
I've applied `black` to both the source files in `chebpy/` and the tests in `tests/`.

I'm happy with what it does to the source, but not so regarding the tests. I think it's probably fair to revert 69d4c206ec1a6b5f263846bb23ca42d63b1f2e9d and exclude auto-formatting from the test files, where non-compliant formatting is frequently used for legibility.