### PR TITLE
chore: select the github-project profile in template.yml

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,12 +1,11 @@
 repository: "jebel-quant/rhiza"
 ref: "v1.3.2"
 
+profiles:
+  - github-project
+
 templates:
   - devcontainer
-  - github
-  - github-marimo
-  - github-tests
-  - github-book
 
 exclude:
   - book/marimo/notebooks/rhiza.py  


### PR DESCRIPTION
## What

Switch `.rhiza/template.yml` from a hand-maintained bundle list to Rhiza's profile mode.

```diff
-templates:
-  - devcontainer
-  - github
-  - github-marimo
-  - github-tests
-  - github-book
+profiles:
+  - github-project
+
+templates:
+  - devcontainer
```

## Why

Rhiza v1.3.x layers **profiles** (named presets that expand to a bundle set, representing a stable user intent) on top of the bundle-level `templates:` list. `github-project` is exactly this repo's intent — a GitHub-hosted Python project with docs, notebooks and hosted CI.

It expands to `core`, `python-core`, `github`, `book`, `marimo`, `tests`, `github-book`, `github-marimo`, `github-tests` — a superset of what the explicit list named here, since the base bundles (`core`, `python-core`, `book`, `marimo`, `tests`) were only arriving as transitive dependencies.

`devcontainer` is **not** part of that profile, so it stays in `templates:` using the documented mixed form. Dropping it would unsync `.devcontainer/*`.

## Expected effect on the next sync

None, file-wise. The pinned `ref` (`v1.3.2`) is unchanged and the resolved bundle set is equivalent — `template.lock` should just be rewritten in profile terms.

## Verification

`/rhiza:status` validation passes and confirms the new mode:

```
✓ Using profile mode (profiles: ['github-project'])
✓ templates list has 1 entry
    - devcontainer
✓ Validation passed: template.yml is valid
```

Note: this PR changes the *config* only. `/rhiza:update` has not been run, so `template.lock` still records the previous selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)