### PR TITLE
fix: drop the stale self_empty TODO and unblock radon

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,12 @@ exclude = ["tests"]
 # in fact all 25 modules are covered. Per-module coverage is guaranteed instead by
 # COVERAGE_FAIL_UNDER = 100 in the Makefile, which is the condition the checker
 # documents for opting out.
+#
+# Keep the reason free of a literal `%`: radon feeds the whole of this file to
+# configparser, which reads `%` as interpolation syntax and dies before analysing
+# anything. See https://github.com/chebpy/chebpy/issues/457.
 enforce = false
-reason = "Tests are flat per-module rather than mirroring src/chebpy/ package depth; per-module coverage is guaranteed by the 100% coverage gate in `make test`."
+reason = "Tests are flat per-module rather than mirroring src/chebpy/ package depth; per-module coverage is guaranteed by the full-coverage gate in `make test`."
 
 [tool.bumpversion]
 allow_dirty = false

--- a/src/chebpy/decorators.py
+++ b/src/chebpy/decorators.py
@@ -69,7 +69,6 @@ def self_empty(resultif: Any = None) -> Callable[..., Any]:
         This decorator is primarily used in chebtech.py.
     """
 
-    # TODO: add unit test for this
     def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
         """Wrap *f* with the empty-object short-circuit logic."""
 


### PR DESCRIPTION
Two independent one-line cleanups surfaced by `/rhiza:quality`.

Closes #456 · Closes #457

## #456 — stale TODO in `decorators.py`

`self_empty` carried `# TODO: add unit test for this`, but the decorator **is** tested:
`tests/test_decorators.py` has a dedicated section for it, and the module reports 100%
coverage against a `COVERAGE_FAIL_UNDER = 100` bar. A TODO that contradicts the code
invites someone to redo finished work, and erodes trust in the 11 genuine TODOs in the
tree. Removed.

## #457 — literal `%` broke radon

The `[tool.check_test_layout]` reason read "the **100%** coverage gate". radon feeds the
whole of `pyproject.toml` to `configparser`, which reads `%` as interpolation syntax, so
*any* radon invocation from the repo root died before analysing a single file:

```
$ uvx radon cc src -a -s
ValueError: invalid interpolation syntax in 'Tests are flat per-module rather than
mirroring src/chebpy/ package depth; ...' at position 119
```

That is radon's bug — it should scope itself to `[tool.radon]` — but the workaround here
is one word, and the alternative is that anyone reaching for a complexity metric hits a
traceback that looks like a broken repo.

Reworded to "the full-coverage gate", plus a comment above the key recording *why* the
string must stay `%`-free, so the next edit doesn't quietly reintroduce it.

**The opt-out itself is unchanged and still justified** — only the wording moved.
`check_test_layout.py` still exits 0, now reporting the new text.

## Verification

| Check | Before | After |
| --- | --- | --- |
| `uvx radon cc src -a -s` from repo root | `ValueError: invalid interpolation syntax` | runs, exit 0 |
| `check_test_layout.py` | exit 0 | exit 0, opt-out honored |
| format/lint gate | 20 hooks pass | 20 hooks pass |
| template test suite | 40 passed | 40 passed |
| full test suite | 1092 passed, 100.00% | 1092 passed, 100.00% |

Radon now correctly reports the one remaining C-ranked block — `api.py:99 equifun`,
tracked separately as #454. That is the confirmation the fix worked rather than merely
silencing the tool.

No behaviour changes: one deleted comment, one reworded config string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
