### PR TITLE
CompactFun

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,15 @@ ChebPy is a Python implementation of [Chebfun](http://www.chebfun.org/), bringin
 > **Work with functions as easily as numbers**
 
 - 🔢 **Function Approximation**: Automatic Chebyshev polynomial approximation of smooth functions
+- 🌊 **Periodic Functions**: Fourier-based approximation via `trigfun` for smooth periodic functions
+- ♾️ **Infinite Intervals**: Functions on $[a, \infty)$, $(-\infty, b]$ or the full real line via `CompactFun`
 - 📐 **Calculus Operations**: Differentiation, integration, and root-finding with machine precision
 - 📊 **Plotting**: Beautiful function visualizations with matplotlib integration
 - 🧮 **Arithmetic**: Add, subtract, multiply, and compose functions naturally
 - 🎯 **Adaptive**: Automatically determines optimal polynomial degree for given tolerance
+- 🔁 **Convolution**: Convolve two Chebfuns to produce a new function
+- 📏 **Quasimatrices**: Continuous linear algebra via QR, SVD, and least-squares
+- 🎲 **Gaussian Process Regression**: GP posteriors returned as Chebfun objects
 - 🔗 **Interoperability**: Works seamlessly with NumPy and SciPy ecosystems
 
 ---
@@ -133,10 +138,6 @@ ax.legend()
 ax.grid(True, alpha=0.3)
 ```
 
-```result
-
-```
-
 ### More Examples
 
 ```python
@@ -204,9 +205,47 @@ extrema = f_mean.diff().roots()   # Local extrema via calculus
 integral = f_mean.sum()           # Definite integral
 ```
 
-```result
+### Periodic Functions
 
+Use `trigfun` for smooth periodic functions — the same API as `chebfun`,
+but backed by a Fourier (Trigtech) representation that is far more compact
+for periodic targets:
+
+```python
+from chebpy import trigfun
+import numpy as np
+
+f = trigfun(lambda x: np.exp(np.sin(np.pi * x)), [-1, 1])
+len(f)            # number of Fourier modes
+f.diff()          # spectral differentiation in Fourier space
+f.sum()           # ≈ 2 · I₀(1)
 ```
+
+The `gpr` interface accepts `trig=True` for a periodic GP posterior,
+also returned as a Trigtech-backed Chebfun.
+
+### Infinite Intervals
+
+Pass `np.inf` or `-np.inf` as a domain endpoint to construct a Chebfun
+on a (semi-)infinite interval. Pieces with infinite endpoints are
+automatically built as `CompactFun` objects: a Chebyshev expansion on
+the discovered numerical-support window, reported as identically zero
+outside.
+
+```python
+from chebpy import chebfun
+import numpy as np
+
+# Doubly-infinite Gaussian — sum is √π
+h = chebfun(lambda x: np.exp(-x**2), [-np.inf, np.inf])
+h.sum()                           # ≈ √π
+
+# Mixed: finite breakpoints with infinite endpoints
+p = chebfun(lambda x: np.exp(-x**2), [-np.inf, -2.0, 0.0, 3.0, np.inf])
+[type(piece).__name__ for piece in p.funs]
+# ['CompactFun', 'Bndfun', 'Bndfun', 'CompactFun']
+```
+
 ---
 
 ## Documentation

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,6 +4,10 @@
 
 ::: chebpy.chebfun.Chebfun
 
+::: chebpy.compactfun.CompactFun
+
+::: chebpy.trigtech.Trigtech
+
 ::: chebpy.quasimatrix.Quasimatrix
 
 ::: chebpy.quasimatrix.polyfit

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,8 @@ ChebPy is a Python implementation of [Chebfun](http://www.chebfun.org/), bringin
 ## Features
 
 - **Function Approximation** — Automatic Chebyshev polynomial approximation of smooth functions
+- **Periodic Functions** — Fourier-based approximation via `trigfun` for smooth periodic functions
+- **Infinite Intervals** — Functions on $[a, \infty)$, $(-\infty, b]$ or the full real line via `CompactFun`
 - **Calculus Operations** — Differentiation, integration, and root-finding with machine precision
 - **Plotting** — Beautiful function visualisations with matplotlib integration
 - **Arithmetic** — Add, subtract, multiply, and compose functions naturally

--- a/docs/notebooks/6_gaussian_process.py
+++ b/docs/notebooks/6_gaussian_process.py
@@ -11,7 +11,7 @@
 
 import marimo
 
-__generated_with = "0.21.0"
+__generated_with = "0.23.2"
 app = marimo.App()
 
 with app.setup(hide_code=True):
@@ -196,12 +196,20 @@ def _(fn_mean, fn_var, x_obs, y_noisy):
     _mu = fn_mean(_tt)
     _sd = np.sqrt(np.maximum(fn_var(_tt), 0.0))
 
-    _fig, _ax = plt.subplots()
-    _ax.fill_between(_tt, _mu - 2 * _sd, _mu + 2 * _sd, alpha=0.25, label="±2σ")
-    _ax.plot(_tt, _mu, linewidth=2, label="posterior mean")
-    _ax.plot(x_obs, y_noisy, "ok", markersize=8, label="noisy data")
-    _ax.legend()
-    _ax.set_title("GPR — noisy observations (σ_y = 0.15)")
+    _fig, (_ax1, _ax2) = plt.subplots(2, 1, figsize=(9, 6), height_ratios=[2, 1], sharex=True)
+
+    _ax1.fill_between(_tt, _mu - 2 * _sd, _mu + 2 * _sd, alpha=0.25, label="±2σ")
+    _ax1.plot(_tt, _mu, linewidth=2, label="posterior mean")
+    _ax1.plot(x_obs, y_noisy, "ok", markersize=8, label="noisy data")
+    _ax1.set_ylabel("y")
+    _ax1.legend()
+    _ax1.set_title("GPR — noisy observations (σ_y = 0.15)")
+
+    _ax2.fill_between(_tt, _sd**2, alpha=0.35, color="C1")
+    _ax2.plot(_tt, _sd**2, linewidth=1.5, color="C1")
+    _ax2.set_xlabel("x")
+    _ax2.set_ylabel("variance")
+
     plt.tight_layout()
     plt.show()
     return
@@ -301,15 +309,36 @@ def _(fp_mean, fp_var, x_per, y_per):
     _mu = fp_mean(_tt)
     _sd = np.sqrt(np.maximum(fp_var(_tt), 0.0))
 
-    _fig, _ax = plt.subplots()
-    _ax.fill_between(_tt, _mu - 2 * _sd, _mu + 2 * _sd, alpha=0.25)
-    _ax.plot(_tt, _mu, linewidth=2, label="periodic GP mean")
-    _ax.plot(x_per, y_per, "ok", markersize=8, label="data")
-    _ax.legend()
-    _ax.set_title("GPR — periodic kernel")
-    _ax.set_xlabel("x")
+    _fig, (_ax1, _ax2) = plt.subplots(2, 1, figsize=(9, 6), height_ratios=[2, 1], sharex=True)
+
+    _ax1.fill_between(_tt, _mu - 2 * _sd, _mu + 2 * _sd, alpha=0.25, label="±2σ")
+    _ax1.plot(_tt, _mu, linewidth=2, label="periodic GP mean")
+    _ax1.plot(x_per, y_per, "ok", markersize=8, label="data")
+    _ax1.set_ylabel("y")
+    _ax1.legend()
+    _ax1.set_title("GPR — periodic kernel")
+
+    _ax2.fill_between(_tt, _sd**2, alpha=0.35, color="C1")
+    _ax2.plot(_tt, _sd**2, linewidth=1.5, color="C1")
+    _ax2.set_xlabel("x")
+    _ax2.set_ylabel("variance")
+
     plt.tight_layout()
     plt.show()
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    Note that, as expected, the underlying representation is based on Trigtech.
+    """)
+    return
+
+
+@app.cell
+def _(fp_mean):
+    fp_mean.funs[0].onefun
     return
 
 

--- a/docs/notebooks/8_periodic.py
+++ b/docs/notebooks/8_periodic.py
@@ -1,0 +1,264 @@
+"""Marimo notebook demonstrating periodic (Fourier) function representations in ChebPy."""
+
+# /// script
+# dependencies = ["marimo==0.18.4", "chebfun", "seaborn"]
+# requires-python = ">=3.13"
+#
+# [tool.uv.sources.chebfun]
+# path = "../.."
+# editable = true
+# ///
+
+import marimo
+
+__generated_with = "0.23.2"
+app = marimo.App()
+
+with app.setup:
+    import marimo as mo
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import seaborn as sns
+
+    from chebpy import chebfun, trigfun
+
+    sns.set(font_scale=1.5)
+    sns.set_style("whitegrid")
+    sns.set_palette("deep")
+    mpl.rc("figure", figsize=(9, 5), dpi=100)
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    # Periodic Representations
+
+    For smooth periodic functions on a bounded interval, ChebPy offers a
+    Fourier-based representation via `Trigtech` — the trigonometric analogue
+    of the default `Chebtech`.  The user-facing entry point is
+    [`trigfun`](../api.md), which mirrors `chebfun` exactly but always uses
+    `Trigtech` as the underlying technology.
+
+    Two design points are worth noting up-front:
+
+    - **Periodicity is opted into explicitly** — there is no automatic
+      detection.  This mirrors MATLAB Chebfun's `chebfun(f, 'trig')` while
+      keeping the Python API unambiguous.
+    - **`Trigtech` shares the `Onefun → Smoothfun` interface** with
+      `Chebtech`, so a `trigfun`-backed Chebfun supports all the usual
+      operations (`diff`, `cumsum`, `sum`, `roots`, arithmetic, plotting).
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## A first example: $\cos(\pi x)$ on $[-1, 1]$
+
+    A simple period-2 cosine is captured exactly by a single Fourier mode:
+    """)
+    return
+
+
+@app.cell
+def _():
+    f = trigfun(lambda x: np.cos(np.pi * x), [-1, 1])
+    print(f)
+    print(f"len(f)            = {len(f)}")
+    print(f"f(0.0)            = {f(0.0):+.15f}   (expected  1)")
+    print(f"f(0.5)            = {f(0.5):+.15f}   (expected  0)")
+    print(f"f(1.0)            = {f(1.0):+.15f}   (expected -1)")
+    return (f,)
+
+
+@app.cell
+def _(f):
+    _fig, _ax = plt.subplots()
+    f.plot(ax=_ax)
+    _ax.set_xlabel("x")
+    _ax.set_title(r"$f(x) = \cos(\pi x)$ via $\mathrm{trigfun}$")
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## Compactness vs. Chebyshev
+
+    For a smooth periodic target, a Fourier series typically requires far
+    fewer coefficients than a Chebyshev series of comparable accuracy.
+    Compare the lengths of two representations of the same function:
+    """)
+    return
+
+
+@app.cell
+def _():
+    def target(x):
+        return np.cos(8 * np.pi * x) + np.sin(3 * np.pi * x)
+
+    fc = chebfun(target, [-1, 1])
+    ft = trigfun(target, [-1, 1])
+    print(f"chebfun length   = {len(fc):4d}   (Chebyshev coefficients)")
+    print(f"trigfun length   = {len(ft):4d}   (Fourier coefficients)")
+    _xx = np.linspace(-1.0, 1.0, 4001)
+    _err_c = float(np.max(np.abs(fc(_xx) - target(_xx))))
+    _err_t = float(np.max(np.abs(ft(_xx) - target(_xx))))
+    print(f"max |error|      chebfun = {_err_c:.2e}")
+    print(f"max |error|      trigfun = {_err_t:.2e}")
+    return fc, ft
+
+
+@app.cell
+def _(fc, ft):
+    _fig, _axes = plt.subplots(1, 2, figsize=(12, 4))
+    fc.plotcoeffs(ax=_axes[0])
+    _axes[0].set_title(f"Chebyshev coefficients (n = {len(fc)})")
+    ft.plotcoeffs(ax=_axes[1])
+    _axes[1].set_title(f"Fourier coefficients (n = {len(ft)})")
+    _fig.tight_layout()
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## Calculus in Fourier space
+
+    Differentiation and integration are spectral operations on the Fourier
+    coefficients.  The result of `diff` or `cumsum` is itself a `trigfun`-
+    backed Chebfun:
+    """)
+    return
+
+
+@app.cell
+def _():
+    g = trigfun(lambda x: np.sin(np.pi * x), [-1, 1])
+    dg = g.diff()
+    print(f"sum(g)         = {g.sum():+.15f}   (expected 0)")
+    print(f"dg(0.0)        = {dg(0.0):+.15f}   (expected π = {np.pi:.15f})")
+    print(f"piece tech     = {type(dg.funs[0].onefun).__name__}")
+    return dg, g
+
+
+@app.cell
+def _(dg, g):
+    _fig, _ax = plt.subplots()
+    g.plot(ax=_ax, label=r"$g(x) = \sin(\pi x)$")
+    dg.plot(ax=_ax, label=r"$g'(x) = \pi \cos(\pi x)$")
+    _ax.set_xlabel("x")
+    _ax.legend()
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## Roots of a periodic function
+
+    `roots` works as usual; for $\sin(2\pi x)$ on $[-1, 1]$ we expect roots
+    at $\{-1, -0.5, 0, 0.5, 1\}$:
+    """)
+    return
+
+
+@app.cell
+def _():
+    h = trigfun(lambda x: np.sin(2 * np.pi * x), [-1, 1])
+    print("roots:", np.array2string(h.roots(), precision=12, suppress_small=True))
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## A non-trivial periodic target
+
+    The function $f(x) = e^{\sin(\pi x)}$ is smooth and exactly 2-periodic on
+    $[-1, 1]$.  Its Fourier coefficients decay geometrically:
+    """)
+    return
+
+
+@app.cell
+def _():
+    fp = trigfun(lambda x: np.exp(np.sin(np.pi * x)), [-1, 1])
+    print(fp)
+    print(f"len(fp)        = {len(fp)}")
+    print(f"sum(fp)        = {fp.sum():.15f}   (≈ 2 * I_0(1) = {2.0 * 1.2660658777520084:.15f})")
+    return (fp,)
+
+
+@app.cell
+def _(fp):
+    _fig, _axes = plt.subplots(1, 2, figsize=(12, 4))
+    fp.plot(ax=_axes[0])
+    _axes[0].set_xlabel("x")
+    _axes[0].set_title(r"$f(x) = e^{\sin(\pi x)}$")
+    fp.plotcoeffs(ax=_axes[1])
+    _axes[1].set_title("Fourier coefficient magnitudes")
+    _fig.tight_layout()
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## When *not* to use `trigfun`
+
+    `trigfun` assumes the target is smooth **and** periodic on the requested
+    domain — i.e. $f(a) = f(b)$ along with all relevant derivatives.  If
+    the target violates periodicity, the Fourier series suffers from the
+    Gibbs phenomenon and convergence stalls.  The example below — a
+    non-periodic linear function fit on $[-1, 1]$ as if it were periodic —
+    illustrates the failure mode:
+    """)
+    return
+
+
+@app.cell
+def _():
+    bad = trigfun(lambda x: x, [-1, 1])
+    _xx = np.linspace(-1.0, 1.0, 4001)
+    _err = float(np.max(np.abs(bad(_xx) - _xx)))
+    print(f"len(bad)        = {len(bad)}")
+    print(f"max |bad - x|   = {_err:.2e}    (large — Gibbs)")
+    return (bad,)
+
+
+@app.cell
+def _(bad):
+    _xx = np.linspace(-1.0, 1.0, 2001)
+    _fig, _ax = plt.subplots()
+    _ax.plot(_xx, _xx, color="C0", linewidth=2, label="$x$ (truth)")
+    _ax.plot(_xx, bad(_xx), color="C1", linewidth=1.2, label="trigfun fit")
+    _ax.set_xlabel("x")
+    _ax.set_title("Non-periodic target: Gibbs oscillations near the endpoints")
+    _ax.legend()
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## See also
+
+    - The [Periodic Functions](../user/features/periodic.md) feature page for
+      a written summary of the `trigfun` API.
+    - The [Gaussian Process Regression notebook](6_gaussian_process.html)
+      for `gpr(..., trig=True)`, which produces a periodic posterior backed
+      by `Trigtech`.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/docs/notebooks/9_infinite_intervals.py
+++ b/docs/notebooks/9_infinite_intervals.py
@@ -15,11 +15,17 @@ __generated_with = "0.23.2"
 app = marimo.App()
 
 with app.setup:
+    import math
+
     import marimo as mo
     import matplotlib as mpl
     import matplotlib.pyplot as plt
     import numpy as np
     import seaborn as sns
+
+    from chebpy import chebfun
+    from chebpy.exceptions import CompactFunConstructionError
+    from chebpy.settings import _preferences as prefs
 
     sns.set(font_scale=1.5)
     sns.set_style("whitegrid")
@@ -54,14 +60,6 @@ def _():
     return
 
 
-@app.cell
-def _():
-    from chebpy import chebfun
-    from chebpy.exceptions import CompactFunConstructionError
-
-    return CompactFunConstructionError, chebfun
-
-
 @app.cell(hide_code=True)
 def _():
     mo.md(r"""
