### PR TITLE
Fixing README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ ax.legend()
 ax.grid(True, alpha=0.3)
 ```
 
+```result
+
+```
+
 ### More Examples
 
 ```python
@@ -133,10 +137,13 @@ g = chebfun(lambda x: x**3 - 2*x - 5, [-3, 3])
 roots = g.roots()         # All roots in the domain
 
 # Function composition
-h = f + g                 # Addition
-product = f * g           # Multiplication
+# h = f + g                 # Addition
+# product = f * g           # Multiplication
 ```
 
+```result
+
+```
 ---
 
 ## Documentation
@@ -190,7 +197,7 @@ Whether you're fixing bugs, adding features, or improving documentation, your he
 - 🤝 [Code of Conduct](CODE_OF_CONDUCT.md)
 - 🐛 [Issue Tracker](https://github.com/chebpy/chebpy/issues)
 
-### Acknowledgments 🙏 
+### Acknowledgments 🙏
 
 - [tschm/.config-templates](https://github.com/tschm/.config-templates) for standardised CI/CD templates and auto-syncing
 


### PR DESCRIPTION
A new convention dictates that a ```python ``` block is followed by a ```result ``` block where all stdout is reported and tested against. Note the the function composition as done in row 140 and 141 of the README file is broken?! @markrichardson 