### PR TITLE
Docs correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,46 +255,22 @@ p = chebfun(lambda x: np.exp(-x**2), [-np.inf, -2.0, 0.0, 3.0, np.inf])
 
 ### Endpoint Singularities
 
-Functions with branch-type singularities at one or both endpoints — such
-as $\sqrt{x}$ on $[0, 1]$ — cannot be resolved by ordinary Chebyshev
-interpolation. Pass `sing="left"`, `"right"`, or `"both"` to switch the
-boundary pieces to `Singfun`, which uses an exponential clustering map
-to recover spectral accuracy.
-
-The map $m: [-1, 1] \to [a, b]$ is the Adcock–Richardson slit-strip
-construction (Adcock & Richardson, *SIAM J. Numer. Anal.* 52(4),
-1887–1912, 2014; [doi:10.1137/130920460](https://doi.org/10.1137/130920460);
-[arXiv:1305.2643](https://arxiv.org/abs/1305.2643)). For `sing="left"`,
-with $s = L(t-1)/2$,
-
-$$
-m(t) = a + (b-a)\,\frac{\alpha}{\pi}\,\log(1 + e^{\pi(s + \gamma)/\alpha}),
-$$
-
-where $\gamma = (\alpha/\pi)\,\log(e^{\pi/\alpha} - 1)$ is chosen so the
-smooth endpoint $b$ is hit exactly, and $m'(\pm 1) \to 0$
-super-exponentially at the clustered endpoint. A `MapParams(L, alpha)`
-object tunes truncation and clustering; defaults work for the canonical
-$\sqrt{\cdot}$ cases:
+Functions with branch-type singularities at one or both endpoints —
+such as $\sqrt{x}$ on $[0, 1]$ — cannot be resolved by ordinary
+Chebyshev interpolation. Pass `sing="left"`, `"right"`, or `"both"` to
+switch the boundary pieces to `Singfun`, which uses an exponential
+clustering map to recover spectral accuracy.
 
 ```python
 from chebpy import chebfun
 import numpy as np
 
-# Plain Bndfun fails to converge for sqrt; Singfun resolves it to machine
-# precision in ~150 coefficients.
 f = chebfun(np.sqrt, [0.0, 1.0], sing="left")
 f.sum()                       # 2/3, to machine precision
 
-# Two-sided singularity on the same domain
 g = chebfun(lambda x: np.sqrt(x * (1 - x)), [0.0, 1.0], sing="both")
 g.sum()                       # pi/8, to machine precision
 ```
-
-Mixed-piece arithmetic (`Singfun + Bndfun`, etc.) is preserved, and
-`restrict` automatically falls back to `Bndfun` on subintervals that
-exclude the clustered endpoint. `conv` and `diff` on `Singfun` pieces
-are not yet supported.
 
 ---
 
@@ -367,9 +343,8 @@ We are grateful for their decades of open scholarship, which made this
 Python port possible. Any errors in translation or adaptation are ours
 alone.
 
-📜 See the [History of the Chebfun Project](https://chebpy.github.io/chebpy/history/)
-page for a fuller timeline, key contributors, and foundational
-publications.
+📜 See the [About](https://chebpy.github.io/chebpy/about/) page for a
+fuller timeline, key contributors, and foundational publications.
 
 Project tooling:
 

--- a/docs/notebooks/10_endpoint_singularities.py
+++ b/docs/notebooks/10_endpoint_singularities.py
@@ -105,32 +105,33 @@ def _():
 @app.cell(hide_code=True)
 def _():
     mo.md(r"""
-    ## A one-sided square root
+    ## A one-sided logarithmic singularity
 
-    The simplest example: $f(x) = \sqrt{x}$ on $[0, 1]$, with the
-    singularity at the left endpoint.  Pass `sing="left"` to `chebfun`:
+    The simplest example: $f(x) = x\log x$ on $[0, 1]$, with the
+    derivative singularity at the left endpoint.  Pass `sing="left"` to
+    `chebfun`:
     """)
     return
 
 
 @app.cell
 def _():
-    sqrt_left = chebfun(np.sqrt, [0.0, 1.0], sing="left")
-    print(sqrt_left)
+    xlogx_left = chebfun(lambda x: x * np.log(x), [0.0, 1.0], sing="left")
+    print(xlogx_left)
     print()
-    print(f"piece type    : {type(sqrt_left.funs[0]).__name__}")
-    print(f"size          : {sqrt_left.funs[0].size} coefficients")
-    print(f"sum (= 2/3)   : {float(sqrt_left.sum()):.16f}")
-    print(f"            ref {2.0 / 3.0:.16f}")
-    return (sqrt_left,)
+    print(f"piece type    : {type(xlogx_left.funs[0]).__name__}")
+    print(f"size          : {xlogx_left.funs[0].size} coefficients")
+    print(f"sum (= -1/4)  : {float(xlogx_left.sum()):.16f}")
+    print(f"            ref {-1.0 / 4.0:.16f}")
+    return (xlogx_left,)
 
 
 @app.cell
-def _(sqrt_left):
+def _(xlogx_left):
     _fig, _ax = plt.subplots()
-    sqrt_left.plot(ax=_ax)
+    xlogx_left.plot(ax=_ax)
     _ax.set_xlabel("x")
-    _ax.set_title(r"$f(x) = \sqrt{x}$ on $[0, 1]$ (sing='left')")
+    _ax.set_title(r"$f(x) = x\log x$ on $[0, 1]$ (sing='left')")
     _fig
     return
 

--- a/docs/user/features/gpr.md
+++ b/docs/user/features/gpr.md
@@ -51,6 +51,6 @@ f_mean, f_var = gpr(x_obs, y_obs, domain=[-2, 2], n_samples=5)
 - C. E. Rasmussen and C. K. I. Williams,
   [*Gaussian Processes for Machine Learning*](https://gaussianprocess.org/gpml/),
   MIT Press, 2006.
-- T. P. Fournier, A. Townsend, and H. D. Wilber,
-  [*Continuous Gaussian process regression with Chebfun*](https://arxiv.org/abs/2202.04465),
-  arXiv preprint, 2022.
+- S. Filip, A. Javeed, and L. N. Trefethen,
+  [*Smooth random functions, random ODEs, and Gaussian processes*](https://doi.org/10.1137/17M1161853),
+  SIAM Review, 61 (2019), 185–205.

--- a/docs/user/features/singularities.md
+++ b/docs/user/features/singularities.md
@@ -12,8 +12,8 @@ Pass a `sing=` hint to `chebfun()` to flag which endpoint(s) carry a singularity
 import numpy as np
 from chebpy import chebfun
 
-# Left endpoint: f(x) = sqrt(x) on [0, 1]
-f = chebfun(np.sqrt, [0.0, 1.0], sing="left")
+# Left endpoint: f(x) = x log(x) on [0, 1] (derivative blows up at x = 0)
+f = chebfun(lambda x: x * np.log(x), [0.0, 1.0], sing="left")
 
 # Right endpoint: f(x) = sqrt(1 - x) on [0, 1]
 g = chebfun(lambda x: np.sqrt(1.0 - x), [0.0, 1.0], sing="right")
@@ -22,7 +22,7 @@ g = chebfun(lambda x: np.sqrt(1.0 - x), [0.0, 1.0], sing="right")
 h = chebfun(lambda x: np.sqrt(x * (1.0 - x)), [0.0, 1.0], sing="both")
 
 # Definite integrals reach machine precision
-float(f.sum())   # 2/3 (up to a tiny endpoint-gap correction; see below)
+float(f.sum())   # -1/4 (up to a tiny endpoint-gap correction; see below)
 float(h.sum())   # pi/8
 ```
 


### PR DESCRIPTION
This pull request updates documentation and examples to use the function \( f(x) = x \log x \) as the primary example of a one-sided endpoint singularity, instead of \( f(x) = \sqrt{x} \). It also revises references and clarifies some explanations. The most important changes are:

**Documentation and Example Updates:**

* Changed the primary one-sided singularity example from `sqrt(x)` to `x * log(x)` in both the user guide (`docs/user/features/singularities.md`) and the endpoint singularities notebook (`docs/notebooks/10_endpoint_singularities.py`). The sum reference for the new example is updated accordingly (from `2/3` to `-1/4`). [[1]](diffhunk://#diff-4479db84a1fb0d3ae65da348f1d8622f86cfda27eba5ac439f8b7582278d9371L15-R16) [[2]](diffhunk://#diff-4479db84a1fb0d3ae65da348f1d8622f86cfda27eba5ac439f8b7582278d9371L25-R25) [[3]](diffhunk://#diff-3325e60c85bcfe7e4980b23ec20d23234a886c435d67f8566a1f90752e449539L108-R134)
* Updated the main README to match the new example focus and removed detailed mathematical exposition of the singularity mapping, streamlining the explanation of endpoint singularities and the use of `Singfun`.

**Reference and Link Updates:**

* Replaced a reference in the Gaussian process regression documentation: removed the Fournier et al. arXiv preprint and added the Filip et al. SIAM Review paper.
* Updated the Chebfun project history link in the README to point to the "About" page instead.