@@ -75,12 +73,9 @@ def _():
 
 
 @app.cell
-def _(chebfun):
+def _():
     f_decay = chebfun(lambda x: np.sin(10 * x) * np.exp(-x), [0, np.inf])
-    _a, _b = f_decay.funs[0].numerical_support
-    print(f"Numerical support: [{_a:.3f}, {_b:.3f}]")
-    print(f"Logical support:   {tuple(f_decay.funs[0].support)}")
-    print(f"Length:            {f_decay.funs[0].size}")
+    f_decay
     return (f_decay,)
 
 
@@ -100,10 +95,11 @@ def _(f_decay):
 
 @app.cell
 def _(f_total):
-    _a, _b = f_total.funs[0].numerical_support
-    _xs = np.linspace(0.0, max(_b, 6.0), 800)
     _fig, _ax = plt.subplots()
-    _ax.plot(_xs, f_total(_xs))
+    with prefs:
+        prefs.N_plot = 10001
+        f_total.plot(ax=_ax)
+    _ax.set_xlim(0.0, 8)
     _ax.set_xlabel("x")
     _ax.set_title(r"$f(x) = 0.75 + \sin(10x)/e^x$")
     _fig
@@ -122,11 +118,7 @@ def _():
 
 
 @app.cell
-def _(chebfun):
-    import math
-
-    # Use 1/Γ(x+1) = exp(-lgamma(x+1)) so the probe at large x underflows to 0
-    # cleanly rather than overflowing math.gamma.
+def _():
     _rgamma = np.frompyfunc(lambda y: math.exp(-math.lgamma(y + 1.0)), 1, 1)
     g = chebfun(lambda x: np.asarray(_rgamma(x), dtype=float), [0, np.inf])
     print(g)
@@ -136,10 +128,10 @@ def _(chebfun):
 
 @app.cell
 def _(g):
-    _a, _b = g.funs[0].numerical_support
-    _xs = np.linspace(0.0, _b, 600)
+    _b = float(g.funs[0].numerical_support[1])
     _fig, _ax = plt.subplots()
-    _ax.plot(_xs, g(_xs))
+    g.plot(ax=_ax)
+    _ax.set_xlim(0.0, _b)
     _ax.set_xlabel("x")
     _ax.set_title(r"$g(x) = 1/\Gamma(x+1)$ on $[0, \infty)$")
     _fig
@@ -158,7 +150,7 @@ def _():
 
 
 @app.cell
-def _(chebfun):
+def _():
     h = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, np.inf])
     print(h)
     print(f"sum(h)  = {h.sum():.15f}")
@@ -168,9 +160,9 @@ def _(chebfun):
 
 @app.cell
 def _(h):
-    _xs = np.linspace(-6.0, 6.0, 600)
     _fig, _ax = plt.subplots()
-    _ax.plot(_xs, h(_xs))
+    h.plot(ax=_ax)
+    _ax.set_xlim(-6.0, 6.0)
     _ax.set_xlabel("x")
     _ax.set_title(r"$h(x) = e^{-x^2}$ on $(-\infty, \infty)$")
     _fig
@@ -190,7 +182,7 @@ def _():
 
 
 @app.cell
-def _(chebfun):
+def _():
     pdf = chebfun(lambda x: np.exp(-(x**2) / 2.0) / np.sqrt(2.0 * np.pi), [-np.inf, np.inf])
     pdf2 = pdf.conv(pdf)
     print(f"sum(pdf)        = {pdf.sum():.15f}  (expected 1)")
@@ -203,10 +195,10 @@ def _(chebfun):
 
 @app.cell
 def _(pdf, pdf2):
-    _xs = np.linspace(-6.0, 6.0, 600)
     _fig, _ax = plt.subplots()
-    _ax.plot(_xs, pdf(_xs), label=r"$\phi(x)$ — $\mathcal{N}(0,1)$")
-    _ax.plot(_xs, pdf2(_xs), label=r"$\phi \star \phi$ — $\mathcal{N}(0,2)$")
+    pdf.plot(ax=_ax, label=r"$\phi(x)$ — $\mathcal{N}(0,1)$")
+    pdf2.plot(ax=_ax, label=r"$\phi \star \phi$ — $\mathcal{N}(0,2)$")
+    _ax.set_xlim(-6.0, 6.0)
     _ax.set_xlabel("x")
     _ax.legend()
     _fig
@@ -225,7 +217,7 @@ def _():
 
 
 @app.cell
-def _(chebfun):
+def _():
     expo = chebfun(lambda x: np.exp(-x), [0, np.inf])
     gamma2 = expo.conv(expo)
     print(f"sum(expo*expo)        = {gamma2.sum():.15f}  (expected 1)")
@@ -237,10 +229,10 @@ def _(chebfun):
 
 @app.cell
 def _(expo, gamma2):
-    _xs = np.linspace(0.0, 12.0, 400)
     _fig, _ax = plt.subplots()
-    _ax.plot(_xs, expo(_xs), label=r"$e^{-x}$")
-    _ax.plot(_xs, gamma2(_xs), label=r"$x \, e^{-x}$")
+    expo.plot(ax=_ax, label=r"$e^{-x}$")
+    gamma2.plot(ax=_ax, label=r"$x \, e^{-x}$")
+    _ax.set_xlim(0.0, 12.0)
     _ax.set_xlabel("x")
     _ax.legend()
     _fig
@@ -267,7 +259,7 @@ def _():
 
 
 @app.cell
-def _(CompactFunConstructionError, chebfun):
+def _():
     _refused = []
     for _label, _f in [
         ("Cauchy 1/(π(1+x²))", lambda x: 1.0 / (np.pi * (1.0 + x * x))),
@@ -296,7 +288,7 @@ def _():
 
 
 @app.cell
-def _(chebfun):
+def _():
     p = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, -2.0, 0.0, 3.0, np.inf])
     print(p)
     print(f"piece types: {[type(_piece).__name__ for _piece in p.funs]}")
@@ -307,11 +299,11 @@ def _(chebfun):
 
 @app.cell
 def _(p):
-    _xs = np.linspace(-6.0, 6.0, 600)
     _fig, _ax = plt.subplots()
-    _ax.plot(_xs, p(_xs))
+    p.plot(ax=_ax)
     for _bp in p.breakpoints[1:-1]:
         _ax.axvline(float(_bp), color="grey", linestyle="--", linewidth=0.8)
+    _ax.set_xlim(-6.0, 6.0)
     _ax.set_xlabel("x")
     _ax.set_title("Piecewise Gaussian on $[-\\infty, -2, 0, 3, +\\infty]$")
     _fig

--- a/docs/notebooks/9_infinite_intervals.py
+++ b/docs/notebooks/9_infinite_intervals.py
@@ -1,0 +1,322 @@
+"""Marimo notebook demonstrating CompactFun support for (semi-)infinite intervals."""
+
+# /// script
+# dependencies = ["marimo==0.18.4", "chebfun", "seaborn"]
+# requires-python = ">=3.13"
+#
+# [tool.uv.sources.chebfun]
+# path = "../.."
+# editable = true
+# ///
+
+import marimo
+
+__generated_with = "0.23.2"
+app = marimo.App()
+
+with app.setup:
+    import marimo as mo
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import seaborn as sns
+
+    sns.set(font_scale=1.5)
+    sns.set_style("whitegrid")
+    sns.set_palette("deep")
+    mpl.rc("figure", figsize=(9, 5), dpi=100)
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    # Infinite Intervals
+
+    This notebook revisits §9.1 of the
+    [Chebfun guide](https://www.chebfun.org/docs/guide/guide09.html), adapted to ChebPy's
+    `CompactFun` machinery.  In MATLAB Chebfun, functions on $(-\infty, \infty)$ or
+    $[a, \infty)$ are represented via a rational change of variables that maps the
+    unbounded domain onto $[-1, 1]$.
+
+    ChebPy takes a deliberately different route.  A `CompactFun` is a `Classicfun`
+    on a finite *storage interval* $[a', b']$ where the function is **numerically
+    nonzero**, and is reported as identically zero outside that interval.  The
+    user-facing logical interval may still extend to $\pm\infty$.  This approach
+    has two consequences for the examples below:
+
+    - Functions that decay rapidly to zero (Gaussians, decaying exponentials) are
+      handled cleanly and accurately.
+    - Functions that **don't** decay to zero — heavy tails like $1/(1+x^2)$,
+      slowly-decaying oscillations, or functions approaching a non-zero asymptote
+      like $\tanh$ — are explicitly refused with a
+      `CompactFunConstructionError`.  These cases are out of scope for `v1`.
+    """)
+    return
+
+
+@app.cell
+def _():
+    from chebpy import chebfun
+    from chebpy.exceptions import CompactFunConstructionError
+
+    return CompactFunConstructionError, chebfun
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## A decaying oscillation on $[0, \infty)$
+
+    The Chebfun guide opens with $f(x) = 0.75 + \sin(10x)/e^x$ on $[0, \infty)$.
+    Below we represent the decaying part $\sin(10x)/e^x$ as a `CompactFun` on
+    $[0, \infty)$ and add the constant $0.75$ separately:
+    """)
+    return
+
+
+@app.cell
+def _(chebfun):
+    f_decay = chebfun(lambda x: np.sin(10 * x) * np.exp(-x), [0, np.inf])
+    _a, _b = f_decay.funs[0].numerical_support
+    print(f"Numerical support: [{_a:.3f}, {_b:.3f}]")
+    print(f"Logical support:   {tuple(f_decay.funs[0].support)}")
+    print(f"Length:            {f_decay.funs[0].size}")
+    return (f_decay,)
+
+
+@app.cell
+def _(f_decay):
+    # Find the maximum of 0.75 + sin(10x)/exp(x) on [0, ∞) via critical points.
+    f_total = f_decay + 0.75
+    _crit = f_total.diff().roots()
+    _a, _b = f_decay.funs[0].numerical_support
+    _candidates = np.concatenate([_crit, [_a, _b]])
+    _values = f_total(_candidates)
+    _idx = int(np.argmax(_values))
+    print(f"argmax (in storage window) = {_candidates[_idx]:.15f}")
+    print(f"max value                  = {_values[_idx]:.15f}")
+    return (f_total,)
+
+
+@app.cell
+def _(f_total):
+    _a, _b = f_total.funs[0].numerical_support
+    _xs = np.linspace(0.0, max(_b, 6.0), 800)
+    _fig, _ax = plt.subplots()
+    _ax.plot(_xs, f_total(_xs))
+    _ax.set_xlabel("x")
+    _ax.set_title(r"$f(x) = 0.75 + \sin(10x)/e^x$")
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## $1/\Gamma(x+1)$ on $[0, \infty)$
+
+    Reciprocal-factorial decays super-exponentially, so it is a textbook
+    `CompactFun` candidate:
+    """)
+    return
+
+
+@app.cell
+def _(chebfun):
+    import math
+
+    # Use 1/Γ(x+1) = exp(-lgamma(x+1)) so the probe at large x underflows to 0
+    # cleanly rather than overflowing math.gamma.
+    _rgamma = np.frompyfunc(lambda y: math.exp(-math.lgamma(y + 1.0)), 1, 1)
+    g = chebfun(lambda x: np.asarray(_rgamma(x), dtype=float), [0, np.inf])
+    print(g)
+    print(f"sum(g) = {g.sum():.15f}")
+    return (g,)
+
+
+@app.cell
+def _(g):
+    _a, _b = g.funs[0].numerical_support
+    _xs = np.linspace(0.0, _b, 600)
+    _fig, _ax = plt.subplots()
+    _ax.plot(_xs, g(_xs))
+    _ax.set_xlabel("x")
+    _ax.set_title(r"$g(x) = 1/\Gamma(x+1)$ on $[0, \infty)$")
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## A doubly-infinite Gaussian
+
+    The bread-and-butter case for `CompactFun`: the standard Gaussian on
+    $(-\infty, \infty)$.
+    """)
+    return
+
+
+@app.cell
+def _(chebfun):
+    h = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, np.inf])
+    print(h)
+    print(f"sum(h)  = {h.sum():.15f}")
+    print(f"√π      = {np.sqrt(np.pi):.15f}")
+    return (h,)
+
+
+@app.cell
+def _(h):
+    _xs = np.linspace(-6.0, 6.0, 600)
+    _fig, _ax = plt.subplots()
+    _ax.plot(_xs, h(_xs))
+    _ax.set_xlabel("x")
+    _ax.set_title(r"$h(x) = e^{-x^2}$ on $(-\infty, \infty)$")
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## Convolution: density of the sum of two independent Gaussians
+
+    Because each `CompactFun` lives on a finite storage interval, the existing
+    Hale–Townsend Legendre convolution machinery applies directly.  Convolving the
+    standard Gaussian density with itself produces $\mathcal{N}(0, 2)$:
+    """)
+    return
+
+
+@app.cell
+def _(chebfun):
+    pdf = chebfun(lambda x: np.exp(-(x**2) / 2.0) / np.sqrt(2.0 * np.pi), [-np.inf, np.inf])
+    pdf2 = pdf.conv(pdf)
+    print(f"sum(pdf)        = {pdf.sum():.15f}  (expected 1)")
+    print(f"sum(pdf*pdf)    = {pdf2.sum():.15f}  (expected 1)")
+    _expected = 1.0 / np.sqrt(4.0 * np.pi)
+    print(f"(pdf*pdf)(0)    = {pdf2(0.0):.15f}")
+    print(f"1/sqrt(4*pi)    = {_expected:.15f}")
+    return pdf, pdf2
+
+
+@app.cell
+def _(pdf, pdf2):
+    _xs = np.linspace(-6.0, 6.0, 600)
+    _fig, _ax = plt.subplots()
+    _ax.plot(_xs, pdf(_xs), label=r"$\phi(x)$ — $\mathcal{N}(0,1)$")
+    _ax.plot(_xs, pdf2(_xs), label=r"$\phi \star \phi$ — $\mathcal{N}(0,2)$")
+    _ax.set_xlabel("x")
+    _ax.legend()
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## Sum of two exponentials: Gamma$(2, 1)$
+
+    Convolving $e^{-x}$ on $[0, \infty)$ with itself yields the $\mathrm{Gamma}(2,1)$
+    density $x \, e^{-x}$:
+    """)
+    return
+
+
+@app.cell
+def _(chebfun):
+    expo = chebfun(lambda x: np.exp(-x), [0, np.inf])
+    gamma2 = expo.conv(expo)
+    print(f"sum(expo*expo)        = {gamma2.sum():.15f}  (expected 1)")
+    print(f"(expo*expo)(1)        = {gamma2(1.0):.15f}")
+    print(f"1*exp(-1)             = {np.exp(-1.0):.15f}")
+    print(f"piece types: {[type(_p).__name__ for _p in gamma2.funs]}")
+    return expo, gamma2
+
+
+@app.cell
+def _(expo, gamma2):
+    _xs = np.linspace(0.0, 12.0, 400)
+    _fig, _ax = plt.subplots()
+    _ax.plot(_xs, expo(_xs), label=r"$e^{-x}$")
+    _ax.plot(_xs, gamma2(_xs), label=r"$x \, e^{-x}$")
+    _ax.set_xlabel("x")
+    _ax.legend()
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## What gets refused
+
+    A central design choice of `CompactFun` is to **honestly refuse** inputs that
+    cannot be represented under the numerical-support model.  These are exactly
+    the cases where MATLAB Chebfun's rational map silently produces a result of
+    questionable accuracy:
+
+    - The Cauchy density $\dfrac{1}{\pi(1+x^2)}$ — heavy tails, only $O(1/x^2)$ decay.
+    - $\dfrac{1}{1+|x|}$ — even heavier tails, $O(1/x)$ decay.
+    - $\tanh(x-1)$ — does not decay; approaches $\pm 1$.
+
+    Each of the following raises a `CompactFunConstructionError`:
+    """)
+    return
+
+
+@app.cell
+def _(CompactFunConstructionError, chebfun):
+    _refused = []
+    for _label, _f in [
+        ("Cauchy 1/(π(1+x²))", lambda x: 1.0 / (np.pi * (1.0 + x * x))),
+        ("1/(1+|x|)", lambda x: 1.0 / (1.0 + np.abs(x))),
+        ("tanh(x-1)", lambda x: np.tanh(x - 1.0)),
+    ]:
+        try:
+            chebfun(_f, [-np.inf, np.inf])
+            _refused.append((_label, "ACCEPTED (unexpected)"))
+        except CompactFunConstructionError as _err:
+            _refused.append((_label, str(_err).split(";")[0]))
+    for _label, _message in _refused:
+        print(f"{_label:25s} -> {_message}")
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    ## Mixed piecewise: finite breakpoints with infinite endpoints
+
+    `chebfun(f, [-inf, a₁, …, a_k, +inf])` produces a `Chebfun` whose two outer
+    pieces are `CompactFun` and whose interior pieces are ordinary `Bndfun`s:
+    """)
+    return
+
+
+@app.cell
+def _(chebfun):
+    p = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, -2.0, 0.0, 3.0, np.inf])
+    print(p)
+    print(f"piece types: {[type(_piece).__name__ for _piece in p.funs]}")
+    print(f"sum(p)  = {p.sum():.15f}")
+    print(f"√π      = {np.sqrt(np.pi):.15f}")
+    return (p,)
+
+
+@app.cell
+def _(p):
+    _xs = np.linspace(-6.0, 6.0, 600)
+    _fig, _ax = plt.subplots()
+    _ax.plot(_xs, p(_xs))
+    for _bp in p.breakpoints[1:-1]:
+        _ax.axvline(float(_bp), color="grey", linestyle="--", linewidth=0.8)
+    _ax.set_xlabel("x")
+    _ax.set_title("Piecewise Gaussian on $[-\\infty, -2, 0, 3, +\\infty]$")
+    _fig
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/docs/notebooks/index.md
+++ b/docs/notebooks/index.md
@@ -11,3 +11,4 @@ Interactive Marimo notebooks exploring ChebPy features. Each notebook opens as a
 | [Convolution](5_convolution.html) | Convolution of Chebfuns |
 | [Gaussian Process Regression](6_gaussian_process.html) | GPR via Chebfun representations |
 | [Variance Swap](7_variance_swap.html) | A quantitative finance application |
