### PR TITLE
CompactFun boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ _book
 _pdoc
 docs/notebooks/*.html
 docs/reports
-docs/reports.md
 _marimushka
 _mkdocs
 _benchmarks

--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ also returned as a Trigtech-backed Chebfun.
 Pass `np.inf` or `-np.inf` as a domain endpoint to construct a Chebfun
 on a (semi-)infinite interval. Pieces with infinite endpoints are
 automatically built as `CompactFun` objects: a Chebyshev expansion on
-the discovered numerical-support window, reported as identically zero
-outside.
+the discovered numerical-support window, with optional non-zero tail
+constants (`tail_left`, `tail_right`) recovered automatically for
+sigmoid-like inputs (`tanh`, logistic, …).
 
 ```python
 from chebpy import chebfun
@@ -239,6 +240,11 @@ import numpy as np
 # Doubly-infinite Gaussian — sum is √π
 h = chebfun(lambda x: np.exp(-x**2), [-np.inf, np.inf])
 h.sum()                           # ≈ √π
+
+# Sigmoid-like: tail constants are detected automatically
+t = chebfun(np.tanh, [-np.inf, np.inf])
+t.funs[0].tail_left, t.funs[0].tail_right    # (-1.0, 1.0)
+t(1e10)                                       # 1.0
 
 # Mixed: finite breakpoints with infinite endpoints
 p = chebfun(lambda x: np.exp(-x**2), [-np.inf, -2.0, 0.0, 3.0, np.inf])

--- a/README.md
+++ b/README.md
@@ -332,8 +332,6 @@ Project tooling:
 
 <div align="center">
 
-**Made with ❤️ by the ChebPy community**
-
 ⭐ *If you find ChebPy useful, please consider giving it a star!* ⭐
 
 </div>

--- a/README.md
+++ b/README.md
@@ -305,6 +305,26 @@ Whether you're fixing bugs, adding features, or improving documentation, your he
 
 ### Acknowledgments 🙏
 
+ChebPy stands on the shoulders of the **Chebfun project** led by
+[Nick Trefethen](https://people.maths.ox.ac.uk/trefethen/) and the Chebfun
+development team at the University of Oxford. The mathematical design,
+algorithmic ideas, and naming conventions in this library are direct
+adaptations of their work — most notably:
+
+- The original [MATLAB Chebfun](https://www.chebfun.org/) system
+  ([github.com/chebfun/chebfun](https://github.com/chebfun/chebfun)).
+- L. N. Trefethen, *Approximation Theory and Approximation Practice*,
+  SIAM, 2013 (extended edition 2019).
+- T. A. Driscoll, N. Hale, and L. N. Trefethen (eds.),
+  [*Chebfun Guide*](https://www.chebfun.org/docs/guide/), Pafnuty
+  Publications, 2014.
+
+We are grateful for their decades of open scholarship, which made this
+Python port possible. Any errors in translation or adaptation are ours
+alone.
+
+Project tooling:
+
 - [Jebel-Quant/rhiza](https://github.com/Jebel-Quant/rhiza) for standardised CI/CD templates and project tooling
 
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,10 @@ We are grateful for their decades of open scholarship, which made this
 Python port possible. Any errors in translation or adaptation are ours
 alone.
 
+📜 See the [History of the Chebfun Project](https://chebpy.github.io/chebpy/history/)
+page for a fuller timeline, key contributors, and foundational
+publications.
+
 Project tooling:
 
 - [Jebel-Quant/rhiza](https://github.com/Jebel-Quant/rhiza) for standardised CI/CD templates and project tooling

--- a/docs/history.md
+++ b/docs/history.md
@@ -138,7 +138,7 @@ complete list at
 | [**Rodrigo Platte**](https://scholar.google.com/citations?user=sujKeUUAAAAJ&hl=en) | Postdoc 2007–2009; extension to infinite intervals; edge-detection / `splitting on` |
 | [**Toby Driscoll**](https://tobydriscoll.net/) | Led ODE/integral side from 2008; `solvebvp`, `eigs`, `expm`, `volt`, `fred`; rectangular & block spectral discretisations |
 | [**Folkmar Bornemann**](https://www.professoren.tum.de/en/bornemann-folkmar) | Lazy-evaluation idea enabling operators |
-| [**Nick Hale**](https://scholar.google.com/citations?user=z1nuzsoAAAAJ) | DPhil 2006–2009, postdoc to 2014; project director 2010–2014; led v5 rewrite; quadrature, `pde15s`, `conv`, `legpts`, `cheb2leg` |
+| [**Nick Hale**](https://scholar.google.com/scholar?q=Nick+Hale+chebfun) | DPhil 2006–2009, postdoc to 2014; project director 2010–2014; led v5 rewrite; quadrature, `pde15s`, `conv`, `legpts`, `cheb2leg` |
 | [**Mark Richardson**](https://scholar.google.com/citations?user=mxOjLP8AAAAJ&hl=en) |MSc / DPhil 2008–2013; `blowup on`, poles and singularities |
 | [**Ásgeir Birkisson**](https://scholar.google.com/citations?user=rVsf9VoAAAAJ&hl=en) | MSc / DPhil / postdoc 2008–2015; automatic differentiation; nonlinear BVPs/IVPs; `Chebgui` |
 | [**Pedro Gonnet**](https://scholar.google.com/citations?user=IqOpdUkAAAAJ&hl=en) | Postdoc 2009–2012; `ratinterp`, `padeapprox` |
@@ -150,7 +150,7 @@ complete list at
 | [**Hrothgar**](https://scholar.google.com/scholar?q=Hrothgar+chebfun) | DPhil 2013–2015; v5 website; block operators / adjoints |
 | [**Kuan Xu**](https://scholar.google.com/scholar?q=Kuan+Xu+chebfun) | Postdoc 2012–2015; rectangular differentiation matrices; v5 unbounded-interval code |
 | [**Hadrien Montanelli**](https://scholar.google.com/citations?user=Bjmkfe8AAAAJ&hl=en) | DPhil 2013–2017; `spin`, `spin2`, `spin3`, `spinsphere`, `cheb.choreo` |
-| [**Behnam Hashemi**](https://scholar.google.com/citations?user=Bw_w8gMAAAAJ) | Postdoc 2014–2017; created Chebfun3 |
+| [**Behnam Hashemi**](https://scholar.google.com/scholar?q=Behnam+Hashemi+chebfun3) | Postdoc 2014–2017; created Chebfun3 |
 | [**Jared Aurentz**](https://scholar.google.com/citations?user=HrT33IsAAAAJ&hl=en) | Postdoc 2014–2016; `standardChop`, `adjoint`; continuous Krylov methods |
 | [**Olivier Sète**](https://scholar.google.com/citations?user=zuvLfoQAAAAJ&hl=en) | Postdoc 2015–2017; co-author of `aaa` |
 | [**Yuji Nakatsukasa**](https://people.maths.ox.ac.uk/nakatsukasa/) | Visiting researcher; `aaa`, `minimax`; fast linear algebra for `spinsphere` |
@@ -158,12 +158,12 @@ complete list at
 | [**Grady Wright**](https://scholar.google.com/citations?user=-wgTqlMAAAAJ&hl=en) | 2014 visit; `'trig'` (trigfun) capability; led Spherefun |
 | [**Heather Wilber**](https://scholar.google.com/citations?user=1Nw_is4AAAAJ&hl=en) | MSc 2015–2016 (Boise State); co-author of Spherefun; led Diskfun |
 | [**Sheehan Olver**](https://www.ma.imperial.ac.uk/~solver/) | JRF Oxford 2007–2011; ultraspherical spectral methods (with Townsend) |
-| [**Vanni Noferini**](https://scholar.google.com/citations?user=BpzPbZsAAAAJ) | Postdoc Manchester; fast rootfinding for Chebfun2 |
+| [**Vanni Noferini**](https://scholar.google.com/scholar?q=Vanni+Noferini+chebfun) | Postdoc Manchester; fast rootfinding for Chebfun2 |
 | [**Marcus Webb**](https://personalpages.manchester.ac.uk/staff/marcus.webb/) | Barycentric formulas; analytic continuation; improvements to `bary` |
 | [**Joris Van Deun**](https://scholar.google.com/scholar?q=Joris+Van+Deun+CF+approximation) | `cf` for Carathéodory–Féjer approximation |
-| [**Richard Mikael Slevinsky**](https://scholar.google.com/citations?user=Q4dFwc8AAAAJ) | Postdoc 2014–2016; quadrature, ultraspherical methods, ApproxFun link |
+| [**Richard Mikael Slevinsky**](https://scholar.google.com/scholar?q=Richard+Mikael+Slevinsky) | Postdoc 2014–2016; quadrature, ultraspherical methods, ApproxFun link |
 | [**Jean-Paul Berrut**](https://scholar.google.com/scholar?q=Jean-Paul+Berrut+barycentric) | Champion of barycentric formulas — the original spark for Chebfun |
-| [**Lourenço Peixoto**](https://scholar.google.com/scholar?q=Louren%C3%A7o+Peixoto+ultrapts) | `ultrapts`, improvements to `jacpts` |
+| [**Lourenço Peixoto**](https://scholar.google.com/citations?user=1x1cmO4AAAAJ&hl=en) | `ultrapts`, improvements to `jacpts` |
 
 ## Foundational publications
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,0 +1,255 @@
+# History of the Chebfun Project
+
+ChebPy is a Python adaptation of [Chebfun](https://www.chebfun.org/), an
+open-source software system for numerical computing with functions originating
+in **Oxford's Numerical Analysis Group** at the Mathematical Institute,
+University of Oxford. This page summarises the history and people behind the
+original Chebfun project, on whose mathematical and algorithmic foundations
+ChebPy is built. The narrative below is condensed from the Chebfun project's
+own [History](https://www.chebfun.org/about/history.html) and
+[People](https://www.chebfun.org/about/people.html) pages.
+
+## Timeline
+
+### The beginning (2002–2005)
+
+Chebfun began during 2002–2005 as the DPhil research of **Zachary Battles**, a
+Rhodes Scholar from the USA, supervised by **Nick Trefethen**. The idea of
+overloading MATLAB vectors as functions was first written down in an email
+from Trefethen to Battles on 8 December 2001. This led to **Chebfun
+Version 1**, for smooth functions on $[-1, 1]$, described in:
+
+- Battles & Trefethen, *An extension of MATLAB to continuous functions and
+  operators*, **SIAM J. Sci. Comp.** (2004).
+
+### Version 2 (2006–2008)
+
+The second phase began in autumn 2006 with EPSRC research funding.
+**Ricardo Pachón** (Colombia) extended Chebfun to **piecewise continuous
+functions and arbitrary intervals**. Automatic subdivision and edge detection
+were added with **Rodrigo Platte** (Brazil, postdoc from 2007). From January
+2008, **Toby Driscoll** (University of Delaware) led the addition of linear
+operators, ODEs, integral operators, eigenvalue problems, and operator
+exponentials, in collaboration with **Folkmar Bornemann** (TU Munich).
+Version 2 was released in **June 2008**.
+
+- Pachón, Platte & Trefethen, *Piecewise smooth chebfuns*, **IMA J. Numer.
+  Anal.** (2010).
+- Platte & Trefethen, *Chebfun: a new kind of numerical computing*, **ECMI
+  2008 Proceedings** (2010).
+- Driscoll, Bornemann & Trefethen, *The chebop system for automatic solution
+  of differential equations*, **BIT Numer. Math.** (2008).
+
+### Version 3 (2008–2009)
+
+**Nick Hale** joined as Trefethen's DPhil student and then postdoc, adding
+Gauss quadrature for millions of points and `pde15s` for nonlinear PDEs.
+**Mark Richardson** added support for functions with poles and singularities;
+**Ásgeir Birkisson** added automatic differentiation and nonlinear BVPs with
+Driscoll. **Pedro Gonnet**, **Sheehan Olver**, **Joris Van Deun** and
+**Alex Townsend** also contributed. Version 3 was released in
+**December 2009**, coordinated by Platte and Hale.
+
+### Version 4 (2010–2014)
+
+Chebfun became **open source under a BSD licence** in 2010. Major new
+features were Driscoll and Hale's differential-equation infrastructure,
+the **Chebgui** graphical interface (Birkisson & Hale), and a curated
+**Examples** collection led by Trefethen.
+
+### Version 5 and "Chebfun and Beyond" (2012–2014)
+
+A five-year **ERC Advanced Grant** to Trefethen in 2012 brought a new
+generation of contributors: **Anthony Austin**, **Mohsin Javed**,
+**Hadrien Montanelli**, **Hrothgar** (DPhil students), and **Kuan Xu**,
+**Behnam Hashemi**, **Jared Aurentz**, **Olivier Sète** (postdocs).
+The September 2012 *Chebfun and Beyond* workshop set the direction for a
+ground-up rewrite. **Chebfun Version 5** — modular, GitHub-hosted, with a
+new website by Hrothgar — was released on **21 June 2014**, led by
+Nick Hale.
+
+### Approximation Theory and Approximation Practice (2011–2013)
+
+Trefethen's textbook **[*Approximation Theory and Approximation Practice*](https://www.chebfun.org/ATAP/)**
+was published by SIAM in 2013 (extended edition 2019) and remains the
+mathematical foundation of the project.
+
+### Chebfun2, Chebfun3 (2013–2016)
+
+**Alex Townsend** created **Chebfun2** for 2D functions on rectangles
+using low-rank representations. **Behnam Hashemi** later created
+**Chebfun3** (2016) for 3D functions.
+
+- Townsend & Trefethen, *An extension of Chebfun to two dimensions*,
+  **SIAM J. Sci. Comp.** (2013).
+- Hashemi & Trefethen, *Chebfun in three dimensions*,
+  **SIAM J. Sci. Comp.** (2017).
+
+### Periodic functions, Spherefun, and Diskfun (2014–)
+
+During a 2014 sabbatical at Oxford, **Grady Wright** (Boise State)
+introduced a `'trig'` option for trigonometric (Fourier-based) Chebfuns —
+the "trigfun" capability, which is the direct ancestor of ChebPy's
+`Trigtech` module. Wright, Townsend, and **Heather Wilber** then built
+**Spherefun** (released with v5.4 in May 2016); Wilber went on to lead
+**Diskfun**.
+
+- Wright, Javed, Montanelli & Trefethen, *Extension of Chebfun to periodic
+  functions*, **SIAM J. Sci. Comp.** (2015).
+- Townsend, Wilber & Wright, *Computing with functions in spherical and
+  polar geometries I & II*, **SIAM J. Sci. Comp.** (2016).
+
+### Unifying ODE IVPs and BVPs (2014–2015)
+
+**Ásgeir Birkisson** unified the IVP/BVP user syntax so both can be solved
+via `u = N\f`, despite using very different underlying algorithms. This
+work informs the book **Exploring ODEs** by Trefethen, Birkisson, and
+Driscoll.
+
+### Time-dependent PDEs and `spin`
+
+**Hadrien Montanelli** introduced `spin`, `spin2`, `spin3` and
+`spinsphere` for stiff reaction–diffusion-type PDEs, based on exponential
+integrators (ETDRK4 of Cox & Matthews).
+
+### Rational approximation: AAA and minimax
+
+**Yuji Nakatsukasa**, **Olivier Sète**, and Trefethen developed the
+**AAA algorithm** for rational approximation; **Silviu Filip** led
+`minimax` for rational best approximation.
+
+- Nakatsukasa, Sète & Trefethen, *The AAA algorithm for rational
+  approximation*, **SIAM J. Sci. Comp.** (2018).
+
+## Key contributors
+
+The list below summarises the people whose contributions shape the
+mathematical and software design that ChebPy adapts. The Chebfun team
+maintains a more complete list at
+[chebfun.org/about/people.html](https://www.chebfun.org/about/people.html).
+
+| Person | Role / contribution |
+| --- | --- |
+| **Nick Trefethen** | Invented Chebfun (2002); project leader throughout; author of *ATAP* and co-author of *Exploring ODEs* |
+| **Zachary Battles** | DPhil 2002–2005; wrote Chebfun v1; quasimatrix `qr`, `svd`, `\`, `roots` |
+| **Ricardo Pachón** | DPhil from 2006; piecewise polynomials; `remez`, `chebpade`, `lebesgue` |
+| **Rodrigo Platte** | Postdoc 2007–2009; extension to infinite intervals; edge-detection / `splitting on` |
+| **Toby Driscoll** | Led ODE/integral side from 2008; `solvebvp`, `eigs`, `expm`, `volt`, `fred`; rectangular & block spectral discretisations |
+| **Folkmar Bornemann** | Lazy-evaluation idea enabling operators |
+| **Nick Hale** | DPhil 2006–2009, postdoc to 2014; project director 2010–2014; led v5 rewrite; quadrature, `pde15s`, `conv`, `legpts`, `cheb2leg` |
+| **Mark Richardson** | DPhil 2008–2013; `blowup on`, poles and singularities |
+| **Ásgeir Birkisson** | MSc / DPhil / postdoc 2008–2015; automatic differentiation; nonlinear BVPs/IVPs; `Chebgui` |
+| **Pedro Gonnet** | Postdoc 2009–2012; `ratinterp`, `padeapprox` |
+| **Stefan Güttel** | Postdoc 2011–2012; rational functions; `chebsnake` |
+| **Alex Townsend** | DPhil 2010–2014; created Chebfun2; co-author of Spherefun; `legpts`, `sum`, `conv`, `cheb2leg`, `nufft` |
+| **Anthony Austin** | DPhil from 2012; preferences architecture; technical leadership |
+| **Mohsin Javed** | MSc/DPhil 2011–2017; `dirac`, `trigremez`; coding-style guide |
+| **Georges Klein** | Postdoc 2012–2013; `chebfun(...,'equi')` for equispaced data |
+| **Hrothgar** | DPhil 2013–2015; v5 website; block operators / adjoints |
+| **Kuan Xu** | Postdoc 2012–2015; rectangular differentiation matrices; v5 unbounded-interval code |
+| **Hadrien Montanelli** | DPhil 2013–2017; `spin`, `spin2`, `spin3`, `spinsphere`, `cheb.choreo` |
+| **Behnam Hashemi** | Postdoc 2014–2017; created Chebfun3 |
+| **Jared Aurentz** | Postdoc 2014–2016; `standardChop`, `adjoint`; continuous Krylov methods |
+| **Olivier Sète** | Postdoc 2015–2017; co-author of `aaa` |
+| **Yuji Nakatsukasa** | Visiting researcher; `aaa`, `minimax`; fast linear algebra for `spinsphere` |
+| **Silviu Filip** | Postdoc from 2016; `minimax` rational best approximation |
+| **Grady Wright** | 2014 visit; `'trig'` (trigfun) capability; led Spherefun |
+| **Heather Wilber** | MSc 2015–2016 (Boise State); co-author of Spherefun; led Diskfun |
+| **Sheehan Olver** | JRF Oxford 2007–2011; ultraspherical spectral methods (with Townsend) |
+| **Vanni Noferini** | Postdoc Manchester; fast rootfinding for Chebfun2 |
+| **Marcus Webb**, **Joris Van Deun**, **Lourenço Peixoto**, **Richard Mikael Slevinsky**, **Jean-Paul Berrut** | Various contributions to barycentric formulas, `cf`, `ultrapts`, `jacpts`, quadrature, and Julia/ApproxFun connections |
+
+## Foundational publications
+
+The Chebfun project maintains a comprehensive
+[publications list](https://www.chebfun.org/publications/). The papers
+below are the most directly relevant to the algorithms and design adapted
+in ChebPy.
+
+### Books
+
+- L. N. Trefethen,
+  [*Approximation Theory and Approximation Practice*](https://www.chebfun.org/ATAP/),
+  SIAM, 2013 (extended edition 2019).
+- T. A. Driscoll, N. Hale, and L. N. Trefethen (eds.),
+  [*Chebfun Guide*](https://www.chebfun.org/docs/guide/), Pafnuty
+  Publications, Oxford, 2014. **(Recommended Chebfun citation.)**
+- L. N. Trefethen, Á. Birkisson, and T. A. Driscoll,
+  [*Exploring ODEs*](https://people.maths.ox.ac.uk/trefethen/ExplODE/),
+  SIAM, 2018.
+
+### Chebfun fundamentals
+
+- Z. Battles and L. N. Trefethen,
+  [*An extension of MATLAB to continuous functions and operators*](https://people.maths.ox.ac.uk/trefethen/publication/PDF/2004_107.pdf),
+  SIAM J. Sci. Comp., 2004.
+- R. Pachón, R. B. Platte and L. N. Trefethen,
+  [*Piecewise smooth chebfuns*](https://people.maths.ox.ac.uk/trefethen/publication/PDF/2010_134.pdf),
+  IMA J. Numer. Anal., 2010.
+- L. N. Trefethen,
+  [*Computing numerically with functions instead of numbers*](https://people.maths.ox.ac.uk/trefethen/cacm.pdf),
+  Comm. ACM, 2015.
+- J. L. Aurentz and L. N. Trefethen,
+  [*Chopping a Chebyshev series*](https://people.maths.ox.ac.uk/trefethen/aurentz_trefethen_revised.pdf),
+  ACM Trans. Math. Softw., 2017.
+
+### Periodic functions (the Trigtech ancestor)
+
+- G. B. Wright, M. Javed, H. Montanelli and L. N. Trefethen,
+  [*Extension of Chebfun to periodic functions*](https://people.maths.ox.ac.uk/trefethen/trigpaper.pdf),
+  SIAM J. Sci. Comp., 2015.
+
+### Quadrature and convolution (used by ChebPy's `conv`)
+
+- N. Hale and A. Townsend,
+  [*Fast and accurate computation of Gauss–Legendre and Gauss–Jacobi quadrature nodes and weights*](https://www.chebfun.org/publications/HaleTownsend2013a.pdf),
+  SIAM J. Sci. Comp., 2013.
+- N. Hale and A. Townsend,
+  [*An algorithm for the convolution of Legendre series*](https://www.chebfun.org/publications/HaleTownsend2014_PREPRINT.pdf),
+  SIAM J. Sci. Comp., 2014.
+- N. Hale and A. Townsend,
+  [*A fast, simple, and stable Chebyshev–Legendre transform using an asymptotic formula*](https://www.chebfun.org/publications/HaleTownsend2013b_PREPRINT.pdf),
+  SIAM J. Sci. Comp., 2014.
+
+### Quasimatrix algebra (used by ChebPy's quasimatrix module)
+
+- L. N. Trefethen,
+  [*Householder triangularization of a quasimatrix*](https://www.chebfun.org/publications/trefethen_householder.pdf),
+  IMA J. Numer. Anal., 2010.
+- A. Townsend and L. N. Trefethen,
+  [*Continuous analogues of matrix factorizations*](https://www.chebfun.org/publications/townsend_trefethen2014.pdf),
+  Proc. Royal Soc. A, 2015.
+
+### Rational approximation
+
+- Y. Nakatsukasa, O. Sète and L. N. Trefethen,
+  [*The AAA algorithm for rational approximation*](https://arxiv.org/abs/1612.00337),
+  SIAM J. Sci. Comp., 2018.
+
+## Sponsors of the Chebfun project
+
+Chebfun has been supported over the years by **EPSRC** (UK Engineering and
+Physical Sciences Research Council), the **European Research Council**
+(Trefethen Advanced Grant, 2012–2017), **MathWorks**, and the **Oxford
+Centre for Collaborative Applied Mathematics (OCCAM)**. See the
+[Chebfun sponsors](https://www.chebfun.org/about/sponsors.html) page.
+
+## Citing ChebPy and Chebfun
+
+If you use ChebPy in published work, please also cite the original Chebfun
+project:
+
+> T. A. Driscoll, N. Hale, and L. N. Trefethen, editors,
+> *Chebfun Guide*, Pafnuty Publications, Oxford, 2014.
+
+Where the topic is closer to a specific Chebfun paper above (for instance
+periodic representations or Hale–Townsend convolution), please cite that
+paper in addition.
+
+---
+
+*This page summarises material from the Chebfun project's
+[history](https://www.chebfun.org/about/history.html) and
+[people](https://www.chebfun.org/about/people.html) pages, © Copyright the
+University of Oxford and the Chebfun Developers, used here for
+attribution.*

--- a/docs/history.md
+++ b/docs/history.md
@@ -124,40 +124,46 @@ integrators (ETDRK4 of Cox & Matthews).
 ## Key contributors
 
 The list below summarises the people whose contributions shape the
-mathematical and software design that ChebPy adapts. The Chebfun team
-maintains a more complete list at
+mathematical and software design that ChebPy adapts. Each name links to
+the contributor's current academic homepage where available, falling back
+to a Google Scholar search otherwise. The Chebfun team maintains a more
+complete list at
 [chebfun.org/about/people.html](https://www.chebfun.org/about/people.html).
 
 | Person | Role / contribution |
 | --- | --- |
-| **Nick Trefethen** | Invented Chebfun (2002); project leader throughout; author of *ATAP* and co-author of *Exploring ODEs* |
-| **Zachary Battles** | DPhil 2002–2005; wrote Chebfun v1; quasimatrix `qr`, `svd`, `\`, `roots` |
-| **Ricardo Pachón** | DPhil from 2006; piecewise polynomials; `remez`, `chebpade`, `lebesgue` |
-| **Rodrigo Platte** | Postdoc 2007–2009; extension to infinite intervals; edge-detection / `splitting on` |
-| **Toby Driscoll** | Led ODE/integral side from 2008; `solvebvp`, `eigs`, `expm`, `volt`, `fred`; rectangular & block spectral discretisations |
-| **Folkmar Bornemann** | Lazy-evaluation idea enabling operators |
-| **Nick Hale** | DPhil 2006–2009, postdoc to 2014; project director 2010–2014; led v5 rewrite; quadrature, `pde15s`, `conv`, `legpts`, `cheb2leg` |
-| **Mark Richardson** | DPhil 2008–2013; `blowup on`, poles and singularities |
-| **Ásgeir Birkisson** | MSc / DPhil / postdoc 2008–2015; automatic differentiation; nonlinear BVPs/IVPs; `Chebgui` |
-| **Pedro Gonnet** | Postdoc 2009–2012; `ratinterp`, `padeapprox` |
-| **Stefan Güttel** | Postdoc 2011–2012; rational functions; `chebsnake` |
-| **Alex Townsend** | DPhil 2010–2014; created Chebfun2; co-author of Spherefun; `legpts`, `sum`, `conv`, `cheb2leg`, `nufft` |
-| **Anthony Austin** | DPhil from 2012; preferences architecture; technical leadership |
-| **Mohsin Javed** | MSc/DPhil 2011–2017; `dirac`, `trigremez`; coding-style guide |
-| **Georges Klein** | Postdoc 2012–2013; `chebfun(...,'equi')` for equispaced data |
-| **Hrothgar** | DPhil 2013–2015; v5 website; block operators / adjoints |
-| **Kuan Xu** | Postdoc 2012–2015; rectangular differentiation matrices; v5 unbounded-interval code |
-| **Hadrien Montanelli** | DPhil 2013–2017; `spin`, `spin2`, `spin3`, `spinsphere`, `cheb.choreo` |
-| **Behnam Hashemi** | Postdoc 2014–2017; created Chebfun3 |
-| **Jared Aurentz** | Postdoc 2014–2016; `standardChop`, `adjoint`; continuous Krylov methods |
-| **Olivier Sète** | Postdoc 2015–2017; co-author of `aaa` |
-| **Yuji Nakatsukasa** | Visiting researcher; `aaa`, `minimax`; fast linear algebra for `spinsphere` |
-| **Silviu Filip** | Postdoc from 2016; `minimax` rational best approximation |
-| **Grady Wright** | 2014 visit; `'trig'` (trigfun) capability; led Spherefun |
-| **Heather Wilber** | MSc 2015–2016 (Boise State); co-author of Spherefun; led Diskfun |
-| **Sheehan Olver** | JRF Oxford 2007–2011; ultraspherical spectral methods (with Townsend) |
-| **Vanni Noferini** | Postdoc Manchester; fast rootfinding for Chebfun2 |
-| **Marcus Webb**, **Joris Van Deun**, **Lourenço Peixoto**, **Richard Mikael Slevinsky**, **Jean-Paul Berrut** | Various contributions to barycentric formulas, `cf`, `ultrapts`, `jacpts`, quadrature, and Julia/ApproxFun connections |
+| [**Nick Trefethen**](https://people.maths.ox.ac.uk/trefethen/) | Invented Chebfun (2002); project leader throughout; author of *ATAP* and co-author of *Exploring ODEs* |
+| [**Zachary Battles**](https://scholar.google.com/scholar?q=Zachary+Battles+chebfun) | DPhil 2002–2005; wrote Chebfun v1; quasimatrix `qr`, `svd`, `\`, `roots` |
+| [**Ricardo Pachón**](https://scholar.google.com/citations?user=BJ7HWzkAAAAJ&hl=en) | DPhil from 2006; piecewise polynomials; `remez`, `chebpade`, `lebesgue` |
+| [**Rodrigo Platte**](https://scholar.google.com/citations?user=sujKeUUAAAAJ&hl=en) | Postdoc 2007–2009; extension to infinite intervals; edge-detection / `splitting on` |
+| [**Toby Driscoll**](https://tobydriscoll.net/) | Led ODE/integral side from 2008; `solvebvp`, `eigs`, `expm`, `volt`, `fred`; rectangular & block spectral discretisations |
+| [**Folkmar Bornemann**](https://www.professoren.tum.de/en/bornemann-folkmar) | Lazy-evaluation idea enabling operators |
+| [**Nick Hale**](https://scholar.google.com/citations?user=z1nuzsoAAAAJ) | DPhil 2006–2009, postdoc to 2014; project director 2010–2014; led v5 rewrite; quadrature, `pde15s`, `conv`, `legpts`, `cheb2leg` |
+| [**Mark Richardson**](https://scholar.google.com/citations?user=mxOjLP8AAAAJ&hl=en) |MSc / DPhil 2008–2013; `blowup on`, poles and singularities |
+| [**Ásgeir Birkisson**](https://scholar.google.com/citations?user=rVsf9VoAAAAJ&hl=en) | MSc / DPhil / postdoc 2008–2015; automatic differentiation; nonlinear BVPs/IVPs; `Chebgui` |
+| [**Pedro Gonnet**](https://scholar.google.com/citations?user=IqOpdUkAAAAJ&hl=en) | Postdoc 2009–2012; `ratinterp`, `padeapprox` |
+| [**Stefan Güttel**](https://guettel.com/) | Postdoc 2011–2012; rational functions; `chebsnake` |
+| [**Alex Townsend**](https://alextownsend.net/) | DPhil 2010–2014; created Chebfun2; co-author of Spherefun; `legpts`, `sum`, `conv`, `cheb2leg`, `nufft` |
+| [**Anthony Austin**](https://scholar.google.com/citations?user=J8pe_aYAAAAJ&hl=en) | DPhil from 2012; preferences architecture; technical leadership |
+| [**Mohsin Javed**](https://scholar.google.com/citations?user=boh_ussAAAAJ&hl=en) | MSc / DPhil 2011–2017; `dirac`, `trigremez`; coding-style guide |
+| [**Georges Klein**](https://scholar.google.com/scholar?q=Georges+Klein+barycentric+interpolation) | Postdoc 2012–2013; `chebfun(...,'equi')` for equispaced data |
+| [**Hrothgar**](https://scholar.google.com/scholar?q=Hrothgar+chebfun) | DPhil 2013–2015; v5 website; block operators / adjoints |
+| [**Kuan Xu**](https://scholar.google.com/scholar?q=Kuan+Xu+chebfun) | Postdoc 2012–2015; rectangular differentiation matrices; v5 unbounded-interval code |
+| [**Hadrien Montanelli**](https://scholar.google.com/citations?user=Bjmkfe8AAAAJ&hl=en) | DPhil 2013–2017; `spin`, `spin2`, `spin3`, `spinsphere`, `cheb.choreo` |
+| [**Behnam Hashemi**](https://scholar.google.com/citations?user=Bw_w8gMAAAAJ) | Postdoc 2014–2017; created Chebfun3 |
+| [**Jared Aurentz**](https://scholar.google.com/citations?user=HrT33IsAAAAJ&hl=en) | Postdoc 2014–2016; `standardChop`, `adjoint`; continuous Krylov methods |
+| [**Olivier Sète**](https://scholar.google.com/citations?user=zuvLfoQAAAAJ&hl=en) | Postdoc 2015–2017; co-author of `aaa` |
+| [**Yuji Nakatsukasa**](https://people.maths.ox.ac.uk/nakatsukasa/) | Visiting researcher; `aaa`, `minimax`; fast linear algebra for `spinsphere` |
+| [**Silviu Filip**](https://scholar.google.com/citations?user=IbrAWwgAAAAJ&hl=en) | Postdoc from 2016; `minimax` rational best approximation |
+| [**Grady Wright**](https://scholar.google.com/citations?user=-wgTqlMAAAAJ&hl=en) | 2014 visit; `'trig'` (trigfun) capability; led Spherefun |
+| [**Heather Wilber**](https://scholar.google.com/citations?user=1Nw_is4AAAAJ&hl=en) | MSc 2015–2016 (Boise State); co-author of Spherefun; led Diskfun |
+| [**Sheehan Olver**](https://www.ma.imperial.ac.uk/~solver/) | JRF Oxford 2007–2011; ultraspherical spectral methods (with Townsend) |
+| [**Vanni Noferini**](https://scholar.google.com/citations?user=BpzPbZsAAAAJ) | Postdoc Manchester; fast rootfinding for Chebfun2 |
+| [**Marcus Webb**](https://personalpages.manchester.ac.uk/staff/marcus.webb/) | Barycentric formulas; analytic continuation; improvements to `bary` |
+| [**Joris Van Deun**](https://scholar.google.com/scholar?q=Joris+Van+Deun+CF+approximation) | `cf` for Carathéodory–Féjer approximation |
+| [**Richard Mikael Slevinsky**](https://scholar.google.com/citations?user=Q4dFwc8AAAAJ) | Postdoc 2014–2016; quadrature, ultraspherical methods, ApproxFun link |
+| [**Jean-Paul Berrut**](https://scholar.google.com/scholar?q=Jean-Paul+Berrut+barycentric) | Champion of barycentric formulas — the original spark for Chebfun |
+| [**Lourenço Peixoto**](https://scholar.google.com/scholar?q=Louren%C3%A7o+Peixoto+ultrapts) | `ultrapts`, improvements to `jacpts` |
 
 ## Foundational publications
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,25 @@ integral = f.sum()
 roots = f.roots()
 ```
 
-## Getting Started
+## Quickstart
 
-Head to the [Getting Started](user/quickstart.md) guide for a hands-on introduction, or explore the [API Reference](api.md) for full documentation.
+Head to the [Quickstart](user/quickstart.md) guide for a hands-on introduction, or explore the [API Reference](api.md) for full documentation.
+
+## Acknowledgments
+
+ChebPy is a direct port of the **Chebfun project** led by
+[Nick Trefethen](https://people.maths.ox.ac.uk/trefethen/) and the Chebfun
+development team at the University of Oxford. The mathematical design,
+algorithms, and naming conventions used here are adaptations of their
+decades of open scholarship, most notably:
+
+- The original [MATLAB Chebfun](https://www.chebfun.org/) system
+  ([github.com/chebfun/chebfun](https://github.com/chebfun/chebfun)).
+- L. N. Trefethen, *Approximation Theory and Approximation Practice*,
+  SIAM, 2013 (extended edition 2019).
+- T. A. Driscoll, N. Hale, and L. N. Trefethen (eds.),
+  [*Chebfun Guide*](https://www.chebfun.org/docs/guide/), Pafnuty
+  Publications, 2014.
+
+We are grateful for their generosity in making this body of work freely
+available; any errors in translation or adaptation are ours alone.

--- a/docs/notebooks/9_infinite_intervals.py
+++ b/docs/notebooks/9_infinite_intervals.py
@@ -11,7 +11,7 @@
 
 import marimo
 
-__generated_with = "0.23.2"
+__generated_with = "0.23.3"
 app = marimo.App()
 
 with app.setup:
@@ -52,10 +52,14 @@ def _():
 
     - Functions that decay rapidly to zero (Gaussians, decaying exponentials) are
       handled cleanly and accurately.
-    - Functions that **don't** decay to zero — heavy tails like $1/(1+x^2)$,
-      slowly-decaying oscillations, or functions approaching a non-zero asymptote
-      like $\tanh$ — are explicitly refused with a
-      `CompactFunConstructionError`.  These cases are out of scope for `v1`.
+    - Functions approaching a **non-zero asymptote** ($\tanh$, logistic
+      sigmoids, …) are also supported: the asymptotic limits are detected
+      automatically and stored as `tail_left` / `tail_right` metadata on the
+      `CompactFun`.  Outside the storage interval the function evaluates to
+      its tail constants rather than to zero.
+    - Functions that genuinely fail the model — heavy algebraic tails like
+      $1/(1+x^2)$, slowly-decaying oscillations, or non-convergent tails — are
+      still explicitly refused with a `CompactFunConstructionError`.
     """)
     return
 
@@ -66,31 +70,33 @@ def _():
     ## A decaying oscillation on $[0, \infty)$
 
     The Chebfun guide opens with $f(x) = 0.75 + \sin(10x)/e^x$ on $[0, \infty)$.
-    Below we represent the decaying part $\sin(10x)/e^x$ as a `CompactFun` on
-    $[0, \infty)$ and add the constant $0.75$ separately:
+    The function approaches the non-zero asymptote $0.75$ as $x \to \infty$, so
+    the probe records `tail_right = 0.75` automatically — the whole expression
+    fits inside a single `CompactFun`:
     """)
     return
 
 
 @app.cell
 def _():
-    f_decay = chebfun(lambda x: np.sin(10 * x) * np.exp(-x), [0, np.inf])
-    f_decay
-    return (f_decay,)
+    f_total = chebfun(lambda x: 0.75 + np.sin(10 * x) * np.exp(-x), [0, np.inf])
+    print(f_total)
+    print("")
+    print(f"tail_right = {f_total.funs[0].tail_right:.15f}   (expected 0.75)")
+    return (f_total,)
 
 
-@app.cell
-def _(f_decay):
+@app.cell(hide_code=True)
+def _(f_total):
     # Find the maximum of 0.75 + sin(10x)/exp(x) on [0, ∞) via critical points.
-    f_total = f_decay + 0.75
     _crit = f_total.diff().roots()
-    _a, _b = f_decay.funs[0].numerical_support
+    _a, _b = f_total.funs[0].numerical_support
     _candidates = np.concatenate([_crit, [_a, _b]])
     _values = f_total(_candidates)
     _idx = int(np.argmax(_values))
     print(f"argmax (in storage window) = {_candidates[_idx]:.15f}")
     print(f"max value                  = {_values[_idx]:.15f}")
-    return (f_total,)
+    return
 
 
 @app.cell
@@ -153,6 +159,7 @@ def _():
 def _():
     h = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, np.inf])
     print(h)
+    print()
     print(f"sum(h)  = {h.sum():.15f}")
     print(f"√π      = {np.sqrt(np.pi):.15f}")
     return (h,)
@@ -183,20 +190,33 @@ def _():
 
 @app.cell
 def _():
-    pdf = chebfun(lambda x: np.exp(-(x**2) / 2.0) / np.sqrt(2.0 * np.pi), [-np.inf, np.inf])
-    pdf2 = pdf.conv(pdf)
-    print(f"sum(pdf)        = {pdf.sum():.15f}  (expected 1)")
-    print(f"sum(pdf*pdf)    = {pdf2.sum():.15f}  (expected 1)")
+    def _f(x):
+        return np.exp(-(x**2) / 2.0) / np.sqrt(2.0 * np.pi)
+
+    pdf1 = chebfun(_f, [-np.inf, np.inf])
+    pdf2 = pdf1.conv(pdf1)
+
+    print(pdf1)
+    print()
+    print(pdf2)
+    return pdf1, pdf2
+
+
+@app.cell(hide_code=True)
+def _(pdf1, pdf2):
+    print(f"sum(pdf1)        = {pdf1.sum():.15f}  (expected 1)")
+    print(f"sum(pdf1*pdf1)   = {pdf2.sum():.15f}  (expected 1)")
     _expected = 1.0 / np.sqrt(4.0 * np.pi)
-    print(f"(pdf*pdf)(0)    = {pdf2(0.0):.15f}")
-    print(f"1/sqrt(4*pi)    = {_expected:.15f}")
-    return pdf, pdf2
+    print()
+    print(f"(pdf1*pdf1)(0)   = {pdf2(0.0):.15f}")
+    print(f"1/sqrt(4*pi)     = {_expected:.15f}")
+    return
 
 
 @app.cell
-def _(pdf, pdf2):
+def _(pdf1, pdf2):
     _fig, _ax = plt.subplots()
-    pdf.plot(ax=_ax, label=r"$\phi(x)$ — $\mathcal{N}(0,1)$")
+    pdf1.plot(ax=_ax, label=r"$\phi(x)$ — $\mathcal{N}(0,1)$")
     pdf2.plot(ax=_ax, label=r"$\phi \star \phi$ — $\mathcal{N}(0,2)$")
     _ax.set_xlim(-6.0, 6.0)
     _ax.set_xlabel("x")
@@ -216,13 +236,14 @@ def _():
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
     expo = chebfun(lambda x: np.exp(-x), [0, np.inf])
     gamma2 = expo.conv(expo)
     print(f"sum(expo*expo)        = {gamma2.sum():.15f}  (expected 1)")
     print(f"(expo*expo)(1)        = {gamma2(1.0):.15f}")
     print(f"1*exp(-1)             = {np.exp(-1.0):.15f}")
+    print()
     print(f"piece types: {[type(_p).__name__ for _p in gamma2.funs]}")
     return expo, gamma2
 
@@ -251,20 +272,20 @@ def _():
 
     - The Cauchy density $\dfrac{1}{\pi(1+x^2)}$ — heavy tails, only $O(1/x^2)$ decay.
     - $\dfrac{1}{1+|x|}$ — even heavier tails, $O(1/x)$ decay.
-    - $\tanh(x-1)$ — does not decay; approaches $\pm 1$.
+    - $\sin(x)$ — non-convergent oscillation at $\pm\infty$.
 
     Each of the following raises a `CompactFunConstructionError`:
     """)
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
     _refused = []
     for _label, _f in [
         ("Cauchy 1/(π(1+x²))", lambda x: 1.0 / (np.pi * (1.0 + x * x))),
         ("1/(1+|x|)", lambda x: 1.0 / (1.0 + np.abs(x))),
-        ("tanh(x-1)", lambda x: np.tanh(x - 1.0)),
+        ("sin(x)", lambda x: np.sin(x)),
     ]:
         try:
             chebfun(_f, [-np.inf, np.inf])
@@ -279,6 +300,73 @@ def _():
 @app.cell(hide_code=True)
 def _():
     mo.md(r"""
+    ## Sigmoid-like inputs: non-zero tail constants
+
+    Functions that approach **finite, non-zero** asymptotic limits at $\pm\infty$
+    — $\tanh$, the logistic sigmoid, smoothed step functions — are supported via
+    `(tail_left, tail_right)` metadata on the `CompactFun`.  The constants are
+    detected automatically by the same probe that locates the numerical-support
+    window, so the user does not need to pass them explicitly.
+
+    Outside the storage interval the function evaluates to its tail constants
+    rather than to zero, and arithmetic with scalars or other `CompactFun`s
+    propagates the tails (e.g. $-f$ flips both, $\alpha f$ scales them, and
+    $f + c$ shifts them).
+    """)
+    return
+
+
+@app.cell
+def _():
+    tanh = chebfun(np.tanh, [-np.inf, np.inf])
+    tanh
+    return (tanh,)
+
+
+@app.cell(hide_code=True)
+def _(tanh):
+    _piece = tanh.funs[0]
+    print(f"  tail_left   =  {_piece.tail_left:+.15f}")
+    print(f"  tail_right  =  {_piece.tail_right:+.15f}")
+    print()
+    print(f"tanh(-1e10)  ->  {tanh(-1e10):+.15f}   (returns tail_left)")
+    print(f"tanh(0.0)    ->  {tanh(0.0):+.15f}")
+    print(f"tanh(+1e10)  ->  {tanh(+1e10):+.15f}   (returns tail_right)")
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
+    Algebraic operations that would diverge on an unbounded domain are still
+    refused — but now with a `DivergentIntegralError` that names the offending
+    operation, rather than silently returning a wrong number:
+
+    - `f.sum()` on a function with a non-zero tail on an infinite side.
+    - `f.cumsum()` on the same (the antiderivative is unbounded).
+    - `f.conv(g)` whenever either operand has a non-zero tail.
+
+    These errors point users at the natural escape hatch: subtract a matched
+    sigmoid first so the residual has zero tails, operate on the residual, then
+    re-add the sigmoid analytically.
+    """)
+    return
+
+
+@app.cell
+def _(tanh):
+    from chebpy.exceptions import DivergentIntegralError
+
+    try:
+        tanh.sum()
+    except DivergentIntegralError as _err:
+        print(f"t.sum() refused: {_err}")
+    return
+
+
+@app.cell(hide_code=True)
+def _():
+    mo.md(r"""
     ## Mixed piecewise: finite breakpoints with infinite endpoints
 
     `chebfun(f, [-inf, a₁, …, a_k, +inf])` produces a `Chebfun` whose two outer
@@ -287,11 +375,13 @@ def _():
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
     p = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, -2.0, 0.0, 3.0, np.inf])
     print(p)
+    print()
     print(f"piece types: {[type(_piece).__name__ for _piece in p.funs]}")
+    print()
     print(f"sum(p)  = {p.sum():.15f}")
     print(f"√π      = {np.sqrt(np.pi):.15f}")
     return (p,)

--- a/docs/plans/02-compactfun-integration.md
+++ b/docs/plans/02-compactfun-integration.md
@@ -1,5 +1,16 @@
 # Plan: CompactFun Integration — Light-Tailed Functions on (−∞, ∞)
 
+> **Status update (plan 02b).** Two of the v1 limitations recorded below
+> have since been lifted by the follow-up plan
+> [`02b-compactfun-tail-constants.md`](02b-compactfun-tail-constants.md):
+> non-zero asymptotic constants (`tanh`, sigmoids) are now representable
+> via `(tail_left, tail_right)` metadata, and `cumsum` now closes inside
+> `CompactFun` (carrying the integral as a right-tail constant) rather
+> than returning a bounded `Chebfun`. Convolution against operands with
+> non-zero tails is still refused — but now with a clear
+> `DivergentIntegralError`. Read this document for the core design;
+> consult plan 02b for the tail-constant extension.
+
 ## Summary
 
 Add support for representing functions on `(−∞, ∞)`, `(−∞, b]`, and `[a, ∞)`

--- a/docs/plans/02b-compactfun-tail-constants.md
+++ b/docs/plans/02b-compactfun-tail-constants.md
@@ -1,0 +1,337 @@
+# Plan: CompactFun Tail-Constants Extension — Non-Zero Asymptotes
+
+## Summary
+
+Extend `CompactFun` (introduced in
+[02-compactfun-integration.md](02-compactfun-integration.md)) to support
+functions whose limits at `±∞` are **non-zero constants**: `tanh`, sigmoids,
+smoothed step functions, and any superposition of a decaying density with a
+piecewise-constant background. The extension adds two scalar metadata fields
+`tail_left`, `tail_right` to `CompactFun` and propagates them through
+arithmetic, calculus, and evaluation. The `(0, 0)` special case reproduces
+plan 02 exactly, so this is a pure superset — no behavioural change for
+existing `CompactFun` users.
+
+The headline observation is that an additive skeleton
+
+$$
+f(x) \;=\; b(x) \;+\; r(x), \qquad r(x) \xrightarrow{|x|\to\infty} 0
+$$
+
+with `b(x)` a closed-form bridge between `tail_left` and `tail_right` makes
+the residual `r` a standard zero-tail `CompactFun`. We do **not** store `b`
+explicitly — it is folded into the `Onefun` sample values during
+construction. What we store is just the pair `(tail_left, tail_right)` plus
+the standard `Onefun` on the discovered storage interval. This keeps the
+representation minimal and makes operator rules algebraic on the tail pair:
+
+| Op | New `tail_left` | New `tail_right` |
+|---|---|---|
+| `α · f` | `α · L` | `α · R` |
+| `f + g` | `L_f + L_g` | `R_f + R_g` |
+| `f · g` | `L_f · L_g` | `R_f · R_g` |
+| `f.diff()` | `0` | `0` |
+| `f.cumsum()` | finite iff `L = 0` | finite iff `R = 0` |
+| `conv(f, g)` | refused unless both decay (zero tails on both sides for at least one operand) | as left |
+
+## Relationship to plan 02
+
+Plan 02 ships first and assumes `tail_left = tail_right = 0`. This plan
+relaxes that assumption. After landing 02b:
+
+- **Refusal removed:** the explicit "non-zero asymptote" refusal in
+  `CompactFun` construction is replaced by a probe path that detects tail
+  constants.
+- **No API break:** existing zero-tail `CompactFun` instances continue to
+  behave identically; defaults for `tail_left`, `tail_right` are `0.0`.
+- **Out-of-scope items in plan 02 that stay out of scope here:** heavy
+  tails, the rational-map `Unbndfun`, `'exps'` / singularities, mixed
+  `Chebfun`s combining bounded and unbounded segments.
+
+## What we are NOT doing in this PR
+
+1. **Heavy / fat tails** — still deferred (plan 02's exclusion stands).
+2. **Convolution with non-decaying signals** — mathematically ill-posed on
+   `ℝ`; we refuse with a clear error.
+3. **Singularities / `'exps'`.** A multiplicative skeleton `f = s · r` is
+   the natural fit there; that is a separate plan.
+4. **Bridge-shape user customisation.** The bridge is an internal
+   implementation detail. Users see only `(tail_left, tail_right)`.
+
+## Background
+
+For `f: ℝ → ℝ` with `lim_{x→−∞} f(x) = L` and `lim_{x→+∞} f(x) = R`
+(both finite, possibly equal, possibly zero), pick a smooth bridge
+`b(x; L, R, w, x₀)` satisfying
+
+$$
+b(-\infty) = L, \qquad b(+\infty) = R, \qquad b - L,\; b - R \;\;\text{decay super-exponentially}.
+$$
+
+The natural choice is the error-function bridge
+
+$$
+b(x) \;=\; \tfrac{L+R}{2} \;+\; \tfrac{R-L}{2}\,\operatorname{erf}\!\left(\frac{x - x_0}{w}\right)
+$$
+
+with `(x₀, w)` chosen from the numsupp probe so that the residual
+`r(x) = f(x) − b(x)` decays to zero within the storage interval at
+tolerance `tol`. The `erf` choice is favoured because:
+
+- super-exponential tails ⇒ `r` is genuinely zero at machine precision
+  outside a modest window;
+- monotone, infinitely smooth ⇒ no artificial features introduced into the
+  residual;
+- centred and symmetric ⇒ `(x₀, w)` are the only free parameters.
+
+Crucially `b` is **not stored**. Once `r` is approximated by a `Onefun` on
+the discovered storage interval `[a, b_storage]`, evaluation outside that
+interval is `tail_left` (left of `a`) or `tail_right` (right of `b_storage`).
+Inside the storage interval, evaluation is `b(x) + r(x)` — but since both
+were folded into the `Onefun` at construction time, this is just
+`onefun(invmap(x))`. The bridge is purely a construction-time fitting
+device.
+
+## Design decisions
+
+1. **Two scalars are enough metadata.** The full bridge shape `(x₀, w)` is
+   a fitting choice that affects only the construction quality of `r`; it
+   does not need to be persisted. Two scalars `(tail_left, tail_right)`
+   carry all the algebraic information operators need.
+
+2. **The `(0, 0)` case is identical to plan 02.** No code path for zero-tail
+   `CompactFun` changes. New code is gated on
+   `tail_left != 0.0 or tail_right != 0.0`.
+
+3. **Bridge family is `erf` only in v1.** A single bridge family keeps the
+   construction code small. Future work may add `tanh`-bridge or
+   `½(1+x/√(1+x²))`-bridge variants for badly-conditioned cases.
+
+4. **Closure under `+`, `−`, `*`, `α·` is algebraic on the tail pair.**
+   The new `Onefun` of the result is constructed by re-sampling `f_op_g`
+   on the union/intersection of storage intervals after subtracting the
+   new combined bridge — exactly the existing "recompute numsupp on the
+   result" step generalised. No new spectral machinery is needed.
+
+5. **`sum` honours mathematical truth.** If either tail is non-zero on its
+   unbounded side, `sum` raises `DivergentIntegralError`. This is correct:
+   `tanh` is not Lebesgue-integrable on `ℝ`. Differences of sigmoids that
+   share asymptotes (residual tails are zero after subtraction) integrate
+   normally — and the metadata model handles this automatically.
+
+6. **`cumsum` extends naturally.** For `[a, ∞)` the antiderivative `F` is
+   finite at `+∞` iff `tail_right = 0`; if so, `F` is itself a
+   `CompactFun` with `tail_left_F = F(a)` and `tail_right_F = ∫f`. This
+   removes the plan-02 caveat that `cumsum` does not close: with tail
+   metadata it does close, provided the integrability condition holds.
+
+7. **`conv` refuses non-decaying inputs.** Convolution of two functions
+   with non-zero asymptotes on the same side diverges. We refuse with a
+   clear `DivergentIntegralError`. Mixed cases (one operand zero-tailed,
+   one not) are *also* refused in v1; revisit if a use case appears.
+
+8. **Detection at construction.** The numsupp probe is extended: instead
+   of looking for `|f| < tol · vscale`, it checks whether `f(±10^k)`
+   *converges to a constant*. If it does, the constant becomes the tail
+   value and bridge fitting kicks in.
+
+## API surface
+
+### User-facing
+
+```python
+from numpy import inf, tanh
+from chebpy import chebfun
+
+# Sigmoid: tail_left = -1, tail_right = +1
+f = chebfun(tanh, [-inf, inf])
+f.tail_left, f.tail_right     # (-1.0, 1.0)
+f(-1e6)                       # -1.0   (returned from tail_left)
+f(0.0)                        # 0.0    (from onefun)
+f(1e6)                        # +1.0   (returned from tail_right)
+f.support                     # [-inf, inf]
+
+# Algebraic closure: difference of two sigmoids has zero tails
+g = chebfun(lambda x: tanh(x - 5), [-inf, inf])
+h = f - g
+h.tail_left, h.tail_right     # (0.0, 0.0)
+h.sum()                       # well-defined, finite
+
+# Sum of a non-decaying function diverges (correctly)
+f.sum()
+# DivergentIntegralError: integrand has non-zero asymptotic limit
+# tail_left=-1.0, tail_right=+1.0; integral over (-inf, inf) diverges.
+
+# Convolution refuses
+f.conv(g)
+# DivergentIntegralError: convolution requires at least one operand to
+# decay to zero at ±inf; got tail_left=-1.0, tail_right=+1.0 for self.
+```
+
+### New / changed internal symbols
+
+| Symbol | Location | Purpose |
+|---|---|---|
+| `CompactFun.tail_left, .tail_right` | `compactfun.py` | Two new scalar attributes; default `0.0` |
+| `_detect_tail_constants(f, side, tol, max_probes)` | `compactfun.py` | Replaces / extends `_discover_numsupp` |
+| `_erf_bridge(L, R, x0, w)` | `compactfun.py` | Constructs the bridge function used during sampling |
+| `CompactFun._combine_tails(other, op)` | `compactfun.py` | Helper used by arithmetic operators |
+| `DivergentIntegralError` | `exceptions.py` | New (or reuse existing if present) |
+
+## Integration steps
+
+1. **Construction — `compactfun.py`**
+   - Add `tail_left`, `tail_right` parameters to `__init__`, defaulting to
+     `0.0`. Persist on the instance.
+   - Extend the numsupp probe to detect convergence to a constant on each
+     unbounded side: probe `f(σ · 10^k)` for `k = 0..K` (`σ = ±1` per
+     side); if `f(σ · 10^k) − f(σ · 10^{k+1})` falls below
+     `tol · max(1, |f|)`, the limit is the running mean of the last few
+     probes — that is the detected tail constant.
+   - If the detected constant is `0` (within tolerance), fall through to
+     the plan-02 zero-tail path unchanged.
+   - Otherwise: pick a bridge centre `x₀` (zero of `f − ½(L+R)` if it
+     exists in the probed range, else `0`) and width `w` (smallest scale
+     at which `|f − b| < tol · max(|L|, |R|, 1)`); fit the residual
+     `r(x) = f(x) − b(x)` with the existing `Classicfun.initfun_adaptive`
+     on the discovered storage interval `[a, b_storage]`.
+   - Store the *bridged* `Onefun` directly: i.e. sample `f` (not `r`) on
+     `[a, b_storage]`. The bridge is only a fitting device for choosing
+     `(a, b_storage)`; the `Onefun` itself represents `f` on its storage
+     interval as usual. This means inside the storage interval evaluation
+     is unchanged from plan 02; only outside-interval evaluation differs.
+
+2. **Evaluation — `__call__`**
+   - For `x` outside the storage interval:
+     - if `x < a` and logical-left is `-inf`: return `tail_left`;
+     - if `x > b_storage` and logical-right is `+inf`: return
+       `tail_right`;
+     - else (finite logical endpoint nearby): unchanged from plan 02
+       (return `0`, or whatever plan 02 specifies).
+   - Inside the storage interval: unchanged.
+
+3. **`endvalues`**
+   - Return `(tail_left, tail_right)` where the corresponding logical
+     endpoint is `±inf`; otherwise the existing finite-endpoint values.
+
+4. **Arithmetic — `compactfun.py`**
+   - `__neg__`: negate both tails.
+   - `__add__`, `__sub__`: tails add/subtract; storage interval becomes the
+     union; rebuild `Onefun` of `f ± g` by resampling on the union (same
+     as plan 02's "recompute numsupp on the result").
+   - `__mul__`: tails multiply; storage interval becomes the union (not
+     intersection — the product `(L_f + r_f)(L_g + r_g)` is non-trivial
+     wherever either `r_f` or `r_g` is non-trivial); rebuild.
+   - Scalar `α · f`: tails scale by `α`; storage interval unchanged.
+   - **Optimisation:** if both operand tails are zero, dispatch to the
+     plan-02 fast paths (intersection-based product etc.) without
+     rebuilding bridges.
+
+5. **Calculus**
+   - `diff`: result tails are `(0, 0)` (derivative of a constant is zero).
+     Storage interval inherited.
+   - `cumsum`:
+     - For `[-inf, +inf]`: requires `tail_left = 0`; result has
+       `tail_left_F = 0`, `tail_right_F = ∫f` (using the existing `sum`
+       on the storage interval).
+     - For `[a, +inf]`: same condition on `tail_right`-driven divergence
+       at `+∞` (must be `0` for the integral to be finite); result is
+       `CompactFun` with `tail_right_F = ∫f`.
+     - For `[-inf, b]`: symmetric.
+     - When the divergence condition fails, raise
+       `DivergentIntegralError` (do not silently truncate).
+   - `sum`:
+     - Raise `DivergentIntegralError` if `tail_left ≠ 0` and logical-left
+       is `-inf`, or `tail_right ≠ 0` and logical-right is `+inf`.
+     - Otherwise inherit `Classicfun.sum` on the storage interval.
+
+6. **Convolution**
+   - `conv` checks both operands' tails. If either operand has any
+     non-zero tail on an unbounded side, raise `DivergentIntegralError`
+     with a message pointing the user to the algebraic-closure escape
+     hatch (subtract matching sigmoids first, convolve the residual).
+   - All zero-tail paths inherit plan 02 behaviour unchanged.
+
+7. **Display — `__repr__`**
+   - Show tail constants when non-zero, e.g.:
+     `CompactFun([-inf, +inf], n=42, tails=(-1.0, +1.0))`.
+   - When both tails are zero, fall back to plan 02's repr.
+
+8. **Settings — `settings.py`**
+   - Reuse `prefs.numsupp_tol`, `prefs.numsupp_max_probes`,
+     `prefs.numsupp_max_width` from plan 02.
+   - Optional: `prefs.tail_detect_tol = prefs.numsupp_tol` for the
+     constant-convergence test (default to `numsupp_tol` if unset).
+
+9. **Exceptions — `exceptions.py`**
+   - Add `DivergentIntegralError(ValueError)` if not already present.
+
+10. **Tests — `tests/test_compactfun_tails.py`** (new file, parallel of
+    `test_compactfun.py` from plan 02)
+    - **Construction**: `tanh`, `1/(1+exp(-x))`, smoothed step
+      `½(1+erf(x/w))`, constant offsets `c + Gaussian` — verify detected
+      `(tail_left, tail_right)` matches analytical limits to `tol`.
+    - **Evaluation**: `f(±1e10)` returns the tail constants exactly (no
+      Onefun extrapolation).
+    - **Algebra**:
+      - `tanh(x) − tanh(x − a)` has zero tails and finite `sum` (equals
+        `2a` analytically — useful sanity check).
+      - `α · tanh(x)` has tails `(±α)`.
+      - Product `tanh(x) · sech²(x)` has tails `(0, 0)` (because
+        `sech² → 0`); the product machinery should recover this.
+    - **Calculus**:
+      - `tanh(x).diff()` = `sech²(x)` with zero tails; round-trip via
+        `cumsum` recovers `tanh(x) − tanh(a)`.
+      - `cumsum` of a Gaussian on `[-inf, +inf]` is an `erf`-shaped
+        `CompactFun` with `tail_left = 0`, `tail_right = √π`.
+      - `sum(tanh)` raises `DivergentIntegralError`.
+    - **Convolution refusal**: `tanh.conv(Gaussian)` raises with a clear
+      message; subtracting matched sigmoids first then convolving works.
+    - **Backward compatibility**: every test in `test_compactfun.py`
+      (plan 02) still passes unchanged.
+
+## Out of scope (deferred)
+
+- Multiplicative skeletons (singfun-style `'exps'`). Different feature.
+- Tail-aware convolution via Fourier/principal-value tricks.
+- User-pluggable bridge families.
+- Heavy tails, rational-map `Unbndfun`, mixed bounded/unbounded
+  `Chebfun`s.
+
+## Risks & open questions
+
+- **Bridge-fitting robustness.** Functions with very slow approach to
+  their asymptote (`1/log(x)`-like) will be misclassified as non-converging
+  by the probe and refused as heavy-tailed. This is acceptable in v1 —
+  any user hitting it is in heavy-tail territory.
+- **Tail detection on noisy callables.** If the user passes a numerically
+  noisy function (e.g. a Monte Carlo estimator), the constant-convergence
+  test may be fooled. Mitigation: the test uses a generous tolerance
+  (`prefs.tail_detect_tol`, default = `numsupp_tol`) and requires three
+  consecutive probes to agree.
+- **Equal-but-non-zero tails.** `f(x) = c + Gaussian` has
+  `tail_left = tail_right = c`. The bridge degenerates to a constant `c`
+  in this case; the residual is just the Gaussian. This is the simplest
+  case and should be the smoke test.
+- **Conv refusal feels strict.** Some users might reasonably want
+  `tanh.conv(narrow_kernel)` interpreted as "convolve the smooth part".
+  We refuse to keep semantics honest; the documented escape hatch is to
+  subtract a matched sigmoid first.
+
+## Dependencies
+
+- Builds directly on plan 02 (`CompactFun`, numsupp discovery,
+  `_conv_legendre` reuse).
+- Independent of trigtech, singfun, heavy-tail, and `Unbndfun` work.
+
+## Migration notes
+
+After 02b lands, two lines in plan 02's text become inaccurate and should
+be removed or amended:
+
+- The "non-zero asymptote" entry in §"What we are NOT doing in this PR".
+- The `cumsum` design decision claiming `cumsum` does not close — with
+  tail metadata it does close, subject to the standard integrability
+  condition.
+
+These are documentation-only follow-ups; no code in plan 02 changes.

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -1,0 +1,6 @@
+# Reports
+
+Generated test and coverage reports for the latest build.
+
+- [Test Report](reports/html-report/report.html) — pytest results.
+- [Coverage Report](reports/html-coverage/index.html) — line/branch coverage.

--- a/docs/user/features/approximation.md
+++ b/docs/user/features/approximation.md
@@ -55,3 +55,17 @@ from chebpy import chebpts
 pts, wts = chebpts(16)              # 16 points on [-1, 1]
 pts, wts = chebpts(16, [0, 3])      # 16 points on [0, 3]
 ```
+
+## References
+
+- Z. Battles and L. N. Trefethen,
+  [*An extension of MATLAB to continuous functions and operators*](https://epubs.siam.org/doi/10.1137/S1064827503430126),
+  SIAM J. Sci. Comput., 25 (2004), pp. 1743–1770.
+- L. N. Trefethen, *Approximation Theory and Approximation Practice*,
+  SIAM, 2013 (extended edition 2019).
+- J. L. Aurentz and L. N. Trefethen,
+  [*Chopping a Chebyshev series*](https://dl.acm.org/doi/10.1145/2998442),
+  ACM Trans. Math. Softw., 43 (2017), Article 33.
+- R. Pachón, R. B. Platte, and L. N. Trefethen,
+  [*Piecewise-smooth chebfuns*](https://academic.oup.com/imajna/article/30/4/898/659725),
+  IMA J. Numer. Anal., 30 (2010), pp. 898–916.

--- a/docs/user/features/arithmetic.md
+++ b/docs/user/features/arithmetic.md
@@ -45,3 +45,12 @@ print(f.norm())          # L2 norm
 print(np.max(f))         # maximum value
 print(np.min(f))         # minimum value
 ```
+
+## References
+
+- Z. Battles and L. N. Trefethen,
+  [*An extension of MATLAB to continuous functions and operators*](https://epubs.siam.org/doi/10.1137/S1064827503430126),
+  SIAM J. Sci. Comput., 25 (2004), pp. 1743–1770.
+- T. A. Driscoll, N. Hale, and L. N. Trefethen (eds.),
+  [*Chebfun Guide*](https://www.chebfun.org/docs/guide/),
+  Pafnuty Publications, 2014.

--- a/docs/user/features/calculus.md
+++ b/docs/user/features/calculus.md
@@ -42,3 +42,13 @@ df = F.diff()
 # df should agree with f to machine precision
 print(np.max(np.abs(f(np.linspace(-1, 1, 100)) - df(np.linspace(-1, 1, 100)))))
 ```
+
+## References
+
+- L. N. Trefethen, *Approximation Theory and Approximation Practice*,
+  SIAM, 2013 (extended edition 2019), chs. 19–21 (differentiation, integration, quadrature).
+- L. N. Trefethen, [*Is Gauss quadrature better than Clenshaw–Curtis?*](https://epubs.siam.org/doi/10.1137/060659831),
+  SIAM Review, 50 (2008), pp. 67–87.
+- T. A. Driscoll, N. Hale, and L. N. Trefethen (eds.),
+  [*Chebfun Guide*](https://www.chebfun.org/docs/guide/),
+  Pafnuty Publications, 2014.

--- a/docs/user/features/convolution.md
+++ b/docs/user/features/convolution.md
@@ -27,3 +27,12 @@ $[a_g, b_g]$ are the domains of `f` and `g` respectively.
 Convolution is computed by converting to Legendre coefficients, exploiting the
 linearisation property of Legendre polynomials, and converting back to Chebyshev
 form.
+
+## References
+
+- N. Hale and A. Townsend,
+  [*An algorithm for the convolution of Legendre series*](https://epubs.siam.org/doi/10.1137/140955835),
+  SIAM J. Sci. Comput., 36 (2014), pp. A1207–A1220.
+- N. Hale and A. Townsend,
+  [*A fast, simple, and stable Chebyshev–Legendre transform using an asymptotic formula*](https://epubs.siam.org/doi/10.1137/130932223),
+  SIAM J. Sci. Comput., 36 (2014), pp. A148–A167.

--- a/docs/user/features/gpr.md
+++ b/docs/user/features/gpr.md
@@ -46,7 +46,11 @@ f_mean, f_var = gpr(x_obs, y_obs, domain=[-2, 2], n_samples=5)
 # f_var is a Quasimatrix with 5 sample columns
 ```
 
-## Reference
+## References
 
-C. E. Rasmussen & C. K. I. Williams, *Gaussian Processes for Machine Learning*,
-MIT Press, 2006.
+- C. E. Rasmussen and C. K. I. Williams,
+  [*Gaussian Processes for Machine Learning*](https://gaussianprocess.org/gpml/),
+  MIT Press, 2006.
+- T. P. Fournier, A. Townsend, and H. D. Wilber,
+  [*Continuous Gaussian process regression with Chebfun*](https://arxiv.org/abs/2202.04465),
+  arXiv preprint, 2022.

--- a/docs/user/features/infinite-intervals.md
+++ b/docs/user/features/infinite-intervals.md
@@ -95,6 +95,6 @@ pdf2(0.0)     # ≈ 1 / sqrt(4π)
 - T. A. Driscoll, N. Hale, and L. N. Trefethen (eds.),
   [*Chebfun Guide*](https://www.chebfun.org/docs/guide/),
   Pafnuty Publications, 2014, ch. 9.
-- M. Richardson,
-  [*Approximating divergent functions in the Chebfun system*](https://ora.ox.ac.uk/objects/uuid:24a5d1c2-fb24-4ad7-8a16-c7c0bd0bda99),
-  DPhil thesis, University of Oxford, 2013.
+- M. Richardson and L. N. Trefethen,
+  [*A sinc function analogue of Chebfun*](https://epubs.siam.org/doi/10.1137/110825947),
+  SIAM J. Sci. Comput., 33 (2011), pp. 2519–2535.

--- a/docs/user/features/infinite-intervals.md
+++ b/docs/user/features/infinite-intervals.md
@@ -89,3 +89,12 @@ pdf2(0.0)     # ≈ 1 / sqrt(4π)
 - The [Infinite Intervals notebook](../../notebooks/9_infinite_intervals.html)
   for a tour of worked examples adapted from §9.1 of the Chebfun guide.
 - The [Convolution](convolution.md) page for finite-interval convolution.
+
+## References
+
+- T. A. Driscoll, N. Hale, and L. N. Trefethen (eds.),
+  [*Chebfun Guide*](https://www.chebfun.org/docs/guide/),
+  Pafnuty Publications, 2014, ch. 9.
+- M. Richardson,
+  [*Approximating divergent functions in the Chebfun system*](https://ora.ox.ac.uk/objects/uuid:24a5d1c2-fb24-4ad7-8a16-c7c0bd0bda99),
+  DPhil thesis, University of Oxford, 2013.

--- a/docs/user/features/periodic.md
+++ b/docs/user/features/periodic.md
@@ -79,3 +79,12 @@ for a worked example.
 - [`Trigtech` API reference](../../api.md)
 - The [Function Approximation](approximation.md) page for the default
   Chebyshev-based construction.
+
+## References
+
+- G. B. Wright, M. Javed, H. Montanelli, and L. N. Trefethen,
+  [*Extension of Chebfun to periodic functions*](https://epubs.siam.org/doi/abs/10.1137/141001007),
+  SIAM J. Sci. Comput., 37 (2015), pp. C554–C573.
+- L. N. Trefethen and J. A. C. Weideman,
+  [*The exponentially convergent trapezoidal rule*](https://epubs.siam.org/doi/10.1137/130932132),
+  SIAM Review, 56 (2014), pp. 385–458.

--- a/docs/user/features/plotting.md
+++ b/docs/user/features/plotting.md
@@ -44,3 +44,9 @@ ax.legend()
 ax.grid(True, alpha=0.3)
 plt.show()
 ```
+
+## References
+
+- J. D. Hunter,
+  [*Matplotlib: A 2D Graphics Environment*](https://doi.org/10.1109/MCSE.2007.55),
+  Computing in Science & Engineering, 9 (2007), pp. 90–95.

--- a/docs/user/features/quasimatrix.md
+++ b/docs/user/features/quasimatrix.md
@@ -49,7 +49,14 @@ f = chebfun(lambda x: np.exp(x), [-1, 1])
 p = polyfit(f, 5)   # degree-5 polynomial least-squares fit
 ```
 
-## Reference
+## References
 
-L. N. Trefethen, "Householder triangularization of a quasimatrix,"
-*IMA Journal of Numerical Analysis*, 30 (2010), 887–897.
+- L. N. Trefethen,
+  [*Householder triangularization of a quasimatrix*](https://academic.oup.com/imajna/article/30/4/887/659727),
+  IMA J. Numer. Anal., 30 (2010), pp. 887–897.
+- Z. Battles and L. N. Trefethen,
+  [*An extension of MATLAB to continuous functions and operators*](https://epubs.siam.org/doi/10.1137/S1064827503430126),
+  SIAM J. Sci. Comput., 25 (2004), pp. 1743–1770.
+- A. Townsend and L. N. Trefethen,
+  [*Continuous analogues of matrix factorizations*](https://royalsocietypublishing.org/doi/10.1098/rspa.2014.0585),
+  Proc. Roy. Soc. A, 471 (2015), 20140585.

--- a/docs/user/features/rootfinding.md
+++ b/docs/user/features/rootfinding.md
@@ -43,3 +43,14 @@ from chebpy import UserPreferences
 prefs = UserPreferences()
 prefs.sortroots = True
 ```
+
+## References
+
+- I. J. Good,
+  [*The colleague matrix, a Chebyshev analogue of the companion matrix*](https://academic.oup.com/qjmath/article/12/1/61/1573665),
+  Quart. J. Math. Oxford, 12 (1961), pp. 61–68.
+- J. P. Boyd,
+  [*Computing zeros on a real interval through Chebyshev expansion and polynomial rootfinding*](https://epubs.siam.org/doi/10.1137/S0036142901398325),
+  SIAM J. Numer. Anal., 40 (2002), pp. 1666–1682.
+- L. N. Trefethen, *Approximation Theory and Approximation Practice*,
+  SIAM, 2013 (extended edition 2019), ch. 18.

--- a/docs/user/intro.md
+++ b/docs/user/intro.md
@@ -50,8 +50,17 @@ Once a function is represented as a Chebfun, operations such as differentiation,
 integration, and root-finding reduce to operations on the Chebyshev coefficients
 and are performed in $O(n)$ or $O(n \log n)$ time, where $n$ is the polynomial degree.
 
+## Acknowledgments
+
+ChebPy is a Python adaptation of the **Chebfun project** led by
+[Nick Trefethen](https://people.maths.ox.ac.uk/trefethen/) and the Chebfun
+development team at the University of Oxford. We follow their mathematical
+design, algorithms, and naming conventions throughout, and gratefully
+acknowledge the decades of open scholarship that made this port possible.
+
 ## References
 
 - L. N. Trefethen, *Approximation Theory and Approximation Practice*, SIAM, 2013.
 - T. A. Driscoll, N. Hale, and L. N. Trefethen (eds.), *Chebfun Guide*, Pafnuty Publications, 2014.
-- [chebfun.org](http://www.chebfun.org/)
+- [chebfun.org](http://www.chebfun.org/) — the original MATLAB Chebfun system.
+- [github.com/chebfun/chebfun](https://github.com/chebfun/chebfun) — Chebfun source on GitHub.

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Quickstart
 
 This guide walks you through the basics of ChebPy in a few minutes.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,33 +57,37 @@ extra_javascript:
 
 nav:
   - Home: index.md
-  - Getting Started: user/quickstart.md
-  - API Reference: api.md
+  - Quickstart: user/quickstart.md
   - User Guide:
       - Introduction: user/intro.md
       - Installation: user/install.md
       - Features:
-          - Function Approximation: user/features/approximation.md
-          - Periodic Functions: user/features/periodic.md
-          - Infinite Intervals: user/features/infinite-intervals.md
+          - Approximation: user/features/approximation.md
+          - Arithmetic: user/features/arithmetic.md
           - Calculus: user/features/calculus.md
           - Root-Finding: user/features/rootfinding.md
-          - Arithmetic: user/features/arithmetic.md
           - Plotting: user/features/plotting.md
-          - Convolution: user/features/convolution.md
-          - Quasimatrices: user/features/quasimatrix.md
-          - Gaussian Process Regression: user/features/gpr.md
+          - Periodic Functions: user/features/periodic.md
+          - Infinite Intervals: user/features/infinite-intervals.md
+          - Fast Convolution: user/features/convolution.md
+          - Quasimatrix Algebra: user/features/quasimatrix.md
+          - Gaussian Processes: user/features/gpr.md
   - Notebooks:
       - Overview: notebooks/index.md
       - Introduction: notebooks/1_introduction.html
       - Examples: notebooks/2_examples.html
       - Complex Chebfuns: notebooks/3_complex.html
-      - Quasimatrices: notebooks/4_quasimatrix.html
-      - Convolution: notebooks/5_convolution.html
-      - Gaussian Process Regression: notebooks/6_gaussian_process.html
-      - Variance Swap: notebooks/7_variance_swap.html
       - Periodic Representations: notebooks/8_periodic.html
       - Infinite Intervals: notebooks/9_infinite_intervals.html
+      - Fast Convolution: notebooks/5_convolution.html
+      - Quasimatrix Algebra: notebooks/4_quasimatrix.html
+      - Gaussian Processes: notebooks/6_gaussian_process.html
+      - Variance Swap Replication: notebooks/7_variance_swap.html
+  - Reports:
+      - Overview: reports.md
+      - Test Report: reports/html-report/report.html
+      - Coverage Report: reports/html-coverage/index.html
+  - API Reference: api.md
   - Developer:
       - Contributing: CONTRIBUTING.md
       - Code of Conduct: CODE_OF_CONDUCT.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,3 +91,4 @@ nav:
   - Developer:
       - Contributing: CONTRIBUTING.md
       - Code of Conduct: CODE_OF_CONDUCT.md
+  - History: history.md

--- a/src/chebpy/chebfun.py
+++ b/src/chebpy/chebfun.py
@@ -386,7 +386,6 @@ class Chebfun:
         numpcs = self.funs.size
         plural = "" if numpcs == 1 else "s"
         header = f"Chebfun {rowcol} ({numpcs} smooth piece{plural})\n"
-        domain_info = f"domain: {self.support}\n"
         toprow = "       interval       length     endpoint values\n"
         tmplat = "[{:8.2g},{:8.2g}]   {:6}  {:8.2g} {:8.2g}\n"
         rowdta = ""
@@ -398,7 +397,7 @@ class Chebfun:
             rowdta += row
         btmrow = f"vertical scale = {self.vscale:3.2g}"
         btmxtr = "" if numpcs == 1 else f"    total length = {sum([f.size for f in self])}"
-        return header + domain_info + toprow + rowdta + btmrow + btmxtr
+        return header + toprow + rowdta + btmrow + btmxtr
 
     def __rsub__(self, f: Any) -> Any:
         """Subtract this Chebfun from another object.
@@ -922,6 +921,21 @@ class Chebfun:
         # CompactFun pieces (with possibly infinite logical support) always
         # take the general piecewise path so the output is wrapped correctly.
         from .compactfun import CompactFun
+        from .exceptions import DivergentIntegralError
+
+        # Convolution of a function with non-zero asymptotic limits diverges
+        # on an unbounded interval, so refuse early with a clear error
+        # pointing the user at the algebraic-closure escape hatch.
+        for label, h in (("self", self), ("other", g)):
+            for piece in h.funs:
+                if isinstance(piece, CompactFun) and (piece.tail_left != 0.0 or piece.tail_right != 0.0):
+                    raise DivergentIntegralError(  # noqa: TRY003
+                        f"Convolution requires both operands to decay to zero at "
+                        f"±inf; got tail_left={piece.tail_left}, "
+                        f"tail_right={piece.tail_right} for {label}. Consider "
+                        f"subtracting a matched sigmoid first so the residual "
+                        f"has zero tails, then convolving the residual."
+                    )
 
         any_compact = any(isinstance(fun, CompactFun) for fun in self.funs) or any(
             isinstance(fun, CompactFun) for fun in g.funs

--- a/src/chebpy/compactfun.py
+++ b/src/chebpy/compactfun.py
@@ -4,25 +4,28 @@ This module provides the :class:`CompactFun` class, which sits next to
 :class:`~chebpy.bndfun.Bndfun` under :class:`~chebpy.classicfun.Classicfun`.
 It represents functions whose user-facing logical interval has one or both
 endpoints at ``±inf`` but whose **numerical support** — the set of points
-where the function exceeds a configured tolerance — is finite.  Internally,
-a :class:`CompactFun` stores a standard :class:`~chebpy.onefun.Onefun`
-(Chebtech) on the discovered finite storage interval; outside that interval
-the function is reported as identically zero.
+where the function differs from its asymptotic limit by more than a
+configured tolerance — is finite.  Internally, a :class:`CompactFun` stores
+a standard :class:`~chebpy.onefun.Onefun` (Chebtech) on the discovered
+finite storage interval; outside that interval the function is reported as
+the corresponding asymptotic constant (``tail_left`` or ``tail_right``,
+default ``0``).
 
 This approach is a deliberate departure from MATLAB Chebfun's ``@unbndfun``
 (which uses a rational change of variables to map ``(-inf, inf)`` onto
-``[-1, 1]``).  See ``docs/plans/02-compactfun-integration.md`` for the design
-rationale and scope.
+``[-1, 1]``).  See ``docs/plans/02-compactfun-integration.md`` for the
+zero-tail design and ``docs/plans/02b-compactfun-tail-constants.md`` for
+the non-zero asymptote extension.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
 from .classicfun import Classicfun, techdict
-from .exceptions import CompactFunConstructionError
+from .exceptions import CompactFunConstructionError, DivergentIntegralError
 from .settings import _preferences as prefs
 from .utilities import Interval
 
@@ -39,12 +42,13 @@ def _ensure_endpoints(interval: Any) -> tuple[float, float]:
 
 def _discover_one_side(
     f: Any, anchor: float, sign: int, tol: float, max_width: float, max_probes: int
-) -> tuple[float, float]:
+) -> tuple[float, float, float]:
     """Discover the numerical-support boundary on one infinite side.
 
     Probes ``f`` at ``anchor + sign * 2**k`` for ``k = 0, 1, 2, ...`` up to
-    the configured budget.  Returns the discovered finite boundary and the
-    observed vertical scale on this side.
+    the configured budget.  Detects the asymptotic limit ``L`` of ``f`` on
+    this side (which may be zero or non-zero) and returns the smallest
+    finite boundary beyond which ``|f - L| < tol * scale``.
 
     Args:
         f: Callable being approximated.
@@ -52,29 +56,30 @@ def _discover_one_side(
             interval, or ``0.0`` for the doubly-infinite case).
         sign: ``+1`` for the rightward (toward ``+inf``) side, ``-1`` for the
             leftward side.
-        tol: Relative tolerance threshold; the boundary is the smallest
-            ``r`` for which ``|f(anchor + sign * r)| < tol * vscale`` for
-            all probes farther out.
+        tol: Relative tolerance threshold for both convergence detection and
+            boundary placement.
         max_width: Maximum permitted boundary distance from ``anchor``.
         max_probes: Maximum number of geometric probes.
 
     Returns:
-        Tuple ``(boundary, vscale)`` where ``boundary`` is a finite ``float``
-        and ``vscale`` is the largest absolute probed value on this side.
+        Tuple ``(boundary, tail, vscale)`` where ``boundary`` is the finite
+        boundary, ``tail`` is the detected asymptotic constant (``0.0`` if
+        the function decays to zero), and ``vscale`` is the largest
+        absolute probed value on this side.
 
     Raises:
-        CompactFunConstructionError: If the function does not decay below
-            ``tol * vscale`` within the probing budget or ``max_width``.
+        CompactFunConstructionError: If ``f`` does not converge to a
+            constant within the probing budget or ``max_width``.
     """
     radii: list[float] = []
-    values: list[float] = []
+    values: list[float] = []  # signed values
     r = 1.0
     for _ in range(max_probes):
         if r > max_width:
             break
         x = anchor + sign * r
         try:
-            v = float(np.abs(f(x)))
+            v = float(f(x))
         except (FloatingPointError, OverflowError, ZeroDivisionError) as err:  # pragma: no cover
             raise CompactFunConstructionError(  # noqa: TRY003
                 f"Could not evaluate f at probe x = {x:g} during numerical-support discovery"
@@ -87,26 +92,46 @@ def _discover_one_side(
         radii.append(r)
         values.append(v)
         r *= 2.0
+
     if not radii:
-        return anchor + sign * 1.0, 0.0
+        return anchor + sign * 1.0, 0.0, 0.0
 
-    vscale = max(values) if values else 0.0
-    threshold = tol * max(vscale, 1.0)
+    abs_values = [abs(v) for v in values]
+    vscale = max(abs_values) if abs_values else 0.0
 
-    # Largest radius at which f is still "active" (above threshold).
+    # Need at least three probes to verify convergence to a constant.
+    last_n = 3
+    if len(values) < last_n:
+        raise CompactFunConstructionError(  # noqa: TRY003
+            f"Too few probes ({len(values)}) to determine the asymptotic "
+            f"behaviour of f near {'+' if sign > 0 else '-'}inf; "
+            f"increase numsupp_max_probes or numsupp_max_width."
+        )
+
+    # Convergence test: the last few signed probes must agree to tol*scale.
+    tail_window = values[-last_n:]
+    conv_threshold = tol * max(vscale, 1.0)
+    spread = max(tail_window) - min(tail_window)
+    if spread > conv_threshold:
+        # Function does not settle to a constant — heavy tail or oscillation.
+        raise CompactFunConstructionError(  # noqa: TRY003
+            f"Function does not converge to a constant within "
+            f"{radii[-1]:g} of anchor {anchor:g} on the "
+            f"{'+' if sign > 0 else '-'}inf side (last {last_n} probes "
+            f"spread by {spread:g} > {conv_threshold:g}); heavy-tailed or "
+            f"oscillating inputs are not supported in this release."
+        )
+    tail = float(np.mean(tail_window))
+    if abs(tail) < conv_threshold:
+        tail = 0.0
+
+    # Find the largest radius at which f is still "active" (above threshold
+    # relative to the tail).
+    threshold = tol * max(abs(tail), vscale, 1.0)
     active_r = 0.0
     for ri, vi in zip(radii, values, strict=False):
-        if vi > threshold:
+        if abs(vi - tail) > threshold:
             active_r = ri
-
-    # If the farthest probe is still active, the function does not decay
-    # within the probing budget.
-    if values[-1] > threshold:
-        raise CompactFunConstructionError(  # noqa: TRY003
-            f"Function does not decay below tolerance {tol:g} within "
-            f"{radii[-1]:g} of anchor {anchor:g}; heavy-tailed inputs are not "
-            f"supported in this release."
-        )
 
     boundary_r = max(2.0 * active_r, 1.0)
     if boundary_r > max_width:
@@ -114,11 +139,13 @@ def _discover_one_side(
             f"Discovered numerical support exceeds max_width = {max_width:g}; "
             f"heavy-tailed inputs are not supported in this release."
         )
-    return anchor + sign * boundary_r, vscale
+    return anchor + sign * boundary_r, tail, vscale
 
 
-def _discover_numsupp(f: Any, a: float, b: float, tol: float, max_width: float, max_probes: int) -> tuple[float, float]:
-    """Discover the storage interval ``[a', b']`` for ``f``.
+def _discover_numsupp(
+    f: Any, a: float, b: float, tol: float, max_width: float, max_probes: int
+) -> tuple[float, float, float, float]:
+    """Discover the storage interval and tail constants for ``f``.
 
     Args:
         f: Callable being approximated.
@@ -129,7 +156,9 @@ def _discover_numsupp(f: Any, a: float, b: float, tol: float, max_width: float, 
         max_probes: Maximum probes per unbounded side.
 
     Returns:
-        Tuple ``(a', b')`` of finite floats with ``a' < b'``.
+        Tuple ``(a', b', tail_left, tail_right)`` where ``a' < b'`` are
+        finite floats and the tails are the detected asymptotic constants
+        (``0.0`` on any side whose logical endpoint is finite).
 
     Raises:
         CompactFunConstructionError: If support cannot be discovered.
@@ -138,7 +167,7 @@ def _discover_numsupp(f: Any, a: float, b: float, tol: float, max_width: float, 
     right_inf = not np.isfinite(b)
 
     if not (left_inf or right_inf):
-        return a, b
+        return a, b, 0.0, 0.0
 
     # Anchor: the finite endpoint of a semi-infinite interval, else 0.
     if left_inf and right_inf:
@@ -149,14 +178,14 @@ def _discover_numsupp(f: Any, a: float, b: float, tol: float, max_width: float, 
         anchor = a
 
     if left_inf:
-        a_storage, _ = _discover_one_side(f, anchor, -1, tol, max_width, max_probes)
+        a_storage, tail_left, _ = _discover_one_side(f, anchor, -1, tol, max_width, max_probes)
     else:
-        a_storage = a
+        a_storage, tail_left = a, 0.0
 
     if right_inf:
-        b_storage, _ = _discover_one_side(f, anchor, +1, tol, max_width, max_probes)
+        b_storage, tail_right, _ = _discover_one_side(f, anchor, +1, tol, max_width, max_probes)
     else:
-        b_storage = b
+        b_storage, tail_right = b, 0.0
 
     if b_storage - a_storage > max_width:
         raise CompactFunConstructionError(  # noqa: TRY003
@@ -165,9 +194,10 @@ def _discover_numsupp(f: Any, a: float, b: float, tol: float, max_width: float, 
             f"in this release."
         )
     if b_storage <= a_storage:
-        # Function appears identically zero; pick a small default storage.
+        # Function appears identically constant on both sides; pick a small
+        # default storage interval.
         a_storage, b_storage = anchor - 1.0, anchor + 1.0
-    return a_storage, b_storage
+    return a_storage, b_storage, tail_left, tail_right
 
 
 class CompactFun(Classicfun):
@@ -175,10 +205,12 @@ class CompactFun(Classicfun):
 
     A :class:`CompactFun` represents a function whose user-facing logical
     interval has one or both endpoints at ``±inf`` but whose numerical
-    support — the set where the function exceeds a configured tolerance —
-    is finite.  Internally it inherits from :class:`Classicfun` and stores a
-    standard :class:`Onefun` on the discovered finite storage interval; the
-    function is reported as identically zero outside that interval.
+    support — the set where the function differs from its asymptotic limit
+    by more than a configured tolerance — is finite.  Internally it
+    inherits from :class:`Classicfun` and stores a standard
+    :class:`Onefun` on the discovered finite storage interval; outside that
+    interval the function is reported as the corresponding asymptotic
+    constant ``tail_left`` or ``tail_right`` (default ``0.0``).
 
     Two intervals are tracked:
 
@@ -187,16 +219,33 @@ class CompactFun(Classicfun):
     - ``self._logical_interval``: the user-facing interval, which may have
       ``±inf`` endpoints; returned by :attr:`support`.
 
-    For finite logical intervals the two coincide and a :class:`CompactFun`
-    behaves identically to :class:`~chebpy.bndfun.Bndfun`.
+    Two scalar tail constants are tracked:
+
+    - ``tail_left``: the value reported for ``x < a_storage`` when the
+      logical-left endpoint is ``-inf``.
+    - ``tail_right``: the value reported for ``x > b_storage`` when the
+      logical-right endpoint is ``+inf``.
+
+    For finite logical intervals the storage and logical intervals coincide
+    and the tails are ignored, so a :class:`CompactFun` behaves identically
+    to :class:`~chebpy.bndfun.Bndfun`.
 
     Attributes:
         onefun: Inherited; the standard :class:`Onefun` on ``[-1, 1]``.
         support: The logical interval (possibly with ``±inf`` endpoints).
         numerical_support: The finite storage interval.
+        tail_left: Asymptotic value at ``-inf`` (``0.0`` if logical-left is finite).
+        tail_right: Asymptotic value at ``+inf`` (``0.0`` if logical-right is finite).
     """
 
-    def __init__(self, onefun: Any, interval: Any, logical_interval: Any = None) -> None:
+    def __init__(
+        self,
+        onefun: Any,
+        interval: Any,
+        logical_interval: Any = None,
+        tail_left: float = 0.0,
+        tail_right: float = 0.0,
+    ) -> None:
         """Create a new :class:`CompactFun` instance.
 
         Args:
@@ -204,16 +253,36 @@ class CompactFun(Classicfun):
             interval: The finite storage :class:`Interval` (always finite).
             logical_interval: The user-facing interval (possibly with ``±inf``
                 endpoints).  Defaults to ``interval`` if omitted.
+            tail_left: Asymptotic value at ``-inf``.  Default ``0.0``.
+            tail_right: Asymptotic value at ``+inf``.  Default ``0.0``.
         """
         super().__init__(onefun, interval)
         if logical_interval is None:
             self._logical_interval = np.asarray(interval, dtype=float)
         else:
             self._logical_interval = np.asarray((float(logical_interval[0]), float(logical_interval[1])), dtype=float)
+        self._tail_left = float(tail_left)
+        self._tail_right = float(tail_right)
 
-    def _rebuild(self, onefun: Any) -> CompactFun:
-        """Construct a new :class:`CompactFun` preserving the logical interval."""
-        return self.__class__(onefun, self._interval, logical_interval=self._logical_interval)
+    def _rebuild(self, onefun: Any, *, tail_left: float | None = None, tail_right: float | None = None) -> CompactFun:
+        """Construct a new :class:`CompactFun` preserving logical interval and tails.
+
+        Args:
+            onefun: Replacement :class:`Onefun` for the new instance.
+            tail_left: Optional override for the new instance's left tail.
+                Defaults to ``self.tail_left``.
+            tail_right: Optional override for the new instance's right tail.
+                Defaults to ``self.tail_right``.
+        """
+        new_tl = self._tail_left if tail_left is None else float(tail_left)
+        new_tr = self._tail_right if tail_right is None else float(tail_right)
+        return self.__class__(
+            onefun,
+            self._interval,
+            logical_interval=self._logical_interval,
+            tail_left=new_tl,
+            tail_right=new_tr,
+        )
 
     # --------------------------
     #  alternative constructors
@@ -229,17 +298,15 @@ class CompactFun(Classicfun):
     def initconst(cls, c: Any, interval: Any) -> CompactFun:
         """Initialise a constant function.
 
-        Non-zero constants on unbounded intervals are not representable as
-        :class:`CompactFun` because the function does not decay to zero at
-        ``±inf``.
+        On an unbounded interval the constant ``c`` becomes the asymptotic
+        value on each unbounded side: ``tail_left = tail_right = c``.  This
+        makes ``initconst`` total — every constant is representable on every
+        interval — but note that integrating a non-zero constant over an
+        unbounded logical interval will (correctly) raise
+        :class:`~chebpy.exceptions.DivergentIntegralError`.
         """
         a, b = _ensure_endpoints(interval)
-        unbounded = (not np.isfinite(a)) or (not np.isfinite(b))
-        if unbounded and float(c) != 0.0:
-            raise CompactFunConstructionError(  # noqa: TRY003
-                "Non-zero constants are not representable as a CompactFun on an "
-                "unbounded interval (a CompactFun must decay to zero at ±inf)."
-            )
+        c_val = float(c)
         if not np.isfinite(a) and not np.isfinite(b):
             storage = Interval(-1.0, 1.0)
         elif not np.isfinite(a):
@@ -248,8 +315,10 @@ class CompactFun(Classicfun):
             storage = Interval(a, a + 1.0)
         else:
             storage = Interval(a, b)
-        onefun = techdict[prefs.tech].initconst(c, interval=storage)
-        return cls(onefun, storage, logical_interval=(a, b))
+        onefun = techdict[prefs.tech].initconst(c_val, interval=storage)
+        tail_left = c_val if not np.isfinite(a) else 0.0
+        tail_right = c_val if not np.isfinite(b) else 0.0
+        return cls(onefun, storage, logical_interval=(a, b), tail_left=tail_left, tail_right=tail_right)
 
     @classmethod
     def initidentity(cls, interval: Any) -> CompactFun:
@@ -272,16 +341,17 @@ class CompactFun(Classicfun):
     def initfun_adaptive(cls, f: Any, interval: Any) -> CompactFun:
         """Initialise from a callable using adaptive sampling.
 
-        Discovers the numerical support of ``f`` on the (possibly unbounded)
-        logical interval, then builds a standard adaptive :class:`Onefun` on
-        that finite storage interval.
+        Discovers the numerical support and asymptotic tail constants of
+        ``f`` on the (possibly unbounded) logical interval, then builds a
+        standard adaptive :class:`Onefun` on that finite storage interval.
 
         Raises:
             CompactFunConstructionError: If the numerical support cannot be
-                discovered within the configured tolerance and width budget.
+                discovered within the configured tolerance and width budget,
+                or if ``f`` does not converge to a constant at ``±inf``.
         """
         a, b = _ensure_endpoints(interval)
-        a_s, b_s = _discover_numsupp(
+        a_s, b_s, tl, tr = _discover_numsupp(
             f,
             a,
             b,
@@ -291,17 +361,17 @@ class CompactFun(Classicfun):
         )
         storage = Interval(a_s, b_s)
         onefun = techdict[prefs.tech].initfun(lambda y: f(storage(y)), interval=storage)
-        return cls(onefun, storage, logical_interval=(a, b))
+        return cls(onefun, storage, logical_interval=(a, b), tail_left=tl, tail_right=tr)
 
     @classmethod
     def initfun_fixedlen(cls, f: Any, interval: Any, n: int) -> CompactFun:
         """Initialise from a callable using a fixed number of points.
 
-        Discovers numerical support as in :meth:`initfun_adaptive`, then
-        builds a fixed-length :class:`Onefun` on the storage interval.
+        Discovers numerical support and tails as in :meth:`initfun_adaptive`,
+        then builds a fixed-length :class:`Onefun` on the storage interval.
         """
         a, b = _ensure_endpoints(interval)
-        a_s, b_s = _discover_numsupp(
+        a_s, b_s, tl, tr = _discover_numsupp(
             f,
             a,
             b,
@@ -311,18 +381,32 @@ class CompactFun(Classicfun):
         )
         storage = Interval(a_s, b_s)
         onefun = techdict[prefs.tech].initfun(lambda y: f(storage(y)), n, interval=storage)
-        return cls(onefun, storage, logical_interval=(a, b))
+        return cls(onefun, storage, logical_interval=(a, b), tail_left=tl, tail_right=tr)
 
     # -------------------
     #  evaluation
     # -------------------
     def __call__(self, x: Any, how: str = "clenshaw") -> Any:
-        """Evaluate the function at ``x``; returns ``0`` outside the storage interval."""
+        """Evaluate the function at ``x``.
+
+        Outside the storage interval, returns the corresponding tail constant
+        when the matching logical endpoint is ``±inf`` (default ``0.0``), or
+        ``0.0`` when the logical endpoint is finite.
+        """
         scalar_input = np.isscalar(x) or np.ndim(x) == 0
         x_arr = np.atleast_1d(np.asarray(x))
         is_complex = bool(getattr(self.onefun, "iscomplex", False))
         result = np.zeros(x_arr.shape, dtype=complex if is_complex else float)
         a_s, b_s = self._interval
+        a_log, b_log = float(self._logical_interval[0]), float(self._logical_interval[1])
+        # Outside-storage values: tail constants where the logical edge is ±inf.
+        left_mask = x_arr < a_s
+        right_mask = x_arr > b_s
+        if not np.isfinite(a_log) and self._tail_left != 0.0:
+            result[left_mask] = self._tail_left
+        if not np.isfinite(b_log) and self._tail_right != 0.0:
+            result[right_mask] = self._tail_right
+        # Inside-storage values: standard onefun evaluation.
         mask = (x_arr >= a_s) & (x_arr <= b_s)
         if mask.any():
             y = self._interval.invmap(x_arr[mask])
@@ -345,37 +429,112 @@ class CompactFun(Classicfun):
         return np.asarray(self._interval)
 
     @property
+    def tail_left(self) -> float:
+        """Asymptotic value of the function as ``x → -inf``.
+
+        Always ``0.0`` when the logical-left endpoint is finite.
+        """
+        return self._tail_left
+
+    @property
+    def tail_right(self) -> float:
+        """Asymptotic value of the function as ``x → +inf``.
+
+        Always ``0.0`` when the logical-right endpoint is finite.
+        """
+        return self._tail_right
+
+    @property
     def endvalues(self) -> Any:
-        """Return values at the logical endpoints; ``0`` at any ``±inf`` endpoint."""
+        """Return values at the logical endpoints; tails at any ``±inf`` endpoint."""
         a_log, b_log = float(self._logical_interval[0]), float(self._logical_interval[1])
-        yl = 0.0 if not np.isfinite(a_log) else self.__call__(a_log)
-        yr = 0.0 if not np.isfinite(b_log) else self.__call__(b_log)
+        yl = self._tail_left if not np.isfinite(a_log) else self.__call__(a_log)
+        yr = self._tail_right if not np.isfinite(b_log) else self.__call__(b_log)
         return np.array([yl, yr])
 
     def __repr__(self) -> str:  # pragma: no cover
-        """Return a string representation showing the logical interval and size."""
+        """Return a string representation showing the logical interval, size, and tails."""
         a_log, b_log = self._logical_interval
+        if self._tail_left != 0.0 or self._tail_right != 0.0:
+            return (
+                f"{self.__class__.__name__}([{a_log}, {b_log}], {self.size}, "
+                f"tails=({self._tail_left}, {self._tail_right}))"
+            )
         return f"{self.__class__.__name__}([{a_log}, {b_log}], {self.size})"
 
     # ----------
     #  calculus
     # ----------
-    def cumsum(self) -> Any:
-        """Indefinite integral.
+    def sum(self) -> Any:
+        """Compute the definite integral over the logical interval.
 
-        ``cumsum`` does not close in :class:`CompactFun` because the
-        antiderivative of an integrable function on ``(-inf, inf)`` does not
-        decay to zero at ``+inf`` (it tends to ``∫f``).  Future releases will
-        return a bounded :class:`Chebfun` representation; for now this is a
-        documented limitation.
+        Raises:
+            DivergentIntegralError: If the logical interval is unbounded on
+                a side where the corresponding tail is non-zero (the integral
+                of a non-decaying function over a half-line diverges).
         """
-        raise NotImplementedError(
-            "CompactFun.cumsum() is not implemented in this release: the "
-            "antiderivative of an integrable function on (-inf, inf) tends "
-            "to a non-zero constant at +inf and so cannot itself be a "
-            "CompactFun.  This is a documented v1 limitation; a future "
-            "release will return a bounded Chebfun representation."
+        a_log, b_log = float(self._logical_interval[0]), float(self._logical_interval[1])
+        if (not np.isfinite(a_log)) and self._tail_left != 0.0:
+            raise DivergentIntegralError(  # noqa: TRY003
+                f"Integrand has non-zero left asymptote tail_left={self._tail_left}; "
+                f"integral over (-inf, ...) diverges."
+            )
+        if (not np.isfinite(b_log)) and self._tail_right != 0.0:
+            raise DivergentIntegralError(  # noqa: TRY003
+                f"Integrand has non-zero right asymptote tail_right={self._tail_right}; "
+                f"integral over (..., +inf) diverges."
+            )
+        return super().sum()
+
+    def cumsum(self) -> CompactFun:
+        """Compute the indefinite integral.
+
+        For a :class:`CompactFun` with zero asymptote on the unbounded
+        left/right side, the antiderivative is well-defined; it is itself a
+        :class:`CompactFun` whose right-tail equals ``∫f`` and whose
+        left-tail is ``0`` (anchored so ``F(-inf) = 0``).
+
+        Raises:
+            DivergentIntegralError: If the logical interval is unbounded on
+                a side where the corresponding tail is non-zero, in which
+                case the antiderivative diverges.
+        """
+        a_log, b_log = float(self._logical_interval[0]), float(self._logical_interval[1])
+        if (not np.isfinite(a_log)) and self._tail_left != 0.0:
+            raise DivergentIntegralError(  # noqa: TRY003
+                f"Antiderivative diverges at -inf because tail_left={self._tail_left} != 0."
+            )
+        if (not np.isfinite(b_log)) and self._tail_right != 0.0:
+            raise DivergentIntegralError(  # noqa: TRY003
+                f"Antiderivative diverges at +inf because tail_right={self._tail_right} != 0."
+            )
+        # Standard cumsum on the storage interval anchors F(a_storage) = 0.
+        # When logical-left is -inf with tail_left=0, this approximates
+        # F(-inf) = 0 (since f is below tolerance below a_storage).
+        inner = super().cumsum()
+        # The right-tail of F is the total integral.
+        total = float(super().sum())
+        # The left-tail is 0 when logical-left is -inf (anchor at -inf).
+        new_tail_left = 0.0
+        new_tail_right = total
+        return self.__class__(
+            inner.onefun,
+            inner._interval,
+            logical_interval=self._logical_interval,
+            tail_left=new_tail_left,
+            tail_right=new_tail_right,
         )
+
+    def diff(self) -> CompactFun:
+        """Compute the derivative.
+
+        The derivative of a function with constant asymptotic limits has
+        zero asymptotes, so the result has ``tail_left = tail_right = 0``.
+        """
+        result = cast(CompactFun, super().diff())
+        result._tail_left = 0.0
+        result._tail_right = 0.0
+        return result
 
     # -------------
     #  rootfinding
@@ -431,11 +590,96 @@ class CompactFun(Classicfun):
         return Bndfun.initfun_adaptive(self, Interval(sub_a, sub_b))
 
     def translate(self, c: float) -> CompactFun:
-        """Translate by ``c`` along the real line, preserving both intervals."""
+        """Translate by ``c`` along the real line, preserving both intervals and tails."""
         new_storage = Interval(float(self._interval[0]) + c, float(self._interval[1]) + c)
         a_log, b_log = float(self._logical_interval[0]), float(self._logical_interval[1])
         new_logical = (a_log + c, b_log + c)
-        return self.__class__(self.onefun, new_storage, logical_interval=new_logical)
+        return self.__class__(
+            self.onefun,
+            new_storage,
+            logical_interval=new_logical,
+            tail_left=self._tail_left,
+            tail_right=self._tail_right,
+        )
+
+    # ------------
+    #  arithmetic
+    # ------------
+    def __neg__(self) -> CompactFun:
+        """Return ``-f``; negates both tail constants."""
+        result = cast(CompactFun, super().__neg__())
+        result._tail_left = -self._tail_left
+        result._tail_right = -self._tail_right
+        return result
+
+    def __add__(self, other: Any) -> Any:
+        """Pointwise addition; combines tail constants additively."""
+        result = super().__add__(other)
+        if isinstance(result, CompactFun):
+            other_tl, other_tr = self._other_tails(other)
+            result._tail_left = self._tail_left + other_tl
+            result._tail_right = self._tail_right + other_tr
+        return result
+
+    def __radd__(self, other: Any) -> Any:
+        """Right-hand addition for scalar + CompactFun."""
+        result = super().__radd__(other)
+        if isinstance(result, CompactFun):
+            other_tl, other_tr = self._other_tails(other)
+            result._tail_left = self._tail_left + other_tl
+            result._tail_right = self._tail_right + other_tr
+        return result
+
+    def __sub__(self, other: Any) -> Any:
+        """Pointwise subtraction; combines tail constants additively."""
+        result = super().__sub__(other)
+        if isinstance(result, CompactFun):
+            other_tl, other_tr = self._other_tails(other)
+            result._tail_left = self._tail_left - other_tl
+            result._tail_right = self._tail_right - other_tr
+        return result
+
+    def __rsub__(self, other: Any) -> Any:
+        """Right-hand subtraction for scalar - CompactFun."""
+        result = super().__rsub__(other)
+        if isinstance(result, CompactFun):
+            other_tl, other_tr = self._other_tails(other)
+            result._tail_left = other_tl - self._tail_left
+            result._tail_right = other_tr - self._tail_right
+        return result
+
+    def __mul__(self, other: Any) -> Any:
+        """Pointwise multiplication; combines tail constants multiplicatively."""
+        result = super().__mul__(other)
+        if isinstance(result, CompactFun):
+            other_tl, other_tr = self._other_tails(other)
+            result._tail_left = self._tail_left * other_tl
+            result._tail_right = self._tail_right * other_tr
+        return result
+
+    def __rmul__(self, other: Any) -> Any:
+        """Right-hand multiplication for scalar * CompactFun."""
+        result = super().__rmul__(other)
+        if isinstance(result, CompactFun):
+            other_tl, other_tr = self._other_tails(other)
+            result._tail_left = self._tail_left * other_tl
+            result._tail_right = self._tail_right * other_tr
+        return result
+
+    def _other_tails(self, other: Any) -> tuple[float, float]:
+        """Extract ``(tail_left, tail_right)`` from a binary-op operand.
+
+        For a :class:`CompactFun` operand, returns its tail attributes; for
+        a scalar, returns ``(scalar, scalar)``.
+        """
+        if isinstance(other, CompactFun):
+            return other._tail_left, other._tail_right
+        if np.isscalar(other):
+            v = float(other)
+            return v, v
+        # Anything else (e.g. a different Classicfun subclass) is treated as
+        # zero-tailed; tail propagation may be inexact in that case.
+        return 0.0, 0.0
 
     # ----------
     #  plotting

--- a/src/chebpy/exceptions.py
+++ b/src/chebpy/exceptions.py
@@ -214,8 +214,24 @@ CompactFunConstructionError = type(
 
         Raised when the numerical support of an unbounded function cannot
         be discovered within the configured tolerance and width budget,
-        or when the function fails preconditions (e.g. non-zero asymptotic
-        limit or non-zero constant on an unbounded interval).
+        or when the function fails preconditions (e.g. non-converging
+        asymptotic limit).
+        """,
+    },
+)
+
+# Exception raised when an integral is divergent
+DivergentIntegralError = type(
+    "DivergentIntegralError",
+    (ChebpyBaseError,),
+    {
+        "default_message": "The integral does not converge",
+        "__doc__": """Exception raised when a definite or indefinite integral diverges.
+
+        Raised by :meth:`CompactFun.sum`, :meth:`CompactFun.cumsum`, or
+        :meth:`Chebfun.conv` when the function has a non-zero asymptotic
+        limit on an unbounded side, making the integral mathematically
+        ill-defined.
         """,
     },
 )

--- a/tests/test_chebfun.py
+++ b/tests/test_chebfun.py
@@ -477,7 +477,7 @@ class TestClassUsage:
 
     def test__repr__(self):
         assert "Chebfun" in repr(self.f1)
-        assert "domain" in repr(self.f1)
+        assert "interval" in repr(self.f1)
 
     def test__iter__(self):
         assert len(list(self.f1)) == 1

--- a/tests/test_compactfun.py
+++ b/tests/test_compactfun.py
@@ -7,7 +7,7 @@ import pytest
 
 from chebpy import CompactFun, chebfun
 from chebpy.bndfun import Bndfun
-from chebpy.exceptions import CompactFunConstructionError
+from chebpy.exceptions import CompactFunConstructionError, DivergentIntegralError
 from chebpy.utilities import Interval
 
 
@@ -62,9 +62,10 @@ class TestInitFunAdaptive:
         with pytest.raises(CompactFunConstructionError):
             CompactFun.initfun_adaptive(lambda x: 1.0 / (1.0 + x * x), (-np.inf, np.inf))
 
-    def test_non_decaying_refused(self) -> None:
+    def test_oscillating_tail_refused(self) -> None:
+        # sin(x) does not converge to a constant at infinity.
         with pytest.raises(CompactFunConstructionError):
-            CompactFun.initfun_adaptive(lambda x: np.tanh(x), (-np.inf, np.inf))
+            CompactFun.initfun_adaptive(lambda x: np.sin(x), (-np.inf, np.inf))
 
 
 class TestInitConst:
@@ -75,11 +76,17 @@ class TestInitConst:
         assert f(1000.0) == 0.0
         assert f(0.0) == 0.0
 
-    def test_nonzero_constant_unbounded_refused(self) -> None:
-        with pytest.raises(CompactFunConstructionError):
-            CompactFun.initconst(1.0, (-np.inf, np.inf))
-        with pytest.raises(CompactFunConstructionError):
-            CompactFun.initconst(2.5, (0.0, np.inf))
+    def test_nonzero_constant_unbounded_promoted_to_tails(self) -> None:
+        # Non-zero constants are now representable on unbounded intervals via
+        # tail-constant metadata.
+        f = CompactFun.initconst(1.0, (-np.inf, np.inf))
+        assert f.tail_left == 1.0
+        assert f.tail_right == 1.0
+        assert f(1e6) == 1.0
+        g = CompactFun.initconst(2.5, (0.0, np.inf))
+        assert g.tail_left == 0.0  # finite endpoint
+        assert g.tail_right == 2.5
+        assert g(1e6) == 2.5
 
     def test_constant_finite_ok(self) -> None:
         f = CompactFun.initconst(3.0, (-1.0, 2.0))
@@ -150,13 +157,19 @@ class TestProperties:
 # -----------------------------
 # calculus / utilities
 # -----------------------------
-class TestCalculusRefusals:
-    """Tests for calculus methods that raise on CompactFun."""
+class TestCumsumZeroTail:
+    """Tests for :meth:`CompactFun.cumsum` on zero-tail inputs."""
 
-    def test_cumsum_not_implemented(self) -> None:
+    def test_cumsum_gaussian(self) -> None:
+        # cumsum of exp(-x^2) anchored at -inf has tail_right = sqrt(pi).
         f = CompactFun.initfun_adaptive(lambda x: np.exp(-(x**2)), (-np.inf, np.inf))
-        with pytest.raises(NotImplementedError):
-            f.cumsum()
+        F = f.cumsum()
+        assert isinstance(F, CompactFun)
+        assert F.tail_left == 0.0
+        assert F.tail_right == pytest.approx(np.sqrt(np.pi), abs=1e-10)
+        # Outside numerical support, F evaluates to its tails.
+        assert F(-1000.0) == 0.0
+        assert F(1000.0) == pytest.approx(np.sqrt(np.pi), abs=1e-10)
 
 
 class TestRestrictAndTranslate:
@@ -352,3 +365,92 @@ class TestRoots:
         # Calling .roots() on the parent Chebfun also benefits from filtering.
         f = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, np.inf])
         assert f.roots().size == 0
+
+
+# -----------------------------
+# tail constants (plan 02b)
+# -----------------------------
+class TestTailConstants:
+    """Tests for non-zero asymptotic limits via tail metadata."""
+
+    def test_tanh_construction(self) -> None:
+        f = CompactFun.initfun_adaptive(np.tanh, (-np.inf, np.inf))
+        assert f.tail_left == pytest.approx(-1.0, abs=1e-12)
+        assert f.tail_right == pytest.approx(1.0, abs=1e-12)
+        # Outside numerical support, the tail constants are returned exactly.
+        assert f(-1e10) == pytest.approx(-1.0)
+        assert f(1e10) == pytest.approx(1.0)
+        # Inside the support, evaluation matches np.tanh.
+        x = np.linspace(-3.0, 3.0, 7)
+        np.testing.assert_allclose(f(x), np.tanh(x), atol=1e-10)
+
+    def test_logistic_one_sided_tail(self) -> None:
+        # Logistic 1/(1+exp(-x)) -> 0 at -inf, 1 at +inf.
+        f = CompactFun.initfun_adaptive(lambda x: 1.0 / (1.0 + np.exp(-x)), (-np.inf, np.inf))
+        assert f.tail_left == pytest.approx(0.0, abs=1e-12)
+        assert f.tail_right == pytest.approx(1.0, abs=1e-12)
+
+    def test_repr_shows_tails(self) -> None:
+        f = CompactFun.initfun_adaptive(np.tanh, (-np.inf, np.inf))
+        assert "tails=" in repr(f)
+
+    def test_endvalues_use_tails(self) -> None:
+        f = CompactFun.initfun_adaptive(np.tanh, (-np.inf, np.inf))
+        ev = f.endvalues
+        assert ev[0] == pytest.approx(-1.0)
+        assert ev[1] == pytest.approx(1.0)
+
+    def test_sum_diverges_with_nonzero_tail(self) -> None:
+        f = CompactFun.initfun_adaptive(np.tanh, (-np.inf, np.inf))
+        with pytest.raises(DivergentIntegralError):
+            f.sum()
+
+    def test_cumsum_diverges_with_nonzero_tail(self) -> None:
+        f = CompactFun.initfun_adaptive(np.tanh, (-np.inf, np.inf))
+        with pytest.raises(DivergentIntegralError):
+            f.cumsum()
+
+    def test_diff_zeros_tails(self) -> None:
+        f = CompactFun.initfun_adaptive(np.tanh, (-np.inf, np.inf))
+        df = f.diff()
+        assert df.tail_left == 0.0
+        assert df.tail_right == 0.0
+
+    def test_neg_flips_tails(self) -> None:
+        f = CompactFun.initfun_adaptive(np.tanh, (-np.inf, np.inf))
+        g = -f
+        assert g.tail_left == pytest.approx(1.0, abs=1e-12)
+        assert g.tail_right == pytest.approx(-1.0, abs=1e-12)
+
+    def test_scalar_add_propagates_tails(self) -> None:
+        f = CompactFun.initfun_adaptive(np.tanh, (-np.inf, np.inf))
+        g = f + 2.0
+        assert g.tail_left == pytest.approx(1.0, abs=1e-12)
+        assert g.tail_right == pytest.approx(3.0, abs=1e-12)
+        h = 2.0 + f
+        assert h.tail_left == pytest.approx(1.0, abs=1e-12)
+        assert h.tail_right == pytest.approx(3.0, abs=1e-12)
+
+    def test_scalar_sub_propagates_tails(self) -> None:
+        f = CompactFun.initfun_adaptive(np.tanh, (-np.inf, np.inf))
+        g = f - 1.0
+        assert g.tail_left == pytest.approx(-2.0, abs=1e-12)
+        assert g.tail_right == pytest.approx(0.0, abs=1e-12)
+        h = 1.0 - f
+        assert h.tail_left == pytest.approx(2.0, abs=1e-12)
+        assert h.tail_right == pytest.approx(0.0, abs=1e-12)
+
+    def test_scalar_mul_propagates_tails(self) -> None:
+        f = CompactFun.initfun_adaptive(np.tanh, (-np.inf, np.inf))
+        g = 3.0 * f
+        assert g.tail_left == pytest.approx(-3.0, abs=1e-12)
+        assert g.tail_right == pytest.approx(3.0, abs=1e-12)
+
+    def test_conv_refuses_nonzero_tails(self) -> None:
+        # Convolution against tanh would diverge \u2014 we refuse early.
+        f = chebfun(np.tanh, [-np.inf, np.inf])
+        g = chebfun(lambda x: np.exp(-(x**2)), [-np.inf, np.inf])
+        with pytest.raises(DivergentIntegralError):
+            f.conv(g)
+        with pytest.raises(DivergentIntegralError):
+            g.conv(f)


### PR DESCRIPTION
This pull request enhances the documentation for ChebPy's support of infinite intervals and provides extensive historical context and attribution to the original Chebfun project. The main changes clarify how ChebPy handles functions with non-zero asymptotes on infinite intervals, update and expand documentation and examples, and add a detailed project history page.

**Key changes:**

### Infinite interval support and documentation

* Updated documentation and examples to clarify that ChebPy now supports functions with non-zero asymptotes (e.g., `tanh`, logistic sigmoid) on infinite intervals, automatically detecting and storing tail constants (`tail_left`, `tail_right`). Previously, only rapidly decaying functions were supported; now, the model is extended to include these sigmoid-like cases. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L232-R234) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R244-R248) [[3]](diffhunk://#diff-139af1a0d021255847bdbd4bc74142c72f54d608dc61fc880e3395e47a241d22L55-R62) [[4]](diffhunk://#diff-139af1a0d021255847bdbd4bc74142c72f54d608dc61fc880e3395e47a241d22L69-R99)
* Improved the infinite interval notebook (`9_infinite_intervals.py`) to demonstrate and explain the new asymptote detection, update example code, and clarify which cases are supported or refused. [[1]](diffhunk://#diff-139af1a0d021255847bdbd4bc74142c72f54d608dc61fc880e3395e47a241d22L55-R62) [[2]](diffhunk://#diff-139af1a0d021255847bdbd4bc74142c72f54d608dc61fc880e3395e47a241d22L69-R99) [[3]](diffhunk://#diff-139af1a0d021255847bdbd4bc74142c72f54d608dc61fc880e3395e47a241d22R162) [[4]](diffhunk://#diff-139af1a0d021255847bdbd4bc74142c72f54d608dc61fc880e3395e47a241d22L186-R219) [[5]](diffhunk://#diff-139af1a0d021255847bdbd4bc74142c72f54d608dc61fc880e3395e47a241d22L219-R246)
* Updated the notebook to use the latest version of `marimo` and improved code clarity and output formatting. [[1]](diffhunk://#diff-139af1a0d021255847bdbd4bc74142c72f54d608dc61fc880e3395e47a241d22L14-R14) [[2]](diffhunk://#diff-139af1a0d021255847bdbd4bc74142c72f54d608dc61fc880e3395e47a241d22R162) [[3]](diffhunk://#diff-139af1a0d021255847bdbd4bc74142c72f54d608dc61fc880e3395e47a241d22L186-R219) [[4]](diffhunk://#diff-139af1a0d021255847bdbd4bc74142c72f54d608dc61fc880e3395e47a241d22L219-R246)

### Attribution and project history

* Added a new `docs/history.md` page with a detailed timeline, key contributors, and foundational publications from the original Chebfun project at Oxford. This provides essential context for ChebPy's mathematical and algorithmic foundations.
* Added and expanded acknowledgments in the main documentation and `README.md`, explicitly crediting the Chebfun project, its leaders, and core references. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L42-R63) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R308-L310)

### Documentation improvements

* Improved terminology and navigation in the documentation (e.g., renaming "Getting Started" to "Quickstart" and updating links for clarity).

These changes make ChebPy's infinite interval support more robust and transparent, and provide clear attribution and historical context for users and contributors.