### PR TITLE
Swap np.sign for pwc and tighten tolerance

### DIFF
--- a/tests/chebfun/test_calculus.py
+++ b/tests/chebfun/test_calculus.py
@@ -298,8 +298,8 @@ class TestChebfunCalculusEdgeCases:
         f = pwc(domain=[-1, 0, 1], values=[-1, 1])
         f_cumsum = f.cumsum()
         # Check continuity at x=0
-        left_val = f_cumsum(-1e-14)
-        right_val = f_cumsum(1e-14)
+        left_val = f_cumsum(-1e-13)
+        right_val = f_cumsum(1e-13)
         # Should be continuous (within tolerance)
         assert np.abs(left_val - right_val) < 1e-12
 


### PR DESCRIPTION
FYI @cmaloney111 

We do not have a slick way of handling `np.sign` yet so switching out the use of it in this test for `pwc`. Although tests were passing they were hiding the following non-convergence behaviour. (We should find a way of explicitly exposing this.)

```
================================================================================================= warnings summary =================================================================================================
tests/chebfun/test_calculus.py::TestChebfunCalculusEdgeCases::test_cumsum_multipiece_continuity
 .../chebpy/src/chebpy/algorithms.py:315: UserWarning: The Chebtech constructor did not converge: using 65537 points
    warnings.warn(f"The {cls.__name__} constructor did not converge: using {n} points")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================
```

Note also we can significantly tightening the tolerance in this case.