+| [Infinite Intervals](9_infinite_intervals.html) | `CompactFun` for functions on (semi-)infinite domains |

--- a/docs/notebooks/index.md
+++ b/docs/notebooks/index.md
@@ -11,4 +11,5 @@ Interactive Marimo notebooks exploring ChebPy features. Each notebook opens as a
 | [Convolution](5_convolution.html) | Convolution of Chebfuns |
 | [Gaussian Process Regression](6_gaussian_process.html) | GPR via Chebfun representations |
 | [Variance Swap](7_variance_swap.html) | A quantitative finance application |
+| [Periodic Representations](8_periodic.html) | `trigfun` for smooth periodic functions via Fourier series |
 | [Infinite Intervals](9_infinite_intervals.html) | `CompactFun` for functions on (semi-)infinite domains |

--- a/docs/plans/02-compactfun-integration.md
+++ b/docs/plans/02-compactfun-integration.md
@@ -1,0 +1,347 @@
+# Plan: CompactFun Integration — Light-Tailed Functions on (−∞, ∞)
+
+## Summary
+
+Add support for representing functions on `(−∞, ∞)`, `(−∞, b]`, and `[a, ∞)`
+that decay rapidly enough to have **finite numerical support** at machine
+precision. The new `CompactFun` class is a sibling of `Bndfun` under
+`Classicfun`: it stores a `Onefun` (Chebtech) on a discovered finite storage
+interval `[a, b]` exactly like `Bndfun` does, and adds a separate *logical*
+interval (which may have `±inf` endpoints) that is what the user sees. The
+function reports zero outside `[a, b]`. From the user's perspective the
+function lives on the whole (semi-)real line; internally everything reduces
+to existing bounded machinery.
+
+This is a deliberate departure from MATLAB Chebfun's `@unbndfun` (which uses a
+rational change of variables to map `(−∞, ∞)` onto `[−1, 1]`). The
+rational-map approach is left for a possible future PR; this plan covers the
+practical-use majority case and — critically — gives us **convolution on
+`ℝ`** for free by reusing the existing `_conv_legendre` machinery.
+
+> **Ref (deliberately not followed):** MATLAB Chebfun's `@unbndfun`
+> [`@unbndfun/createMap.m`](https://github.com/chebfun/chebfun/blob/master/%40unbndfun/createMap.m).
+> See [Chebfun guide chapter 9.1](https://www.chebfun.org/docs/guide/guide09.html)
+> for the user-level behaviour we partially mirror.
+
+## What we are NOT doing in this PR
+
+These are explicitly out of scope and deferred to follow-up plans:
+
+1. **Heavy / fat tails** (Cauchy `1/(1 + x²)`, Pareto, Lévy stable, Student-t
+   with low df, anything that does not decay below `tol · vscale` in a
+   finite, modestly-sized window). A separate plan will introduce the
+   appropriate machinery; do not attempt a logarithmic-mesh workaround here.
+2. **Non-zero asymptotic constants** (`tanh`, sigmoids, step-like functions
+   that approach `±1` at infinity). The numerical-support model is only
+   sound when both tail limits are zero; non-zero asymptotes break closure
+   under multiplication and are deferred.
+3. **Singularities / poles / `'exps'` mode.** Independent feature.
+4. **The rational-map `Unbndfun` class.** Possible future addition; not
+   required by anything in this plan.
+5. **Convolution involving non-zero asymptotes** (mathematically ill-posed
+   on `ℝ`).
+
+The scope is intentionally narrow: integrable, light-tailed functions whose
+numerical support comfortably fits in a single `Bndfun`.
+
+## Background
+
+For an integrable `f: ℝ → ℝ` with `lim_{x → ±∞} f(x) = 0` and rapid decay,
+define the numerical support at tolerance `ε`:
+
+$$
+\text{numsupp}_\varepsilon(f) \;=\; [a, b] \quad \text{such that} \quad
+|f(x)| < \varepsilon\,\|f\|_\infty \;\;\forall\, x \notin [a, b].
+$$
+
+For Gaussians, exponentials, sub-exponentials, and any density with
+super-algebraic decay, `numsupp` is finite and modest in width (e.g.
+`[−40, 40]` for a unit Gaussian at `tol = 1e-15`).
+
+Inside `[a, b]`, `f` is approximated by an ordinary `Onefun` (Chebtech) via
+the `Classicfun` mapping plumbing — exactly the same machinery `Bndfun`
+uses. Outside `[a, b]`, `f` is reported as identically zero. From the
+user's perspective:
+
+- `f(x)` evaluates the underlying `Onefun` for `x ∈ [a, b]`, and returns `0`
+  otherwise.
+- `sum(f) = ∫_{-∞}^{∞} f = ∫_a^b f` is computed by the existing
+  `Classicfun.sum` (truncation error bounded by `ε · (b − a)`).
+- `diff(f)`, `roots(f)` reduce to the inherited `Classicfun` operations,
+  with the result extended by `0` outside `[a, b]`.
+- `cumsum(f)` is the one operation that does not close (the result has a
+  non-zero right-tail asymptote `∫f`); it returns a bounded `Chebfun` on
+  `[a, b]` for v1.
+- `conv(f, g)` reuses the existing `_conv_legendre` machinery on the
+  underlying `Onefun`s, with result interval `[a_f + a_g, b_f + b_g]`.
+  This is the headline win.
+
+## Scope
+
+| Area | Detail |
+|------|--------|
+| **New module** | `src/chebpy/compactfun.py` — `CompactFun(Classicfun)` |
+| **New tests** | `tests/test_compactfun.py` parallel of `tests/test_bndfun.py` |
+| **New user API** | `chebfun(f, [-inf, inf])` / `[a, inf]` / `[-inf, b]` returns a `CompactFun`-backed `Chebfun` |
+| **Modified — utilities** | `src/chebpy/utilities.py` — relax `Domain` to allow `±inf` only at the outermost breakpoints; teach `generate_funs` to dispatch to `CompactFun` for unbounded intervals |
+| **Modified — chebfun** | `src/chebpy/chebfun.py` — `conv` accepts `CompactFun` pieces; display; mixed-piece sums |
+| **Modified — settings** | `src/chebpy/settings.py` — `numsupp_tol` (default `prefs.eps`), `numsupp_max_width` (refusal threshold for v1, default `1e6`) |
+| **Modified — exports** | `src/chebpy/__init__.py` — export `CompactFun` |
+
+## Design decisions
+
+1. **`CompactFun` is a sibling of `Bndfun` under `Classicfun`.** It reuses
+   the existing `Classicfun` plumbing (`Onefun` + storage `Interval`,
+   evaluation via `interval.invmap`, calculus via the standard Jacobian)
+   exactly as `Bndfun` does. The only thing that's new is a separate
+   *logical* interval that is what the user sees and what arithmetic with
+   other `CompactFun`s validates against. For `Bndfun` the logical and
+   storage intervals coincide; for `CompactFun` they differ when the
+   logical interval is unbounded.
+
+2. **The logical interval may be unbounded; the storage interval is always
+   finite.** Two attributes:
+   - `self._logical_interval`: what the user sees (e.g. `[-inf, inf]`).
+   - `self._interval`: storage interval `[a, b] = numsupp_ε(f)`, inherited
+     from `Classicfun`.
+   - `self.onefun` is the standard `Onefun` (Chebtech) on `[−1, 1]`,
+     inherited from `Classicfun`.
+
+3. **Numerical-support discovery** is done once at construction time by
+   probing `f(±10^k)` for `k = 0, 1, 2, ...` until `|f| < tol · vscale_so_far`,
+   then refining via bisection. The probing budget is bounded
+   (`prefs.numsupp_max_probes`, default 30). If `tol` is not reached within
+   `prefs.numsupp_max_width`, construction fails with a clear error pointing
+   to the future "heavy tails" facility.
+
+4. **Closure under operations is preserved by recomputing numerical support
+   when needed.**
+   - `f + g`: union of supports, then re-trim to the new numerical support
+     of the sum (since cancellation may shrink it; addition cannot enlarge
+     support beyond the union).
+   - `f * g` (pointwise): intersection of supports (product is zero where
+     either factor is zero); re-trim is unnecessary in the common case.
+   - `α · f`: support unchanged (assuming `α ≠ 0`).
+   - `f.diff()`: support unchanged at construction-tolerance level.
+   - `f.cumsum()`: result has **non-zero left or right asymptotic value**
+     (the integral). `cumsum` is therefore the one operation that does NOT
+     close in `CompactFun` — it returns a regular `Chebfun` on the bounded
+     interval `[a, b]` (supplemented with constant pieces if the user wants
+     `(−∞, ∞)`). For v1 we return the bounded `Chebfun` and document the
+     restriction.
+
+5. **`conv` is implemented via existing `_conv_legendre`** on the
+   underlying `Onefun`s. Result storage interval `[a_f + a_g, b_f + b_g]`.
+   Returned as a `CompactFun` whose logical interval is the union of the
+   inputs' logical intervals (typically `(−∞, ∞)`).
+
+6. **No tech choice for `CompactFun` storage; always Chebtech.** Trigtech is
+   meaningless here (no periodicity).
+
+7. **Construction always begins with a finite-domain probe.** We do not
+   trust the user-supplied `±inf` literally; we always discover numerical
+   support and instantiate the underlying `Onefun` on the discovered finite
+   storage interval. The logical interval keeps the user's requested `±inf`
+   for the lifetime of the object.
+
+8. **Minimal overrides.** Because `CompactFun` reuses the `Classicfun`
+   machinery, only a small set of methods need to be overridden:
+   - `__call__` (return `0` outside the storage interval)
+   - `support` (returns the logical interval, not the storage one)
+   - `endvalues` (returns `0` at any `±inf` endpoint)
+   - `__repr__` (displays the logical interval)
+   - `cumsum` (returns a bounded `Chebfun` on `[a, b]`; documented
+     restriction)
+   - `restrict` and `translate` (need to update both intervals
+     consistently)
+   Everything else — `coeffs`, `size`, `vscale`, `iscomplex`, `+`, `-`,
+   `*`, `**`, `diff`, `roots`, `sum`, `simplify`, plotting — is inherited
+   from `Classicfun` unchanged.
+
+## API surface
+
+### User-facing
+
+```python
+from numpy import inf
+from chebpy import chebfun
+
+# Light-tailed, integrable, decays to zero on both sides → CompactFun
+f = chebfun(lambda x: np.exp(-x**2) / np.sqrt(np.pi), [-inf, inf])
+f.sum()            # ≈ 1
+f(0.0)             # 1/√π
+f(100.0)           # 0   (outside numerical support)
+f.support          # [-inf, inf]    (logical)
+f.numerical_support  # [-a, +a]    (discovered)
+
+# Convolution: this is the headline feature
+g = chebfun(lambda x: np.exp(-x**2) / np.sqrt(np.pi), [-inf, inf])
+h = f.conv(g)      # CompactFun, ≈ exp(-x²/2)/√(2π)
+h.sum()            # ≈ 1
+
+# Heavy tail: explicit refusal in v1
+chebfun(lambda x: 1 / (1 + x**2), [-inf, inf])
+# ConstructorError: numerical support not contained in [-1e6, 1e6] at
+# tolerance 2.22e-16; heavy-tailed inputs are not supported in this
+# release.
+
+# Non-zero asymptote: explicit refusal in v1
+chebfun(lambda x: np.tanh(x), [-inf, inf])
+# ConstructorError: function does not decay to zero at ±∞; non-zero
+# asymptotic limits are not supported in this release.
+```
+
+### New internal classes / functions
+
+| Symbol | Location | Purpose |
+|---|---|---|
+| `CompactFun(Classicfun)` | `compactfun.py` | New sibling of `Bndfun`; adds a logical (possibly unbounded) interval on top of the standard `Classicfun` storage |
+| `CompactFun.initfun_adaptive(f, interval)` | `compactfun.py` | Adaptive constructor; runs numsupp discovery, then calls the inherited `Classicfun.initfun_adaptive` on the discovered storage interval |
+| `CompactFun.initfun_fixedlen(f, interval, n)` | `compactfun.py` | Fixed-length variant (numsupp discovery still runs) |
+| `CompactFun.initconst(c, interval)` | `compactfun.py` | Constant on unbounded interval — only `c == 0` allowed (else error) |
+| `CompactFun.numerical_support` | `compactfun.py` | Property returning the storage interval `[a, b]` |
+| `_discover_numsupp(f, interval, tol, max_width)` | `compactfun.py` | Probe-and-bisect helper |
+
+## Integration steps
+
+1. **Foundations — `utilities.py`**
+   - Relax `Domain` to accept `±inf` at the outermost breakpoints (interior
+     breakpoints must remain finite).
+   - Update `generate_funs` to inspect each interval: if both endpoints are
+     finite, dispatch to `Bndfun.initfun_*` as today; if either endpoint is
+     `±inf`, dispatch to `CompactFun.initfun_*`.
+   - Update `check_funs` and `compute_breakdata` so that `±inf` outer
+     endpoints don't trigger the existing "must average endpoint values"
+     code (we report `0` at `±inf`).
+
+2. **`CompactFun` class — `compactfun.py`**
+   - Subclass `Classicfun`, sibling of `Bndfun`. Add
+     `self._logical_interval` alongside the inherited `self._interval`
+     (storage) and `self.onefun`.
+   - Override `__init__(onefun, storage_interval, logical_interval)` to
+     accept the logical interval; default it to the storage interval if
+     not supplied (so a `CompactFun` constructed with a finite logical
+     interval behaves identically to a `Bndfun`).
+   - Override `__call__(x)`: zero outside the storage interval; inside,
+     delegate to the inherited evaluation path (`self.interval.invmap` +
+     `self.onefun(y)`).
+   - Override `support` (returns logical interval), `endvalues` (returns
+     `0` at any `±inf` endpoint, evaluates normally at finite endpoints),
+     `__repr__`.
+   - Override `cumsum` to return a bounded `Chebfun` on the storage
+     interval; document the restriction.
+   - Override `restrict` and `translate` to keep the logical and storage
+     intervals consistent.
+   - Implement `_discover_numsupp(f, interval, tol, max_width)`:
+     - Probe at `x = ±10^k` for `k = 0..K` (with sign chosen by which side
+       of the interval is unbounded).
+     - Track a running `vscale = max |f(probe)|`.
+     - Identify the largest `k` with `|f| > tol · vscale`; set the outer
+       endpoint a small multiple beyond that.
+     - Bisect to refine the boundary.
+     - Verify by sampling within (catch missed bumps): if any sample inside
+       `[a, b]` exceeds `vscale`, expand and retry; if budget exhausted,
+       error.
+     - For semi-infinite intervals, only the unbounded side is discovered;
+       the finite endpoint is kept verbatim.
+
+3. **`Chebfun` integration — `chebfun.py`**
+   - `Chebfun.conv` currently dispatches on `Bndfun` only. Extend it to
+     handle the case where one or both `funs` are `CompactFun`s: the
+     existing equal-width / piecewise paths apply directly to the
+     underlying `Onefun`s and storage intervals; wrap the result as a
+     `CompactFun` whose logical interval is `[−inf, +inf]` (or the
+     appropriate semi-infinite combination).
+   - Update display so unbounded pieces print the logical interval
+     (e.g. `[ -inf, +inf ]    13`).
+   - Sums / arithmetic across a chebfun with mixed bounded and `CompactFun`
+     pieces: the existing piece-by-piece machinery should work because
+     `CompactFun` exposes the same `Classicfun` interface; only operations
+     that compare `support` need to be aware that two `CompactFun`s with
+     differing storage but matching logical intervals are compatible.
+
+   **Piecewise `conv` involving `CompactFun` pieces.** A user-supplied
+   piecewise density on `ℝ` (e.g.
+   `chebfun(f, domain=[-inf, -2, 0, 3, +inf])`) yields a chebfun whose
+   outer pieces are `CompactFun` and interior pieces are `Bndfun`.
+   Convolving two such chebfuns must produce a result whose breakpoints are
+   the pairwise sums of the input breakpoints; with `±inf` endpoints these
+   sums collapse correctly to `[-inf, ..., +inf]` thanks to IEEE arithmetic
+   (`-inf + finite = -inf`, etc.). The required adjustments are:
+   - **Equal-width fast path:** add a guard that skips the fast path when
+     either piece is a `CompactFun` (logical width `inf`); fall through to
+     the general piecewise path.
+   - **General `_conv_piecewise`:** when computing integration limits for a
+     sub-interval that touches a `CompactFun` piece, use the piece's
+     **storage interval** (i.e. its discovered numerical support), not its
+     logical interval. This is consistent with `__call__`, which reports
+     zero outside the storage interval.
+   - **Output piece dispatch:** an output piece is wrapped as `CompactFun`
+     iff at least one of its breakpoints is `±inf`; otherwise as `Bndfun`.
+     Numerical support of each `CompactFun` output piece is discovered from
+     the constructed `Onefun` exactly as in standalone construction.
+
+4. **Settings — `settings.py`**
+   - `prefs.numsupp_tol = prefs.eps` (default tolerance for numerical
+     support discovery; users can tighten/loosen).
+   - `prefs.numsupp_max_width = 1e6` (refusal threshold for v1).
+   - `prefs.numsupp_max_probes = 30` (probing budget).
+
+5. **Exports — `__init__.py`**
+   - Export `CompactFun`.
+
+6. **Tests — `tests/test_compactfun.py`**
+   - **Construction**: Gaussian, exp(−x), exp(−|x|), bump function — verify
+     discovered support is sensible and `f(x_far)` returns `0`.
+   - **Round-trip evaluation**: `f(x) ≈ ground_truth(x)` for `x` inside and
+     outside numerical support.
+   - **Calculus**: `sum` against analytic answers (`∫e^{−x²}dx = √π`,
+     `∫_0^∞ e^{−x}dx = 1`, etc.); `diff` round-trip
+     (`f.diff().cumsum()` ≈ `f − f(a)`).
+   - **Convolution** (the headline test):
+     - Two unit Gaussians convolve to `N(0, 2)` density.
+     - Two unit-rate exponentials on `[0, ∞)` convolve to a Gamma(2, 1)
+       density.
+     - `f.conv(g).sum() == f.sum() * g.sum()` for any two `CompactFun`s.
+   - **Algebra**: `CompactFun + CompactFun`, `CompactFun + scalar`,
+     `CompactFun * CompactFun` (product of two Gaussians).
+   - **Error paths**:
+     - `1/(1+x²)` on `[-inf, inf]`: refuse with heavy-tail message.
+     - `tanh(x)` on `[-inf, inf]`: refuse with non-zero-asymptote message.
+     - `initconst(c≠0, [-inf, inf])`: refuse.
+   - **Mixed-domain `Chebfun`**: not in v1 (interior breakpoints must remain
+     finite, and a chebfun cannot mix `CompactFun` pieces with bounded
+     pieces in the same object except as outermost segments — defer until
+     there's a use case).
+
+## Out of scope (deferred)
+
+- Heavy-tailed distributions (Cauchy, Pareto, etc.).
+- Non-zero asymptotic limits (`tanh`-like).
+- The rational-map `Unbndfun` (Chebfun's `@unbndfun`).
+- `cumsum` returning a `CompactFun` (would need either non-zero asymptote
+  support or a sentinel right-tail constant).
+- Mixed `Chebfun`s combining bounded and unbounded segments.
+- `'splitting on'`, `blowup`, `'exps'`.
+
+## Risks & open questions
+
+- **Numerical-support discovery may miss bumps far from origin.** Mitigation:
+  the verification step samples within the discovered support and expands
+  if any sample exceeds `vscale`. This is heuristic but matches Chebfun's
+  general philosophy.
+- **`f * g` pointwise can have larger numerical support than expected if
+  the factors' tails interact.** Closure is preserved (product is bounded
+  by both factors), but the discovered support of the product may need
+  re-discovery. We will recompute numsupp on the product result.
+- **Refusing heavy tails is a UX choice.** We must produce a clear,
+  actionable error message rather than silently truncating. The error
+  should mention that a future release will handle these cases.
+- **`cumsum` not closing under `CompactFun` is unfortunate** but
+  unavoidable without asymptotic-constants metadata. Documenting clearly
+  that `cumsum` returns a bounded `Chebfun` is acceptable for v1.
+
+## Dependencies
+
+- Builds on existing `Bndfun`, `Chebtech`, and `_conv_legendre` machinery.
+- Independent of any trigtech / singfun / unbndfun work.

--- a/docs/user/features/infinite-intervals.md
+++ b/docs/user/features/infinite-intervals.md
@@ -1,0 +1,91 @@
+# Infinite Intervals
+
+ChebPy supports functions defined on semi-infinite intervals $[a, \infty)$,
+$(-\infty, b]$ or the full real line $(-\infty, \infty)$ through the
+`CompactFun` class.
+
+## Usage
+
+Pass a domain containing `np.inf` or `-np.inf` to `chebfun`:
+
+```python
+import numpy as np
+from chebpy import chebfun
+
+# A doubly-infinite Gaussian
+f = chebfun(lambda x: np.exp(-x**2), [-np.inf, np.inf])
+
+# Decaying oscillation on [0, ∞)
+g = chebfun(lambda x: np.sin(10 * x) * np.exp(-x), [0, np.inf])
+
+# Standard operations work transparently
+g.sum()       # definite integral over [0, ∞)
+g.diff()      # derivative
+g.roots()     # roots within numerical support
+```
+
+Pieces with infinite endpoints are automatically constructed as `CompactFun`
+objects, while interior pieces remain ordinary `Bndfun`s:
+
+```python
+p = chebfun(lambda x: np.exp(-x**2), [-np.inf, -2.0, 0.0, 3.0, np.inf])
+print([type(piece).__name__ for piece in p.funs])
+# ['CompactFun', 'Bndfun', 'Bndfun', 'CompactFun']
+```
+
+## How it works
+
+`CompactFun` represents a function whose **logical** interval may extend to
+$\pm\infty$, but whose **numerical support** — the set of points where
+the function is non-negligible relative to tolerance — is finite. At
+construction time, ChebPy probes the function geometrically outward from
+the finite anchor to discover the storage interval, then represents the
+function as a standard Chebyshev expansion on that interval. Outside the
+storage interval the function is reported as identically zero.
+
+This is a deliberate departure from MATLAB Chebfun's `@unbndfun`, which
+applies a rational change of variables $[a, \infty) \to [-1, 1]$. The
+numerical-support approach has two consequences:
+
+- **Decaying functions** (Gaussians, $e^{-x}$, $1/\Gamma(x+1)$) are handled
+  cleanly and accurately, and benefit directly from the existing
+  Hale–Townsend Legendre convolution machinery.
+- **Heavy-tailed or non-decaying functions** — $1/(1+x^2)$, $\tanh(x)$,
+  $1/(1+|x|)$ — are explicitly **refused** with a
+  `CompactFunConstructionError` rather than silently approximated.
+
+## What gets refused
+
+```python
+from chebpy.exceptions import CompactFunConstructionError
+
+for f in [
+    lambda x: 1.0 / (np.pi * (1.0 + x * x)),   # Cauchy density: O(1/x²) decay
+    lambda x: 1.0 / (1.0 + np.abs(x)),          # O(1/x) decay
+    lambda x: np.tanh(x - 1.0),                 # does not decay
+]:
+    try:
+        chebfun(f, [-np.inf, np.inf])
+    except CompactFunConstructionError as err:
+        print(err)
+```
+
+## Convolution
+
+Because each `CompactFun` lives on a finite storage interval, convolution
+works directly. For example, convolving the standard Gaussian density
+with itself yields $\mathcal{N}(0, 2)$:
+
+```python
+pdf = chebfun(lambda x: np.exp(-x**2 / 2) / np.sqrt(2 * np.pi),
+              [-np.inf, np.inf])
+pdf2 = pdf.conv(pdf)
+pdf2.sum()    # ≈ 1
+pdf2(0.0)     # ≈ 1 / sqrt(4π)
+```
+
+## See also
+
+- The [Infinite Intervals notebook](../../notebooks/9_infinite_intervals.html)
+  for a tour of worked examples adapted from §9.1 of the Chebfun guide.
+- The [Convolution](convolution.md) page for finite-interval convolution.

--- a/docs/user/features/periodic.md
+++ b/docs/user/features/periodic.md
@@ -1,0 +1,81 @@
+# Periodic Functions
+
+For smooth periodic functions, ChebPy provides Fourier-based approximation
+through `Trigtech` — the trigonometric analogue of the default `Chebtech`
+representation. The two technologies share the same `Onefun → Smoothfun`
+interface, so periodic Chebfuns interoperate transparently with the rest of
+ChebPy.
+
+## The `trigfun` constructor
+
+`trigfun` is the explicit user-facing entry point for periodic functions.
+It mirrors `chebfun` exactly but always uses `Trigtech` as the underlying
+approximation technology.
+
+```python
+import numpy as np
+from chebpy import trigfun
+
+f = trigfun(lambda x: np.cos(np.pi * x), [-1, 1])
+g = trigfun(lambda x: np.sin(2 * np.pi * x))
+```
+
+The user is responsible for ensuring that `f` is smooth and periodic on the
+given domain. There is no automatic detection — periodicity is opted into
+explicitly. This mirrors MATLAB Chebfun's `chebfun(f, 'trig')` while keeping
+the Python API unambiguous.
+
+### Special constructors
+
+The same shorthand forms as `chebfun` are supported:
+
+```python
+trigfun()               # empty Chebfun
+trigfun(3.14)            # constant function
+trigfun(lambda x: np.sin(np.pi * x), n=16)   # fixed number of Fourier modes
+```
+
+## Why use `trigfun`?
+
+For a smooth periodic function, a Fourier series typically requires far
+fewer coefficients than a Chebyshev series of comparable accuracy. As a
+result `trigfun` approximations are more compact and cheaper to evaluate,
+differentiate, and integrate.
+
+```python
+import numpy as np
+from chebpy import chebfun, trigfun
+
+f = lambda x: np.cos(8 * np.pi * x) + np.sin(3 * np.pi * x)
+
+fc = chebfun(f, [-1, 1])
+ft = trigfun(f, [-1, 1])
+
+len(fc)   # Chebyshev degree
+len(ft)   # number of Fourier modes
+```
+
+## Calculus and arithmetic
+
+All standard Chebfun operations work on periodic Chebfuns:
+
+```python
+f = trigfun(lambda x: np.sin(np.pi * x), [-1, 1])
+
+df = f.diff()        # spectral differentiation in Fourier space
+F = f.cumsum()       # antiderivative
+total = f.sum()      # ≈ 0
+```
+
+## Periodic Gaussian process regression
+
+The `gpr` interface accepts a `trig=True` flag that produces a posterior
+backed by `Trigtech`. See the
+[Gaussian Process Regression notebook](../../notebooks/6_gaussian_process.html)
+for a worked example.
+
+## See also
+
+- [`Trigtech` API reference](../../api.md)
+- The [Function Approximation](approximation.md) page for the default
+  Chebyshev-based construction.

--- a/docs/user/intro.md
+++ b/docs/user/intro.md
@@ -22,11 +22,15 @@ ChebPy uses a layered class hierarchy:
 | Layer | Class | Purpose |
 |-------|-------|---------|
 | Top | `Chebfun` | Piecewise function on arbitrary intervals |
-| Middle | `Bndfun` / `Classicfun` | Function on a single bounded interval $[a, b]$ |
-| Base | `Chebtech` | Chebyshev expansion on the canonical interval $[-1, 1]$ |
+| Middle | `Classicfun` (`Bndfun` / `CompactFun`) | Function on a single (possibly infinite) interval |
+| Base | `Chebtech` / `Trigtech` | Chebyshev or Fourier expansion on the canonical interval $[-1, 1]$ |
 
-A `Chebfun` consists of one or more `Bndfun` pieces, each of which maps its
-interval to $[-1, 1]$ and delegates to a `Chebtech` for all the numerical work.
+A `Chebfun` consists of one or more `Classicfun` pieces. Each piece maps its
+interval to $[-1, 1]$ and delegates to a `Smoothfun` (`Chebtech` for the
+default polynomial representation, or `Trigtech` for periodic
+[Fourier-based approximation](features/periodic.md)). Pieces with one or
+both endpoints at $\pm\infty$ are represented as
+[`CompactFun`s](features/infinite-intervals.md).
 
 ## Core Concepts
 

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -75,6 +75,24 @@ f.plot()
 plt.show()
 ```
 
+## Beyond polynomials and bounded intervals
+
+ChebPy also handles smooth periodic functions and (semi-)infinite domains:
+
+```python
+from chebpy import chebfun, trigfun
+
+# Fourier-based approximation for smooth periodic functions
+p = trigfun(lambda x: np.cos(np.pi * x), [-1, 1])
+
+# Functions on (-∞, ∞) via numerical-support truncation
+g = chebfun(lambda x: np.exp(-x**2), [-np.inf, np.inf])
+g.sum()    # ≈ √π
+```
+
+See [Periodic Functions](features/periodic.md) and
+[Infinite Intervals](features/infinite-intervals.md) for details.
+
 ## What's Next?
 
 - [User Guide](intro.md) — deeper introduction to ChebPy concepts

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,8 @@ nav:
       - Installation: user/install.md
       - Features:
           - Function Approximation: user/features/approximation.md
+          - Periodic Functions: user/features/periodic.md
+          - Infinite Intervals: user/features/infinite-intervals.md
           - Calculus: user/features/calculus.md
           - Root-Finding: user/features/rootfinding.md
           - Arithmetic: user/features/arithmetic.md
@@ -80,6 +82,8 @@ nav:
       - Convolution: notebooks/5_convolution.html
       - Gaussian Process Regression: notebooks/6_gaussian_process.html
       - Variance Swap: notebooks/7_variance_swap.html
+      - Periodic Representations: notebooks/8_periodic.html
+      - Infinite Intervals: notebooks/9_infinite_intervals.html
   - Developer:
       - Contributing: CONTRIBUTING.md
       - Code of Conduct: CODE_OF_CONDUCT.md

--- a/src/chebpy/__init__.py
+++ b/src/chebpy/__init__.py
@@ -21,10 +21,22 @@ Main components and modules:
 import importlib.metadata
 
 from .api import chebfun, chebpts, pwc, trigfun
+from .compactfun import CompactFun
 from .gpr import gpr
 from .quasimatrix import Quasimatrix, polyfit
 from .settings import ChebPreferences as UserPreferences
 from .trigtech import Trigtech
 
-__all__ = ["Quasimatrix", "Trigtech", "UserPreferences", "chebfun", "chebpts", "gpr", "polyfit", "pwc", "trigfun"]
+__all__ = [
+    "CompactFun",
+    "Quasimatrix",
+    "Trigtech",
+    "UserPreferences",
+    "chebfun",
+    "chebpts",
+    "gpr",
+    "polyfit",
+    "pwc",
+    "trigfun",
+]
 __version__ = importlib.metadata.version("chebfun")

--- a/src/chebpy/chebfun.py
+++ b/src/chebpy/chebfun.py
@@ -1352,6 +1352,11 @@ class Chebfun:
         This method plots the Chebfun over its domain using matplotlib.
         For complex-valued Chebfuns, it plots the real part against the imaginary part.
 
+        For Chebfuns with ``±inf`` endpoints (containing :class:`CompactFun`
+        pieces), each unbounded endpoint is replaced for plotting purposes
+        with the corresponding ``plot_support`` endpoint of the outermost
+        :class:`CompactFun` piece, so the decay-to-zero region is visible.
+
         Args:
             ax (matplotlib.axes.Axes, optional): The axes on which to plot. If None,
                 a new axes will be created. Defaults to None.
@@ -1360,7 +1365,15 @@ class Chebfun:
         Returns:
             matplotlib.axes.Axes: The axes on which the plot was created.
         """
-        return plotfun(self, self.support, ax=ax, **kwds)
+        a, b = float(self.support[0]), float(self.support[-1])
+        if not np.isfinite(a):
+            left = self.funs[0]
+            a = float(left.plot_support[0]) if hasattr(left, "plot_support") else a
+        if not np.isfinite(b):
+            right = self.funs[-1]
+            b = float(right.plot_support[1]) if hasattr(right, "plot_support") else b
+        support = kwds.pop("support", (a, b))
+        return plotfun(self, support, ax=ax, **kwds)
 
     def plotcoeffs(self, ax: Axes | None = None, **kwds: Any) -> Axes:
         """Plot the coefficients of the Chebfun on a semilogy scale.

--- a/src/chebpy/chebfun.py
+++ b/src/chebpy/chebfun.py
@@ -918,8 +918,15 @@ class Chebfun:
                 "not yet implemented."
             )
 
-        # Fast path: both single-piece with equal-width domains
-        if self.funs.size == 1 and g.funs.size == 1:
+        # Fast path: both single-piece with equal-width finite domains.
+        # CompactFun pieces (with possibly infinite logical support) always
+        # take the general piecewise path so the output is wrapped correctly.
+        from .compactfun import CompactFun
+
+        any_compact = any(isinstance(fun, CompactFun) for fun in self.funs) or any(
+            isinstance(fun, CompactFun) for fun in g.funs
+        )
+        if not any_compact and self.funs.size == 1 and g.funs.size == 1:
             f_fun, g_fun = self.funs[0], g.funs[0]
             f_w = float(f_fun.support[1]) - float(f_fun.support[0])
             g_w = float(g_fun.support[1]) - float(g_fun.support[0])
@@ -967,10 +974,31 @@ class Chebfun:
 
         The breakpoints of the result are the sorted, unique pairwise sums of
         the breakpoints of self and g.  On each sub-interval the convolution
-        integral is smooth, so we construct it adaptively.
+        integral is smooth, so we construct it adaptively.  When either input
+        contains :class:`CompactFun` pieces, the corresponding ``±inf``
+        breakpoints are replaced with the numerical-support bounds for the
+        purposes of integration; the outermost output pieces are then wrapped
+        as :class:`CompactFun` so the result preserves the unbounded logical
+        support.
         """
-        f_breaks = self.breakpoints
-        g_breaks = g.breakpoints
+        from .compactfun import CompactFun
+
+        def _effective_breakpoints(h: Chebfun) -> np.ndarray:
+            """Return breakpoints with ±inf replaced by numerical_support bounds."""
+            bps = np.array(h.breakpoints, dtype=float)
+            if not np.isfinite(bps[0]) and isinstance(h.funs[0], CompactFun):
+                bps[0] = float(h.funs[0].numerical_support[0])
+            if not np.isfinite(bps[-1]) and isinstance(h.funs[-1], CompactFun):
+                bps[-1] = float(h.funs[-1].numerical_support[1])
+            return bps
+
+        f_logical_breaks = np.array(self.breakpoints, dtype=float)
+        g_logical_breaks = np.array(g.breakpoints, dtype=float)
+        left_inf = (not np.isfinite(f_logical_breaks[0])) or (not np.isfinite(g_logical_breaks[0]))
+        right_inf = (not np.isfinite(f_logical_breaks[-1])) or (not np.isfinite(g_logical_breaks[-1]))
+
+        f_breaks = _effective_breakpoints(self)
+        g_breaks = _effective_breakpoints(g)
         f_a, f_b = float(f_breaks[0]), float(f_breaks[-1])
         g_c, g_d = float(g_breaks[0]), float(g_breaks[-1])
 
@@ -1024,12 +1052,26 @@ class Chebfun:
                 result[idx] = total
             return result
 
-        # Build a Bndfun on each output sub-interval
+        # Build a fun on each output sub-interval.  Outermost pieces are
+        # wrapped as CompactFun when the corresponding logical edge is ±inf;
+        # interior pieces are always finite Bndfuns.
+        n_pieces = len(out_breaks) - 1
         funs_list = []
-        for i in range(len(out_breaks) - 1):
-            interval = Interval(out_breaks[i], out_breaks[i + 1])
-            fun = Bndfun.initfun_adaptive(conv_eval, interval)
-            funs_list.append(fun)
+        for i in range(n_pieces):
+            a_storage = float(out_breaks[i])
+            b_storage = float(out_breaks[i + 1])
+            interval = Interval(a_storage, b_storage)
+            bnd = Bndfun.initfun_adaptive(conv_eval, interval)
+            is_first = i == 0
+            is_last = i == n_pieces - 1
+            wrap_left = is_first and left_inf
+            wrap_right = is_last and right_inf
+            if wrap_left or wrap_right:
+                a_logical = -np.inf if wrap_left else a_storage
+                b_logical = np.inf if wrap_right else b_storage
+                funs_list.append(CompactFun(bnd.onefun, interval, logical_interval=(a_logical, b_logical)))
+            else:
+                funs_list.append(bnd)
 
         return self.__class__(funs_list)
 

--- a/src/chebpy/chebfun.py
+++ b/src/chebpy/chebfun.py
@@ -239,7 +239,8 @@ class Chebfun:
 
         # evaluate a fun when x is an interior point
         for fun in self:
-            idx = fun.interval.isinterior(x)
+            sa, sb = fun.support[0], fun.support[-1]
+            idx = np.logical_and(sa < x, x < sb)
             out[idx] = fun(x[idx])
 
         # evaluate the breakpoint data for x at a breakpoint

--- a/src/chebpy/classicfun.py
+++ b/src/chebpy/classicfun.py
@@ -157,6 +157,22 @@ class Classicfun(Fun, ABC):
         self.onefun = onefun
         self._interval = interval
 
+    def _rebuild(self, onefun: Any) -> "Classicfun":
+        """Construct a new instance of this class with a replacement ``onefun``.
+
+        Subclasses that carry additional metadata beyond ``onefun`` and
+        ``interval`` (e.g. :class:`CompactFun`'s logical interval) should
+        override this method so that operations defined on the parent class
+        preserve that metadata.
+
+        Args:
+            onefun: The replacement Onefun object.
+
+        Returns:
+            Classicfun: A new instance of ``type(self)``.
+        """
+        return self.__class__(onefun, self._interval)
+
     def __repr__(self) -> str:  # pragma: no cover
         """Return a string representation of the function.
 
@@ -299,7 +315,7 @@ class Classicfun(Fun, ABC):
             Classicfun: A new function representing the imaginary part of this function.
         """
         if self.iscomplex:
-            return self.__class__(self.onefun.imag(), self.interval)
+            return self._rebuild(self.onefun.imag())
         else:
             return self.initconst(0, interval=self.interval)
 
@@ -313,7 +329,7 @@ class Classicfun(Fun, ABC):
             Classicfun: A new function representing the real part of this function.
         """
         if self.iscomplex:
-            return self.__class__(self.onefun.real(), self.interval)
+            return self._rebuild(self.onefun.real())
         else:
             return self
 
@@ -385,9 +401,9 @@ class Classicfun(Fun, ABC):
         Returns:
             Classicfun: A new function representing the indefinite integral of this function.
         """
-        a, b = self.support
+        a, b = self.interval
         onefun = 0.5 * (b - a) * self.onefun.cumsum()
-        return self.__class__(onefun, self.interval)
+        return self._rebuild(onefun)
 
     def diff(self) -> "Classicfun":
         """Compute the derivative of the function.
@@ -399,9 +415,9 @@ class Classicfun(Fun, ABC):
         Returns:
             Classicfun: A new function representing the derivative of this function.
         """
-        a, b = self.support
+        a, b = self.interval
         onefun = 2.0 / (b - a) * self.onefun.diff()
-        return self.__class__(onefun, self.interval)
+        return self._rebuild(onefun)
 
     def sum(self) -> Any:
         """Compute the definite integral of the function over its interval of definition.
@@ -413,7 +429,7 @@ class Classicfun(Fun, ABC):
         Returns:
             float or complex: The definite integral of the function over its interval of definition.
         """
-        a, b = self.support
+        a, b = self.interval
         return 0.5 * (b - a) * self.onefun.sum()
 
     # ----------
@@ -522,7 +538,7 @@ def add_zero_arg_op(methodname: str) -> None:
             Classicfun: A new Classicfun instance with the result of the operation.
         """
         onefun = getattr(self.onefun, methodname)(*args, **kwds)
-        return self.__class__(onefun, self.interval)
+        return self._rebuild(onefun)
 
     method.__name__ = methodname
     method.__doc__ = method.__doc__
@@ -604,7 +620,7 @@ def add_binary_op(methodname: str) -> None:
             # let the lower level classes raise any other exceptions
             g = f
         onefun = getattr(self.onefun, methodname)(g, *args, **kwds)
-        return cls(onefun, self.interval)
+        return self._rebuild(onefun)
 
     method.__name__ = methodname
     method.__doc__ = method.__doc__

--- a/src/chebpy/compactfun.py
+++ b/src/chebpy/compactfun.py
@@ -1,0 +1,400 @@
+"""Implementation of functions on (semi-)infinite intervals via numerical-support truncation.
+
+This module provides the :class:`CompactFun` class, which sits next to
+:class:`~chebpy.bndfun.Bndfun` under :class:`~chebpy.classicfun.Classicfun`.
+It represents functions whose user-facing logical interval has one or both
+endpoints at ``±inf`` but whose **numerical support** — the set of points
+where the function exceeds a configured tolerance — is finite.  Internally,
+a :class:`CompactFun` stores a standard :class:`~chebpy.onefun.Onefun`
+(Chebtech) on the discovered finite storage interval; outside that interval
+the function is reported as identically zero.
+
+This approach is a deliberate departure from MATLAB Chebfun's ``@unbndfun``
+(which uses a rational change of variables to map ``(-inf, inf)`` onto
+``[-1, 1]``).  See ``docs/plans/02-compactfun-integration.md`` for the design
+rationale and scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .classicfun import Classicfun, techdict
+from .exceptions import CompactFunConstructionError
+from .settings import _preferences as prefs
+from .utilities import Interval
+
+
+def _ensure_endpoints(interval: Any) -> tuple[float, float]:
+    """Return ``(a, b)`` floats from any 2-element interval-like object.
+
+    Accepts :class:`Interval`, ``numpy.ndarray``, list, or tuple.  Both
+    endpoints may be ``±inf``.
+    """
+    a, b = interval[0], interval[1]
+    return float(a), float(b)
+
+
+def _discover_one_side(
+    f: Any, anchor: float, sign: int, tol: float, max_width: float, max_probes: int
+) -> tuple[float, float]:
+    """Discover the numerical-support boundary on one infinite side.
+
+    Probes ``f`` at ``anchor + sign * 2**k`` for ``k = 0, 1, 2, ...`` up to
+    the configured budget.  Returns the discovered finite boundary and the
+    observed vertical scale on this side.
+
+    Args:
+        f: Callable being approximated.
+        anchor: Finite anchor point (the bounded endpoint of a semi-infinite
+            interval, or ``0.0`` for the doubly-infinite case).
+        sign: ``+1`` for the rightward (toward ``+inf``) side, ``-1`` for the
+            leftward side.
+        tol: Relative tolerance threshold; the boundary is the smallest
+            ``r`` for which ``|f(anchor + sign * r)| < tol * vscale`` for
+            all probes farther out.
+        max_width: Maximum permitted boundary distance from ``anchor``.
+        max_probes: Maximum number of geometric probes.
+
+    Returns:
+        Tuple ``(boundary, vscale)`` where ``boundary`` is a finite ``float``
+        and ``vscale`` is the largest absolute probed value on this side.
+
+    Raises:
+        CompactFunConstructionError: If the function does not decay below
+            ``tol * vscale`` within the probing budget or ``max_width``.
+    """
+    radii: list[float] = []
+    values: list[float] = []
+    r = 1.0
+    for _ in range(max_probes):
+        if r > max_width:
+            break
+        x = anchor + sign * r
+        try:
+            v = float(np.abs(f(x)))
+        except (FloatingPointError, OverflowError, ZeroDivisionError) as err:  # pragma: no cover
+            raise CompactFunConstructionError(  # noqa: TRY003
+                f"Could not evaluate f at probe x = {x:g} during numerical-support discovery"
+            ) from err
+        if not np.isfinite(v):
+            raise CompactFunConstructionError(  # noqa: TRY003
+                f"f returned non-finite value {v} at probe x = {x:g}; CompactFun "
+                f"requires the function to be finite at all sampled points."
+            )
+        radii.append(r)
+        values.append(v)
+        r *= 2.0
+    if not radii:
+        return anchor + sign * 1.0, 0.0
+
+    vscale = max(values) if values else 0.0
+    threshold = tol * max(vscale, 1.0)
+
+    # Largest radius at which f is still "active" (above threshold).
+    active_r = 0.0
+    for ri, vi in zip(radii, values, strict=False):
+        if vi > threshold:
+            active_r = ri
+
+    # If the farthest probe is still active, the function does not decay
+    # within the probing budget.
+    if values[-1] > threshold:
+        raise CompactFunConstructionError(  # noqa: TRY003
+            f"Function does not decay below tolerance {tol:g} within "
+            f"{radii[-1]:g} of anchor {anchor:g}; heavy-tailed inputs are not "
+            f"supported in this release."
+        )
+
+    boundary_r = max(2.0 * active_r, 1.0)
+    if boundary_r > max_width:
+        raise CompactFunConstructionError(  # noqa: TRY003
+            f"Discovered numerical support exceeds max_width = {max_width:g}; "
+            f"heavy-tailed inputs are not supported in this release."
+        )
+    return anchor + sign * boundary_r, vscale
+
+
+def _discover_numsupp(f: Any, a: float, b: float, tol: float, max_width: float, max_probes: int) -> tuple[float, float]:
+    """Discover the storage interval ``[a', b']`` for ``f``.
+
+    Args:
+        f: Callable being approximated.
+        a: Left endpoint of the logical interval (may be ``-inf``).
+        b: Right endpoint of the logical interval (may be ``+inf``).
+        tol: Relative tolerance for support detection.
+        max_width: Maximum permitted storage interval width.
+        max_probes: Maximum probes per unbounded side.
+
+    Returns:
+        Tuple ``(a', b')`` of finite floats with ``a' < b'``.
+
+    Raises:
+        CompactFunConstructionError: If support cannot be discovered.
+    """
+    left_inf = not np.isfinite(a)
+    right_inf = not np.isfinite(b)
+
+    if not (left_inf or right_inf):
+        return a, b
+
+    # Anchor: the finite endpoint of a semi-infinite interval, else 0.
+    if left_inf and right_inf:
+        anchor = 0.0
+    elif left_inf:
+        anchor = b
+    else:
+        anchor = a
+
+    if left_inf:
+        a_storage, _ = _discover_one_side(f, anchor, -1, tol, max_width, max_probes)
+    else:
+        a_storage = a
+
+    if right_inf:
+        b_storage, _ = _discover_one_side(f, anchor, +1, tol, max_width, max_probes)
+    else:
+        b_storage = b
+
+    if b_storage - a_storage > max_width:
+        raise CompactFunConstructionError(  # noqa: TRY003
+            f"Discovered numerical support [{a_storage:g}, {b_storage:g}] exceeds "
+            f"max_width = {max_width:g}; heavy-tailed inputs are not supported "
+            f"in this release."
+        )
+    if b_storage <= a_storage:
+        # Function appears identically zero; pick a small default storage.
+        a_storage, b_storage = anchor - 1.0, anchor + 1.0
+    return a_storage, b_storage
+
+
+class CompactFun(Classicfun):
+    """Functions on (semi-)infinite intervals with finite numerical support.
+
+    A :class:`CompactFun` represents a function whose user-facing logical
+    interval has one or both endpoints at ``±inf`` but whose numerical
+    support — the set where the function exceeds a configured tolerance —
+    is finite.  Internally it inherits from :class:`Classicfun` and stores a
+    standard :class:`Onefun` on the discovered finite storage interval; the
+    function is reported as identically zero outside that interval.
+
+    Two intervals are tracked:
+
+    - ``self._interval`` (inherited): the finite storage interval where the
+      underlying ``Onefun`` lives.
+    - ``self._logical_interval``: the user-facing interval, which may have
+      ``±inf`` endpoints; returned by :attr:`support`.
+
+    For finite logical intervals the two coincide and a :class:`CompactFun`
+    behaves identically to :class:`~chebpy.bndfun.Bndfun`.
+
+    Attributes:
+        onefun: Inherited; the standard :class:`Onefun` on ``[-1, 1]``.
+        support: The logical interval (possibly with ``±inf`` endpoints).
+        numerical_support: The finite storage interval.
+    """
+
+    def __init__(self, onefun: Any, interval: Any, logical_interval: Any = None) -> None:
+        """Create a new :class:`CompactFun` instance.
+
+        Args:
+            onefun: The :class:`Onefun` representing the function on ``[-1, 1]``.
+            interval: The finite storage :class:`Interval` (always finite).
+            logical_interval: The user-facing interval (possibly with ``±inf``
+                endpoints).  Defaults to ``interval`` if omitted.
+        """
+        super().__init__(onefun, interval)
+        if logical_interval is None:
+            self._logical_interval = np.asarray(interval, dtype=float)
+        else:
+            self._logical_interval = np.asarray((float(logical_interval[0]), float(logical_interval[1])), dtype=float)
+
+    def _rebuild(self, onefun: Any) -> CompactFun:
+        """Construct a new :class:`CompactFun` preserving the logical interval."""
+        return self.__class__(onefun, self._interval, logical_interval=self._logical_interval)
+
+    # --------------------------
+    #  alternative constructors
+    # --------------------------
+    @classmethod
+    def initempty(cls) -> CompactFun:
+        """Initialise an empty CompactFun on ``(-inf, +inf)``."""
+        storage = Interval(-1.0, 1.0)
+        onefun = techdict[prefs.tech].initempty(interval=storage)
+        return cls(onefun, storage, logical_interval=(-np.inf, np.inf))
+
+    @classmethod
+    def initconst(cls, c: Any, interval: Any) -> CompactFun:
+        """Initialise a constant function.
+
+        Non-zero constants on unbounded intervals are not representable as
+        :class:`CompactFun` because the function does not decay to zero at
+        ``±inf``.
+        """
+        a, b = _ensure_endpoints(interval)
+        unbounded = (not np.isfinite(a)) or (not np.isfinite(b))
+        if unbounded and float(c) != 0.0:
+            raise CompactFunConstructionError(  # noqa: TRY003
+                "Non-zero constants are not representable as a CompactFun on an "
+                "unbounded interval (a CompactFun must decay to zero at ±inf)."
+            )
+        if not np.isfinite(a) and not np.isfinite(b):
+            storage = Interval(-1.0, 1.0)
+        elif not np.isfinite(a):
+            storage = Interval(b - 1.0, b)
+        elif not np.isfinite(b):
+            storage = Interval(a, a + 1.0)
+        else:
+            storage = Interval(a, b)
+        onefun = techdict[prefs.tech].initconst(c, interval=storage)
+        return cls(onefun, storage, logical_interval=(a, b))
+
+    @classmethod
+    def initidentity(cls, interval: Any) -> CompactFun:
+        """Initialise the identity function ``f(x) = x``.
+
+        The identity function is unbounded and so cannot be represented as a
+        :class:`CompactFun` on an unbounded interval.  This method is provided
+        only for completeness and refuses any infinite endpoint.
+        """
+        a, b = _ensure_endpoints(interval)
+        if not (np.isfinite(a) and np.isfinite(b)):
+            raise CompactFunConstructionError(  # noqa: TRY003
+                "The identity function f(x) = x cannot be represented as a CompactFun on an unbounded interval."
+            )
+        storage = Interval(a, b)
+        onefun = techdict[prefs.tech].initvalues(np.asarray(storage), interval=storage)
+        return cls(onefun, storage, logical_interval=(a, b))
+
+    @classmethod
+    def initfun_adaptive(cls, f: Any, interval: Any) -> CompactFun:
+        """Initialise from a callable using adaptive sampling.
+
+        Discovers the numerical support of ``f`` on the (possibly unbounded)
+        logical interval, then builds a standard adaptive :class:`Onefun` on
+        that finite storage interval.
+
+        Raises:
+            CompactFunConstructionError: If the numerical support cannot be
+                discovered within the configured tolerance and width budget.
+        """
+        a, b = _ensure_endpoints(interval)
+        a_s, b_s = _discover_numsupp(
+            f,
+            a,
+            b,
+            prefs.numsupp_tol,
+            prefs.numsupp_max_width,
+            prefs.numsupp_max_probes,
+        )
+        storage = Interval(a_s, b_s)
+        onefun = techdict[prefs.tech].initfun(lambda y: f(storage(y)), interval=storage)
+        return cls(onefun, storage, logical_interval=(a, b))
+
+    @classmethod
+    def initfun_fixedlen(cls, f: Any, interval: Any, n: int) -> CompactFun:
+        """Initialise from a callable using a fixed number of points.
+
+        Discovers numerical support as in :meth:`initfun_adaptive`, then
+        builds a fixed-length :class:`Onefun` on the storage interval.
+        """
+        a, b = _ensure_endpoints(interval)
+        a_s, b_s = _discover_numsupp(
+            f,
+            a,
+            b,
+            prefs.numsupp_tol,
+            prefs.numsupp_max_width,
+            prefs.numsupp_max_probes,
+        )
+        storage = Interval(a_s, b_s)
+        onefun = techdict[prefs.tech].initfun(lambda y: f(storage(y)), n, interval=storage)
+        return cls(onefun, storage, logical_interval=(a, b))
+
+    # -------------------
+    #  evaluation
+    # -------------------
+    def __call__(self, x: Any, how: str = "clenshaw") -> Any:
+        """Evaluate the function at ``x``; returns ``0`` outside the storage interval."""
+        scalar_input = np.isscalar(x) or np.ndim(x) == 0
+        x_arr = np.atleast_1d(np.asarray(x))
+        is_complex = bool(getattr(self.onefun, "iscomplex", False))
+        result = np.zeros(x_arr.shape, dtype=complex if is_complex else float)
+        a_s, b_s = self._interval
+        mask = (x_arr >= a_s) & (x_arr <= b_s)
+        if mask.any():
+            y = self._interval.invmap(x_arr[mask])
+            result[mask] = self.onefun(y, how)
+        if scalar_input:
+            return result.item()
+        return result
+
+    # ------------
+    #  properties
+    # ------------
+    @property
+    def support(self) -> Any:
+        """Return the logical (user-facing) interval, possibly with ``±inf`` endpoints."""
+        return self._logical_interval
+
+    @property
+    def numerical_support(self) -> Any:
+        """Return the finite storage interval ``[a, b]`` discovered at construction."""
+        return np.asarray(self._interval)
+
+    @property
+    def endvalues(self) -> Any:
+        """Return values at the logical endpoints; ``0`` at any ``±inf`` endpoint."""
+        a_log, b_log = float(self._logical_interval[0]), float(self._logical_interval[1])
+        yl = 0.0 if not np.isfinite(a_log) else self.__call__(a_log)
+        yr = 0.0 if not np.isfinite(b_log) else self.__call__(b_log)
+        return np.array([yl, yr])
+
+    def __repr__(self) -> str:  # pragma: no cover
+        """Return a string representation showing the logical interval and size."""
+        a_log, b_log = self._logical_interval
+        return f"{self.__class__.__name__}([{a_log}, {b_log}], {self.size})"
+
+    # ----------
+    #  calculus
+    # ----------
+    def cumsum(self) -> Any:
+        """Indefinite integral.
+
+        ``cumsum`` does not close in :class:`CompactFun` because the
+        antiderivative of an integrable function on ``(-inf, inf)`` does not
+        decay to zero at ``+inf`` (it tends to ``∫f``).  Future releases will
+        return a bounded :class:`Chebfun` representation; for now this is a
+        documented limitation.
+        """
+        raise NotImplementedError(
+            "CompactFun.cumsum() is not implemented in this release: the "
+            "antiderivative of an integrable function on (-inf, inf) tends "
+            "to a non-zero constant at +inf and so cannot itself be a "
+            "CompactFun.  This is a documented v1 limitation; a future "
+            "release will return a bounded Chebfun representation."
+        )
+
+    # -----------
+    #  utilities
+    # -----------
+    def restrict(self, subinterval: Any) -> Any:
+        """Restrict to a finite subinterval, returning a :class:`Bndfun`."""
+        from .bndfun import Bndfun
+
+        sub_a, sub_b = _ensure_endpoints(subinterval)
+        if not (np.isfinite(sub_a) and np.isfinite(sub_b)):
+            raise NotImplementedError(
+                "CompactFun.restrict() requires a finite subinterval; "
+                "restriction to unbounded subintervals is not supported."
+            )
+        return Bndfun.initfun_adaptive(self, Interval(sub_a, sub_b))
+
+    def translate(self, c: float) -> CompactFun:
+        """Translate by ``c`` along the real line, preserving both intervals."""
+        new_storage = Interval(float(self._interval[0]) + c, float(self._interval[1]) + c)
+        a_log, b_log = float(self._logical_interval[0]), float(self._logical_interval[1])
+        new_logical = (a_log + c, b_log + c)
+        return self.__class__(self.onefun, new_storage, logical_interval=new_logical)

--- a/src/chebpy/compactfun.py
+++ b/src/chebpy/compactfun.py
@@ -398,3 +398,33 @@ class CompactFun(Classicfun):
         a_log, b_log = float(self._logical_interval[0]), float(self._logical_interval[1])
         new_logical = (a_log + c, b_log + c)
         return self.__class__(self.onefun, new_storage, logical_interval=new_logical)
+
+    # ----------
+    #  plotting
+    # ----------
+    @property
+    def plot_support(self) -> tuple[float, float]:
+        """Return a finite ``[a, b]`` plotting window.
+
+        Replaces any ``±inf`` logical endpoint with the corresponding
+        numerical-support endpoint padded by 10% of the storage width
+        (minimum padding of 1.0) so the decay-to-zero region is visible.
+        """
+        a_s, b_s = float(self._interval[0]), float(self._interval[1])
+        a_log, b_log = float(self._logical_interval[0]), float(self._logical_interval[1])
+        pad = max(0.1 * (b_s - a_s), 1.0)
+        a = a_log if np.isfinite(a_log) else a_s - pad
+        b = b_log if np.isfinite(b_log) else b_s + pad
+        return (a, b)
+
+    def plot(self, ax: Any = None, **kwds: Any) -> Any:
+        """Plot the function over a finite window derived from its numerical support.
+
+        For doubly- or singly-infinite logical intervals, the plotting window
+        defaults to the numerical-support interval padded by 10% on each
+        unbounded side. Pass an explicit ``support=(a, b)`` keyword to override.
+        """
+        from .plotting import plotfun
+
+        support = kwds.pop("support", self.plot_support)
+        return plotfun(self, support, ax=ax, **kwds)

--- a/src/chebpy/compactfun.py
+++ b/src/chebpy/compactfun.py
@@ -377,6 +377,44 @@ class CompactFun(Classicfun):
             "release will return a bounded Chebfun representation."
         )
 
+    # -------------
+    #  rootfinding
+    # -------------
+    def roots(self) -> Any:
+        """Find the roots, filtering out spurious roots in numerical-noise regions.
+
+        The underlying polynomial approximation can produce many spurious
+        roots in regions where the function has decayed to numerical noise
+        (typically near the boundary of the storage interval).  We keep a
+        candidate root ``r`` only if both:
+
+        - ``f(r - δ)`` and ``f(r + δ)`` have opposite signs (the function
+          actually crosses zero), **and**
+        - ``max(|f(r - δ)|, |f(r + δ)|)`` exceeds ``numsupp_tol * vscale``
+          (the values are above numerical noise).
+
+        Here ``delta = 1e-3 * storage_width``.  This heuristic does not preserve
+        double roots; that is a documented limitation since double roots are
+        uncommon in the decay-to-zero functions that :class:`CompactFun` is
+        designed for.
+        """
+        raw = super().roots()
+        if raw.size == 0:
+            return raw
+        a_s, b_s = float(self._interval[0]), float(self._interval[1])
+        vals = np.abs(np.atleast_1d(self.onefun.values()))
+        vscale = float(vals.max()) if vals.size else 1.0
+        threshold = prefs.numsupp_tol * max(vscale, 1.0)
+        delta = 1e-3 * (b_s - a_s)
+        left = np.clip(raw - delta, a_s, b_s)
+        right = np.clip(raw + delta, a_s, b_s)
+        f_left = np.atleast_1d(self.__call__(left))
+        f_right = np.atleast_1d(self.__call__(right))
+        sign_flip = np.sign(f_left) != np.sign(f_right)
+        above_noise = np.maximum(np.abs(f_left), np.abs(f_right)) > threshold
+        keep = sign_flip & above_noise
+        return np.sort(np.unique(raw[keep]))
+
     # -----------
     #  utilities
     # -----------

--- a/src/chebpy/exceptions.py
+++ b/src/chebpy/exceptions.py
@@ -198,3 +198,24 @@ BadFunLengthArgument = type(
         """,
     },
 )
+
+
+# ===============================================
+#    chebpy.compactfun.CompactFun exceptions
+# ===============================================
+
+# Exception raised when a CompactFun cannot be constructed
+CompactFunConstructionError = type(
+    "CompactFunConstructionError",
+    (ChebpyBaseError,),
+    {
+        "default_message": "Could not construct a CompactFun for the supplied function and interval",
+        "__doc__": """Exception raised when CompactFun construction fails.
+
+        Raised when the numerical support of an unbounded function cannot
+        be discovered within the configured tolerance and width budget,
+        or when the function fails preconditions (e.g. non-zero asymptotic
+        limit or non-zero constant on an unbounded interval).
+        """,
+    },
+)

--- a/src/chebpy/gpr.py
+++ b/src/chebpy/gpr.py
@@ -26,6 +26,7 @@ from numpy.typing import ArrayLike
 from .algorithms import chebpts2
 from .chebfun import Chebfun
 from .quasimatrix import Quasimatrix
+from .settings import _preferences as prefs
 
 
 # ---------------------------------------------------------------------------
@@ -262,10 +263,18 @@ def _posterior_chebfuns(
     chol_l = np.linalg.cholesky(cov_mat)
     alpha = np.linalg.solve(chol_l.T, np.linalg.solve(chol_l, y_arr))
 
-    # Shared Chebyshev grid
+    # Sample grid: Chebyshev points for the default tech, equispaced points
+    # for the periodic (Trigtech) case.  Using the right grid here is critical
+    # because the constructed Chebfun pieces are then built via
+    # ``Chebfun.initfun_fixedlen`` whose underlying tech evaluates at exactly
+    # this grid.
     sample_size = min(20 * n, 2000)
-    t = chebpts2(sample_size)
-    x_sample = 0.5 * (opts.domain[1] - opts.domain[0]) * t + 0.5 * (opts.domain[0] + opts.domain[1])
+    if opts.trig:
+        # n equispaced points on [a, b) — matches Trigtech._trigpts mapped to domain
+        x_sample = opts.domain[0] + (opts.domain[1] - opts.domain[0]) * np.arange(sample_size) / sample_size
+    else:
+        t = chebpts2(sample_size)
+        x_sample = 0.5 * (opts.domain[1] - opts.domain[0]) * t + 0.5 * (opts.domain[0] + opts.domain[1])
 
     in_x = np.isin(x_sample, x_arr)
 
@@ -275,7 +284,6 @@ def _posterior_chebfuns(
 
     # Posterior mean
     mean_vals = k_star @ alpha
-    f_mean = Chebfun.initfun_fixedlen(lambda _z: mean_vals, sample_size, opts.domain)
 
     # Posterior variance
     k_ss = _kernel_matrix(x_sample, x_sample, opts)
@@ -285,27 +293,35 @@ def _posterior_chebfuns(
     v = np.linalg.solve(chol_l, k_star.T)
     var_diag = np.diag(k_ss) - np.sum(v**2, axis=0)
     var_diag = np.maximum(var_diag, 0.0)
-    f_var = Chebfun.initfun_fixedlen(lambda _z: var_diag, sample_size, opts.domain)
 
-    if n_samples <= 0:
-        return f_mean, f_var
+    # Build Chebfuns under the appropriate tech.  For ``trig=True`` this
+    # produces Trigtech-backed pieces so that downstream calculus is performed
+    # in Fourier space.
+    tech_name = "Trigtech" if opts.trig else prefs.tech
+    with prefs:
+        prefs.tech = tech_name
+        f_mean = Chebfun.initfun_fixedlen(lambda _z: mean_vals, sample_size, opts.domain)
+        f_var = Chebfun.initfun_fixedlen(lambda _z: var_diag, sample_size, opts.domain)
 
-    # Posterior samples
-    cov_post = k_ss - v.T @ v
-    cov_post = 0.5 * (cov_post + cov_post.T)
-    cov_post += 1e-12 * scaling_factor**2 * n * np.eye(sample_size)
-    chol_s = np.linalg.cholesky(cov_post)
+        if n_samples <= 0:
+            return f_mean, f_var
 
-    draws = mean_vals[:, None] + chol_s @ np.random.randn(sample_size, n_samples)
-    cols: list[Chebfun] = []
-    for j in range(n_samples):
-        cols.append(
-            Chebfun.initfun_fixedlen(
-                lambda _z, _j=j: draws[:, _j],
-                sample_size,
-                opts.domain,
+        # Posterior samples
+        cov_post = k_ss - v.T @ v
+        cov_post = 0.5 * (cov_post + cov_post.T)
+        cov_post += 1e-12 * scaling_factor**2 * n * np.eye(sample_size)
+        chol_s = np.linalg.cholesky(cov_post)
+
+        draws = mean_vals[:, None] + chol_s @ np.random.randn(sample_size, n_samples)
+        cols: list[Chebfun] = []
+        for j in range(n_samples):
+            cols.append(
+                Chebfun.initfun_fixedlen(
+                    lambda _z, _j=j: draws[:, _j],
+                    sample_size,
+                    opts.domain,
+                )
             )
-        )
     return f_mean, f_var, Quasimatrix(cols)
 
 

--- a/src/chebpy/settings.py
+++ b/src/chebpy/settings.py
@@ -30,6 +30,10 @@ class DefaultPreferences:
     maxiter = 10
     sortroots = False
     mergeroots = True
+    # CompactFun (numerical-support) settings
+    numsupp_tol = np.finfo(float).eps
+    numsupp_max_width = 1.0e6
+    numsupp_max_probes = 30
 
     @classmethod
     def _defaults(cls) -> dict[str, Any]:

--- a/src/chebpy/utilities.py
+++ b/src/chebpy/utilities.py
@@ -229,10 +229,13 @@ class Domain(np.ndarray):
 
         Args:
             breakpoints (array-like): Collection of monotonically increasing breakpoints.
-                Must have at least 2 elements.
+                Must have at least 2 elements. The outermost breakpoints may be
+                ``-np.inf`` / ``+np.inf``; interior breakpoints must be finite.
 
         Raises:
-            InvalidDomain: If breakpoints has fewer than 2 elements or is not monotonically increasing.
+            InvalidDomain: If breakpoints has fewer than 2 elements, is not
+                monotonically increasing, or contains non-finite values at
+                interior positions.
 
         Returns:
             Domain: A new Domain instance.
@@ -240,10 +243,15 @@ class Domain(np.ndarray):
         bpts = np.asarray(breakpoints, dtype=float)
         if bpts.size == 0:
             return bpts.view(cls)  # type: ignore[return-value]
-        elif bpts.size < 2 or np.any(np.diff(bpts) <= 0):
+        if bpts.size < 2 or np.any(np.diff(bpts) <= 0):
             raise InvalidDomain
-        else:
-            return bpts.view(cls)  # type: ignore[return-value]
+        # Interior breakpoints must be finite; only the outermost two may be infinite.
+        if bpts.size > 2 and not np.all(np.isfinite(bpts[1:-1])):
+            raise InvalidDomain
+        # NaN is never permitted anywhere.
+        if np.any(np.isnan(bpts)):
+            raise InvalidDomain
+        return bpts.view(cls)  # type: ignore[return-value]
 
     def __contains__(self, other: object) -> bool:
         """Check whether one domain object is a subdomain of another (within tolerance).
@@ -459,7 +467,10 @@ def check_funs(funs: Any) -> np.ndarray:
     if funs.size == 0:
         sortedfuns = np.array([])
     else:
-        intervals = (fun.interval for fun in funs)
+        # Use ``support`` (logical interval) rather than ``interval`` (storage)
+        # so CompactFun pieces are validated against their unbounded user-facing
+        # endpoints rather than their finite numerical-support storage.
+        intervals = (fun.support for fun in funs)
         idx = _sortindex(intervals)
         sortedfuns = funs[idx]
     return sortedfuns
@@ -501,11 +512,17 @@ def generate_funs(
     """Generate a collection of function objects over a domain.
 
     This method is used by several of the Chebfun classmethod constructors to
-    generate a collection of function objects over the specified domain.
+    generate a collection of function objects over the specified domain. For
+    pieces with finite endpoints the supplied ``bndfun_constructor`` is used;
+    for pieces with one or both endpoints at ``±inf`` the corresponding
+    classmethod on :class:`CompactFun` is invoked instead, dispatched by
+    method name.
 
     Args:
         domain (array-like or None): Domain breakpoints. If None, uses default domain from preferences.
-        bndfun_constructor (callable): Constructor function for creating function objects.
+            The outermost breakpoints may be ``±inf``; interior breakpoints must be finite.
+        bndfun_constructor (callable): Constructor function for creating function objects on
+            finite intervals (typically a :class:`Bndfun` classmethod).
         kwds (dict, optional): Additional keyword arguments to pass to the constructor. Defaults to {}.
 
     Returns:
@@ -514,10 +531,27 @@ def generate_funs(
     if kwds is None:
         kwds = {}
     domain = Domain(domain if domain is not None else prefs.domain)
+    # Local import avoids a circular dependency with chebpy.compactfun, which
+    # imports from utilities for Interval / Domain.
+    from .compactfun import CompactFun
+
+    method_name = getattr(bndfun_constructor, "__name__", None)
+    compact_constructor: Callable[..., Any] | None = (
+        getattr(CompactFun, method_name) if method_name is not None and hasattr(CompactFun, method_name) else None
+    )
+
     funs = []
-    for interval in domain.intervals:
-        kwds = {**kwds, **{"interval": interval}}
-        funs.append(bndfun_constructor(**kwds))
+    for a, b in itertools.pairwise(domain):
+        a_f, b_f = float(a), float(b)
+        if np.isfinite(a_f) and np.isfinite(b_f):
+            interval = Interval(a_f, b_f)
+            ctor = bndfun_constructor
+        else:
+            if compact_constructor is None:
+                raise InvalidDomain
+            interval = (a_f, b_f)  # CompactFun classmethods accept (a, b) tuples with ±inf
+            ctor = compact_constructor
+        funs.append(ctor(**{**kwds, "interval": interval}))
     return funs
 
 

--- a/tests/test_compactfun.py
+++ b/tests/test_compactfun.py
@@ -1,0 +1,223 @@
+"""Tests for the :class:`chebpy.compactfun.CompactFun` class."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from chebpy import CompactFun, chebfun
+from chebpy.bndfun import Bndfun
+from chebpy.exceptions import CompactFunConstructionError
+from chebpy.utilities import Interval
+
+
+# -----------------------------
+# direct construction
+# -----------------------------
+class TestInitFunAdaptive:
+    """Tests for :meth:`CompactFun.initfun_adaptive`."""
+
+    def test_gaussian_doubly_infinite(self) -> None:
+        f = CompactFun.initfun_adaptive(lambda x: np.exp(-(x**2)), (-np.inf, np.inf))
+        a, b = f.numerical_support
+        assert np.isfinite(a)
+        assert np.isfinite(b)
+        # Gaussian decays well within ±20.
+        assert -50.0 < a < -3.0
+        assert 3.0 < b < 50.0
+        # Logical interval is preserved.
+        assert not np.isfinite(f.support[0])
+        assert not np.isfinite(f.support[1])
+
+    def test_gaussian_evaluation(self) -> None:
+        f = CompactFun.initfun_adaptive(lambda x: np.exp(-(x**2)), (-np.inf, np.inf))
+        x = np.linspace(-2.0, 2.0, 11)
+        np.testing.assert_allclose(f(x), np.exp(-(x**2)), atol=1e-10)
+        # Outside numerical support → exactly zero.
+        assert f(1000.0) == 0.0
+        assert f(-1000.0) == 0.0
+
+    def test_semi_infinite_left(self) -> None:
+        f = CompactFun.initfun_adaptive(lambda x: np.exp(x), (-np.inf, 0.0))
+        a, b = f.numerical_support
+        assert b == 0.0
+        assert np.isfinite(a)
+
+    def test_semi_infinite_right(self) -> None:
+        f = CompactFun.initfun_adaptive(lambda x: np.exp(-x), (0.0, np.inf))
+        a, b = f.numerical_support
+        assert a == 0.0
+        assert np.isfinite(b)
+        np.testing.assert_allclose(f(0.5), np.exp(-0.5), atol=1e-10)
+
+    def test_finite_interval_behaves_like_bndfun(self) -> None:
+        f = CompactFun.initfun_adaptive(lambda x: np.sin(x), (-1.0, 2.0))
+        assert tuple(f.support) == (-1.0, 2.0)
+        assert tuple(f.numerical_support) == (-1.0, 2.0)
+        x = np.linspace(-1.0, 2.0, 17)
+        np.testing.assert_allclose(f(x), np.sin(x), atol=1e-12)
+
+    def test_heavy_tail_refused(self) -> None:
+        # 1/(1+x^2) decays only as 1/x^2 — too slowly for our threshold/budget.
+        with pytest.raises(CompactFunConstructionError):
+            CompactFun.initfun_adaptive(lambda x: 1.0 / (1.0 + x * x), (-np.inf, np.inf))
+
+    def test_non_decaying_refused(self) -> None:
+        with pytest.raises(CompactFunConstructionError):
+            CompactFun.initfun_adaptive(lambda x: np.tanh(x), (-np.inf, np.inf))
+
+
+class TestInitConst:
+    """Tests for :meth:`CompactFun.initconst`."""
+
+    def test_zero_constant_unbounded_ok(self) -> None:
+        f = CompactFun.initconst(0.0, (-np.inf, np.inf))
+        assert f(1000.0) == 0.0
+        assert f(0.0) == 0.0
+
+    def test_nonzero_constant_unbounded_refused(self) -> None:
+        with pytest.raises(CompactFunConstructionError):
+            CompactFun.initconst(1.0, (-np.inf, np.inf))
+        with pytest.raises(CompactFunConstructionError):
+            CompactFun.initconst(2.5, (0.0, np.inf))
+
+    def test_constant_finite_ok(self) -> None:
+        f = CompactFun.initconst(3.0, (-1.0, 2.0))
+        assert f(0.5) == pytest.approx(3.0)
+
+
+class TestInitIdentity:
+    """Tests for :meth:`CompactFun.initidentity`."""
+
+    def test_unbounded_refused(self) -> None:
+        with pytest.raises(CompactFunConstructionError):
+            CompactFun.initidentity((-np.inf, np.inf))
+        with pytest.raises(CompactFunConstructionError):
+            CompactFun.initidentity((0.0, np.inf))
+
+    def test_finite_ok(self) -> None:
+        f = CompactFun.initidentity((-1.0, 2.0))
+        x = np.linspace(-1.0, 2.0, 5)
+        np.testing.assert_allclose(f(x), x, atol=1e-12)
+
+
+class TestInitEmpty:
+    """Tests for :meth:`CompactFun.initempty`."""
+
+    def test_initempty(self) -> None:
+        f = CompactFun.initempty()
+        assert f.isempty
+
+
+# -----------------------------
+# evaluation
+# -----------------------------
+class TestCall:
+    """Tests for :meth:`CompactFun.__call__`."""
+
+    def test_scalar_returns_scalar(self) -> None:
+        f = CompactFun.initfun_adaptive(lambda x: np.exp(-(x**2)), (-np.inf, np.inf))
+        result = f(0.0)
+        assert np.isscalar(result) or np.ndim(result) == 0
+
+    def test_array_returns_array(self) -> None:
+        f = CompactFun.initfun_adaptive(lambda x: np.exp(-(x**2)), (-np.inf, np.inf))
+        x = np.array([-1.0, 0.0, 1.0, 1000.0])
+        y = f(x)
+        assert y.shape == x.shape
+        assert y[-1] == 0.0
+
+
+# -----------------------------
+# properties
+# -----------------------------
+class TestProperties:
+    """Tests for the support / endvalues / repr properties of CompactFun."""
+
+    def test_endvalues_at_inf_are_zero(self) -> None:
+        f = CompactFun.initfun_adaptive(lambda x: np.exp(-(x**2)), (-np.inf, np.inf))
+        ev = f.endvalues
+        assert ev[0] == 0.0
+        assert ev[1] == 0.0
+
+    def test_endvalues_semi_infinite(self) -> None:
+        f = CompactFun.initfun_adaptive(lambda x: np.exp(-x), (0.0, np.inf))
+        ev = f.endvalues
+        assert ev[0] == pytest.approx(1.0, abs=1e-10)
+        assert ev[1] == 0.0
+
+
+# -----------------------------
+# calculus / utilities
+# -----------------------------
+class TestCalculusRefusals:
+    """Tests for calculus methods that raise on CompactFun."""
+
+    def test_cumsum_not_implemented(self) -> None:
+        f = CompactFun.initfun_adaptive(lambda x: np.exp(-(x**2)), (-np.inf, np.inf))
+        with pytest.raises(NotImplementedError):
+            f.cumsum()
+
+
+class TestRestrictAndTranslate:
+    """Tests for :meth:`restrict` and :meth:`translate`."""
+
+    def test_restrict_to_finite_returns_bndfun(self) -> None:
+        f = CompactFun.initfun_adaptive(lambda x: np.exp(-(x**2)), (-np.inf, np.inf))
+        g = f.restrict(Interval(-1.0, 1.0))
+        assert isinstance(g, Bndfun)
+        x = np.linspace(-1.0, 1.0, 11)
+        np.testing.assert_allclose(g(x), np.exp(-(x**2)), atol=1e-10)
+
+    def test_translate_preserves_logical_interval(self) -> None:
+        f = CompactFun.initfun_adaptive(lambda x: np.exp(-(x**2)), (-np.inf, np.inf))
+        g = f.translate(2.0)
+        assert isinstance(g, CompactFun)
+        # logical interval still infinite
+        assert not np.isfinite(g.support[0])
+        assert not np.isfinite(g.support[1])
+        # numerical support shifts by 2
+        np.testing.assert_allclose(g.numerical_support, np.asarray(f.numerical_support) + 2.0, atol=1e-12)
+        # value relation
+        np.testing.assert_allclose(g(2.0), f(0.0), atol=1e-12)
+
+
+# -----------------------------
+# integration with chebfun()
+# -----------------------------
+class TestChebfunIntegration:
+    """Tests that ``chebfun(...)`` constructs CompactFun pieces on infinite intervals."""
+
+    def test_chebfun_doubly_infinite(self) -> None:
+        f = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, np.inf])
+        assert len(f.funs) == 1
+        assert isinstance(f.funs[0], CompactFun)
+        assert f.sum() == pytest.approx(np.sqrt(np.pi), abs=1e-10)
+
+    def test_chebfun_semi_infinite(self) -> None:
+        f = chebfun(lambda x: np.exp(-x), [0.0, np.inf])
+        assert isinstance(f.funs[0], CompactFun)
+        assert f.sum() == pytest.approx(1.0, abs=1e-10)
+
+    def test_chebfun_piecewise_mixed(self) -> None:
+        f = chebfun(lambda x: np.exp(-np.abs(x)), [-np.inf, 0.0, np.inf])
+        assert len(f.funs) == 2
+        assert all(isinstance(p, CompactFun) for p in f.funs)
+        assert f.sum() == pytest.approx(2.0, abs=1e-10)
+
+    def test_chebfun_piecewise_with_finite_middle(self) -> None:
+        # Outer pieces unbounded; middle piece finite — middle should be a Bndfun.
+        f = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, -1.0, 1.0, np.inf])
+        assert len(f.funs) == 3
+        assert isinstance(f.funs[0], CompactFun)
+        assert isinstance(f.funs[1], Bndfun)
+        assert isinstance(f.funs[2], CompactFun)
+        assert f.sum() == pytest.approx(np.sqrt(np.pi), abs=1e-10)
+
+    def test_chebfun_evaluation_outside_storage(self) -> None:
+        f = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, np.inf])
+        # Far outside numerical support but inside logical domain → 0, not NaN.
+        y = f(np.array([-1000.0, 0.0, 1000.0]))
+        assert y[0] == 0.0
+        assert y[2] == 0.0
+        assert y[1] == pytest.approx(1.0, abs=1e-10)

--- a/tests/test_compactfun.py
+++ b/tests/test_compactfun.py
@@ -301,3 +301,54 @@ class TestConvolution:
         # Result has unbounded logical support.
         assert not np.isfinite(h.breakpoints[0])
         assert not np.isfinite(h.breakpoints[-1])
+
+
+# -----------------------------
+# rootfinding
+# -----------------------------
+class TestRoots:
+    """Tests for the spurious-root filtering on :class:`CompactFun`."""
+
+    def test_no_spurious_roots_for_strictly_positive_decay(self) -> None:
+        # exp(-x^2) has no real roots; raw polynomial roots in noise regions
+        # (near the storage-interval boundary) must be filtered out.
+        f = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, np.inf])
+        roots = f.roots()
+        assert roots.size == 0
+
+    def test_genuine_root_kept_in_doubly_infinite(self) -> None:
+        # (x - 2) * exp(-x^2) has a single sign change at x = 2.
+        f = chebfun(lambda x: (x - 2.0) * np.exp(-(x**2)), [-np.inf, np.inf])
+        roots = f.roots()
+        assert roots.size == 1
+        assert roots[0] == pytest.approx(2.0, abs=1e-8)
+
+    def test_multiple_genuine_roots_in_semi_infinite(self) -> None:
+        # (x - 1)(x - 3) * exp(-x) has two simple roots; spurious noise roots
+        # at large x must be filtered.
+        f = chebfun(lambda x: (x - 1.0) * (x - 3.0) * np.exp(-x), [0.0, np.inf])
+        roots = f.roots()
+        assert roots.size == 2
+        np.testing.assert_allclose(roots, [1.0, 3.0], atol=1e-8)
+
+    def test_oscillation_roots_match_expected_grid(self) -> None:
+        # sin(10x) * exp(-x) on [0, inf) has roots at k*pi/10 for as many k as
+        # exp(-x) stays above noise. All retained roots must lie on this grid.
+        # Roots in the well-resolved region (exp(-x) >> noise floor) should
+        # match k*pi/10 to high precision.
+        f = chebfun(lambda x: np.sin(10.0 * x) * np.exp(-x), [0.0, np.inf])
+        roots = f.roots()
+        assert roots.size > 50  # should retain dozens of genuine roots
+        well_resolved = roots[roots < 25.0]
+        assert well_resolved.size > 70
+        ks = np.rint(well_resolved * 10.0 / np.pi)
+        np.testing.assert_allclose(well_resolved, ks * np.pi / 10.0, atol=1e-8)
+        # No retained root should be outside the storage interval.
+        a_s, b_s = f.funs[0].numerical_support
+        assert roots.min() >= a_s
+        assert roots.max() <= b_s
+
+    def test_roots_via_chebfun_filtered(self) -> None:
+        # Calling .roots() on the parent Chebfun also benefits from filtering.
+        f = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, np.inf])
+        assert f.roots().size == 0

--- a/tests/test_compactfun.py
+++ b/tests/test_compactfun.py
@@ -221,3 +221,46 @@ class TestChebfunIntegration:
         assert y[0] == 0.0
         assert y[2] == 0.0
         assert y[1] == pytest.approx(1.0, abs=1e-10)
+
+
+# -----------------------------
+# convolution
+# -----------------------------
+class TestConvolution:
+    """Tests for ``Chebfun.conv`` involving :class:`CompactFun` inputs."""
+
+    def test_gaussian_self_convolution(self) -> None:
+        # (exp(-x^2)) ★ (exp(-x^2)) = sqrt(pi/2) * exp(-x^2/2); total mass = pi.
+        f = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, np.inf])
+        h = f.conv(f)
+        assert h.sum() == pytest.approx(np.pi, abs=1e-8)
+        assert h(0.0) == pytest.approx(np.sqrt(np.pi / 2.0), abs=1e-8)
+        assert h(2.0) == pytest.approx(np.sqrt(np.pi / 2.0) * np.exp(-2.0), abs=1e-8)
+        # Outermost pieces should be CompactFun (logical support is unbounded).
+        assert isinstance(h.funs[0], CompactFun)
+        assert isinstance(h.funs[-1], CompactFun)
+        assert not np.isfinite(h.breakpoints[0])
+        assert not np.isfinite(h.breakpoints[-1])
+
+    def test_exp_self_convolution_semi_infinite(self) -> None:
+        # exp(-x) ★ exp(-x) on [0, inf) = x * exp(-x) (Gamma(2,1)); total mass 1.
+        f = chebfun(lambda x: np.exp(-x), [0.0, np.inf])
+        h = f.conv(f)
+        assert h.sum() == pytest.approx(1.0, abs=1e-8)
+        for xi in (0.5, 1.0, 3.0):
+            assert h(xi) == pytest.approx(xi * np.exp(-xi), abs=1e-8)
+        # Right edge piece is CompactFun, left endpoint is finite (= 0.0).
+        assert isinstance(h.funs[-1], CompactFun)
+        assert h.breakpoints[0] == pytest.approx(0.0)
+        assert not np.isfinite(h.breakpoints[-1])
+
+    def test_compact_with_finite_bndfun(self) -> None:
+        # exp(-x^2) on R convolved with a bump on [-1, 1].
+        f = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, np.inf])
+        g = chebfun(lambda x: 1.0 - x * x, [-1.0, 1.0])
+        h = f.conv(g)
+        # Mass of result equals product of masses.
+        assert h.sum() == pytest.approx(np.sqrt(np.pi) * (4.0 / 3.0), abs=1e-8)
+        # Result has unbounded logical support.
+        assert not np.isfinite(h.breakpoints[0])
+        assert not np.isfinite(h.breakpoints[-1])

--- a/tests/test_compactfun.py
+++ b/tests/test_compactfun.py
@@ -214,6 +214,43 @@ class TestChebfunIntegration:
         assert isinstance(f.funs[2], CompactFun)
         assert f.sum() == pytest.approx(np.sqrt(np.pi), abs=1e-10)
 
+    def test_chebfun_piecewise_multiple_finite_breakpoints(self) -> None:
+        # chebfun(f, [-inf, -2, 0, 3, +inf]): two CompactFun ends, two Bndfun middles.
+        f = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, -2.0, 0.0, 3.0, np.inf])
+        assert len(f.funs) == 4
+        assert isinstance(f.funs[0], CompactFun)
+        assert isinstance(f.funs[1], Bndfun)
+        assert isinstance(f.funs[2], Bndfun)
+        assert isinstance(f.funs[3], CompactFun)
+
+        # Logical breakpoints: leftmost = -inf, rightmost = +inf, interior finite.
+        bps = f.breakpoints
+        assert not np.isfinite(bps[0])
+        assert bps[1] == pytest.approx(-2.0)
+        assert bps[2] == pytest.approx(0.0)
+        assert bps[3] == pytest.approx(3.0)
+        assert not np.isfinite(bps[-1])
+
+        # Per-piece supports line up correctly.
+        assert not np.isfinite(f.funs[0].support[0])
+        assert f.funs[0].support[1] == pytest.approx(-2.0)
+        np.testing.assert_allclose(f.funs[1].support, [-2.0, 0.0])
+        np.testing.assert_allclose(f.funs[2].support, [0.0, 3.0])
+        assert f.funs[3].support[0] == pytest.approx(3.0)
+        assert not np.isfinite(f.funs[3].support[1])
+
+        # Total integral is the same Gaussian integral, regardless of breakpoint choice.
+        assert f.sum() == pytest.approx(np.sqrt(np.pi), abs=1e-10)
+
+        # Pointwise evaluation matches the underlying function across all four pieces
+        # (sample inside each), at interior breakpoints, and far outside numerical support.
+        x = np.array([-1000.0, -10.0, -2.0, -1.0, 0.0, 1.5, 3.0, 10.0, 1000.0])
+        expected = np.exp(-(x**2))
+        # Far outside numerical support → exact zero (function is below tolerance there).
+        expected[0] = 0.0
+        expected[-1] = 0.0
+        np.testing.assert_allclose(f(x), expected, atol=1e-9)
+
     def test_chebfun_evaluation_outside_storage(self) -> None:
         f = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, np.inf])
         # Far outside numerical support but inside logical domain → 0, not NaN.

--- a/tests/test_gpr.py
+++ b/tests/test_gpr.py
@@ -6,8 +6,10 @@ import numpy as np
 import pytest
 
 from chebpy.chebfun import Chebfun
+from chebpy.chebtech import Chebtech
 from chebpy.gpr import gpr
 from chebpy.quasimatrix import Quasimatrix
+from chebpy.trigtech import Trigtech
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +139,45 @@ class TestGPRTrig:
         y = np.sin(x)
         f_mean, _ = gpr(x, y, domain=[0, 2 * np.pi], trig=True, length_scale=1.0)
         np.testing.assert_allclose(f_mean(x), y, atol=1e-4)
+
+    def test_trig_posterior_is_trigtech_backed(self) -> None:
+        """The trig posterior must be backed by Trigtech, not Chebtech."""
+        x = np.linspace(0, 2 * np.pi, 12, endpoint=False)
+        y = np.sin(x) + 0.3 * np.cos(3 * x)
+        f_mean, f_var = gpr(x, y, domain=[0, 2 * np.pi], trig=True)
+        for piece in f_mean.funs:
+            assert isinstance(piece.onefun, Trigtech)
+        for piece in f_var.funs:
+            assert isinstance(piece.onefun, Trigtech)
+
+    def test_trig_posterior_samples_are_trigtech_backed(self) -> None:
+        """Posterior samples under trig=True must also be Trigtech-backed."""
+        x = np.linspace(0, 2 * np.pi, 8, endpoint=False)
+        y = np.sin(x)
+        _, _, samples = gpr(x, y, domain=[0, 2 * np.pi], trig=True, n_samples=2)
+        for j in range(samples.shape[1]):
+            col = samples[:, j]
+            for piece in col.funs:
+                assert isinstance(piece.onefun, Trigtech)
+
+    def test_trig_posterior_is_periodic(self) -> None:
+        """Posterior mean must agree at the two endpoints (periodicity)."""
+        x = np.linspace(0, 2 * np.pi, 16, endpoint=False)
+        y = np.sin(x) + 0.3 * np.cos(3 * x)
+        f_mean, f_var = gpr(x, y, domain=[0, 2 * np.pi], trig=True)
+        np.testing.assert_allclose(float(f_mean(0.0)), float(f_mean(2 * np.pi)), atol=1e-10)
+        np.testing.assert_allclose(float(f_var(0.0)), float(f_var(2 * np.pi)), atol=1e-10)
+
+    def test_non_trig_posterior_is_chebtech_backed(self) -> None:
+        """Sanity check: the default posterior is still Chebtech-backed."""
+        rng = np.random.default_rng(3)
+        x = np.sort(-1 + 2 * rng.random(8))
+        y = np.cos(x)
+        f_mean, f_var = gpr(x, y, domain=[-1, 1])
+        for piece in f_mean.funs:
+            assert isinstance(piece.onefun, Chebtech)
+        for piece in f_var.funs:
+            assert isinstance(piece.onefun, Chebtech)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces support for integrable, light-tailed functions defined on unbounded domains (such as $(-\infty, \infty)$, via a new `CompactFun` class. This enables efficient and accurate representation, manipulation, and convolution of such functions by discovering their finite numerical support and leveraging existing bounded-domain machinery. The integration includes new class definitions, API enhancements, utility updates, and comprehensive tests, while explicitly deferring heavy-tailed and non-zero-asymptote cases to future work.

**Key changes:**

### Major new feature: Light-tailed unbounded function support

* Added the `CompactFun` class as a sibling of `Bndfun` under `Classicfun`, representing functions on unbounded domains with rapid decay by discovering and storing their finite numerical support. This enables efficient evaluation, arithmetic, calculus, and especially convolution on $\mathbb{R}$ using existing machinery.
* Introduced adaptive and fixed-length construction methods, robust numerical support discovery, and comprehensive API/documentation for `CompactFun`.
* Added extensive tests for construction, evaluation, calculus, convolution, algebra, and error handling for `CompactFun`.

### Integration and API updates

* Exported `CompactFun` in `src/chebpy/__init__.py` to make it available as part of the public API.
* Updated utilities and chebfun construction logic to dispatch to `CompactFun` when unbounded intervals are detected, and adjusted logic for mixed-domain and piecewise chebfuns.
* Enhanced convolution logic to handle `CompactFun` pieces, ensuring correct storage/logical interval handling and output type selection.

### Core class improvements for extensibility

* Added a `_rebuild` method to `Classicfun` to enable subclasses (like `CompactFun`) to preserve additional metadata (such as logical interval) during operations that produce new function objects. Updated all relevant methods (`real`, `imag`, `cumsum`, `diff`, etc.) to use `_rebuild` instead of direct class construction, ensuring correct propagation of subclass-specific attributes. [[1]](diffhunk://#diff-ead679c9be60c44a3e7bdeb06de5dbb369409815e24d71199b1cc7b966fb3a75R160-R175) [[2]](diffhunk://#diff-ead679c9be60c44a3e7bdeb06de5dbb369409815e24d71199b1cc7b966fb3a75L302-R318) [[3]](diffhunk://#diff-ead679c9be60c44a3e7bdeb06de5dbb369409815e24d71199b1cc7b966fb3a75L316-R332) [[4]](diffhunk://#diff-ead679c9be60c44a3e7bdeb06de5dbb369409815e24d71199b1cc7b966fb3a75L388-R406) [[5]](diffhunk://#diff-ead679c9be60c44a3e7bdeb06de5dbb369409815e24d71199b1cc7b966fb3a75L402-R420) [[6]](diffhunk://#diff-ead679c9be60c44a3e7bdeb06de5dbb369409815e24d71199b1cc7b966fb3a75L416-R432) [[7]](diffhunk://#diff-ead679c9be60c44a3e7bdeb06de5dbb369409815e24d71199b1cc7b966fb3a75L525-R541) [[8]](diffhunk://#diff-ead679c9be60c44a3e7bdeb06de5dbb369409815e24d71199b1cc7b966fb3a75L607-R623)

### Evaluation and support logic fixes

* Changed chebfun evaluation logic to use the logical support interval (`fun.support`) rather than the storage interval for determining whether a point is inside a fun's domain. This ensures correct zeroing outside the intended logical interval.

---

These changes collectively extend chebpy's capabilities to efficiently handle a wide range of practical functions on unbounded domains, with a clear and extensible design for future enhancements.