### PR TITLE
Fix README pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ChebPy is a Python implementation of [Chebfun](http://www.chebfun.org/), bringin
 ### Using pip (recommended)
 
 ```bash
-pip install chebpy
+pip install chebfun
 ```
 
 ### From source (development)


### PR DESCRIPTION
### Motivation
- The README recommended `pip install chebpy` while the published PyPI package is `chebfun` (regression introduced in PR #126), so the installation instruction must be corrected to address issue #387.

### Description
- Update `README.md` to replace the pip install line with `pip install chebfun`.

### Testing
- Verified with `rg -n "pip install chebpy|pip install chebfun|project/chebfun|name = 'chebfun'" README.md docs pyproject.toml` and ran `git diff --check`, and both checks completed successfully.
- [Manual] Ran `pip install chebfun`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b40b540848326aa13fabb0686bafc)