### PR TITLE
fix: drop License:: classifier test that contradicts PEP 639

### DIFF
--- a/.rhiza/tests/test_pyproject.py
+++ b/.rhiza/tests/test_pyproject.py
@@ -140,7 +140,7 @@ class TestProjectUrls:
 
 
 class TestProjectClassifiers:
-    """Tests for [project].classifiers — Python version and licence entries."""
+    """Tests for [project].classifiers — Python version entries."""
 
     @pytest.fixture
     def classifiers(self, project: dict) -> list[str]:
@@ -156,11 +156,6 @@ class TestProjectClassifiers:
         assert len(python_classifiers) >= 1, (
             "classifiers must include at least one 'Programming Language :: Python :: 3.X' entry"
         )
-
-    def test_license_classifier_present(self, classifiers: list[str]) -> None:
-        """At least one 'License :: ' classifier must be present."""
-        license_classifiers = [c for c in classifiers if c.startswith("License ::")]
-        assert len(license_classifiers) >= 1, "classifiers must include at least one 'License :: ' entry"
 
 
 class TestDependencyGroups:


### PR DESCRIPTION
## Problem

`.rhiza/tests/test_pyproject.py::TestProjectClassifiers::test_license_classifier_present` required at least one deprecated `License ::` trove classifier:

```python
def test_license_classifier_present(self, classifiers: list[str]) -> None:
    """At least one 'License :: ' classifier must be present."""
    license_classifiers = [c for c in classifiers if c.startswith("License ::")]
    assert len(license_classifiers) >= 1, "classifiers must include at least one 'License :: ' entry"
```

PEP 639 deprecated those classifiers in favour of the SPDX `license` expression plus `license-files`, and setuptools >= 77 / PyPI now **reject** uploads that declare both forms.

chebpy already uses the PEP 639 form (`pyproject.toml:8-9`):

```toml
license = "BSD-3-Clause"
license-files = ["LICENSE"]
```

So the only way to satisfy this test would be to break packaging.

## Why it wasn't already red

chebpy declares no `classifiers` key at all, so the `classifiers` fixture calls `pytest.skip` and both classifier tests skip. It's a latent trap rather than a live failure — it goes red the moment anyone adds a `classifiers` list, e.g. the Python-version entries the sibling test asks for.

## Change

Removes `test_license_classifier_present` and the "licence entries" mention in the enclosing class docstring. The Python-version classifier test is untouched.

## Caveat: this is a stopgap

`.rhiza/tests/test_pyproject.py` is Rhiza-managed (listed in `.rhiza/template.lock:68`), so the next template sync will restore the deleted test. The durable fix belongs upstream in [`jebel-quant/rhiza`](https://github.com/jebel-quant/rhiza): accept *either* an SPDX `license` string *or* a `License ::` classifier, fail only when both are declared, and drop the dependency on `classifiers` being non-empty so the check actually runs instead of silently skipping.

## Verification

- `pytest .rhiza/tests/test_pyproject.py` → 22 passed, 1 skipped (remaining skip is the Python-version classifier test, still skipping for the same no-`classifiers` reason).
- `make fmt` passes clean.
- `make validate` (template-drift gate) was **not** run locally — since this edits a Rhiza-managed file, that gate may flag drift in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)