### PR TITLE
fix: describe the failure when chebfun() cannot build a constant

### DIFF
--- a/src/chebpy/api.py
+++ b/src/chebpy/api.py
@@ -53,7 +53,9 @@ def chebfun(
         Chebfun: A Chebfun object representing the function.
 
     Raises:
-        ValueError: If unable to construct a constant function from the input.
+        ValueError: If ``f`` is none of the accepted forms — that is, if it is
+            neither None, nor callable, nor a single alphabetic character, nor
+            convertible to a float.
 
     Examples:
         >>> # Empty Chebfun
@@ -93,7 +95,11 @@ def chebfun(
         # Constant fct via chebfun(3.14, ... ), chebfun('3.14', ... )
         return Chebfun.initconst(float(f), domain)
     except (OverflowError, ValueError) as err:
-        raise ValueError(f) from err
+        msg = (
+            f"cannot construct a Chebfun from {f!r}: expected None, a callable, "
+            "a single alphabetic character such as 'x', or a number"
+        )
+        raise ValueError(msg) from err
 
 
 def equifun(values: np.ndarray | list[float | complex], domain: np.ndarray | list[float] | None = None) -> "Chebfun":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,6 +89,21 @@ def test_chebfun_raises() -> None:
         chebfun("asdfasdf")
 
 
+def test_chebfun_raises_describes_the_failure() -> None:
+    """Test that the ValueError message explains the failure rather than echoing the input."""
+    with pytest.raises(ValueError) as excinfo:
+        chebfun("asdfasdf")
+
+    message = str(excinfo.value)
+    # the offending input is quoted, so the caller can see what was rejected
+    assert "'asdfasdf'" in message
+    # ...but the message also says what would have been accepted
+    assert "expected None, a callable" in message
+    assert "a number" in message
+    # and the underlying conversion failure is preserved for debugging
+    assert isinstance(excinfo.value.__cause__, ValueError)
+
+
 def test_pwc() -> None:
     """Test creating piecewise constant functions."""
     dom = [-1, 0, 1]


### PR DESCRIPTION
Closes #455

## The problem

`chebfun()` raised `ValueError(f)` — the caller's own input as the message:

```python
except (OverflowError, ValueError) as err:
    raise ValueError(f) from err
```

So a bad call reported:

```
>>> chebfun("asdfasdf")
ValueError: asdfasdf
```

which tells the user what they typed, which they already knew. Every other raise site in
the package raises a typed exception with a descriptive message — `compactfun.py`,
`trigtech.py`, `quasimatrix.py`, and `equifun` a few lines below in this very file. This
one was the outlier.

## The change

```
>>> chebfun("asdfasdf")
ValueError: cannot construct a Chebfun from 'asdfasdf': expected None, a callable,
a single alphabetic character such as 'x', or a number
```

The offending input is still quoted, so nothing diagnostic is lost, and the underlying
conversion error stays chained via `from err`:

```
cause: ValueError: could not convert string to float: 'asdfasdf'
```

Uses the `msg = ...; raise ValueError(msg)` form that `equifun` already uses in this
file, rather than an inline literal.

Also corrected the docstring's `Raises:` section. It said "if unable to construct a
constant function from the input", which described only the last of the four branches
`chebfun()` dispatches over; it now states the actual condition.

## Test

Added `test_chebfun_raises_describes_the_failure`, which asserts on the message content
and on the `__cause__` chain, so the wording cannot silently regress. That is the
acceptance criterion the issue asked for — a test on the type alone would not have
caught the original defect.

The pre-existing `test_chebfun_raises` is **unchanged** and still passes: its
`match="asdfasdf"` is a `re.search`, so it finds the quoted input inside the longer
message.

## Verification

| Gate | Result |
| --- | --- |
| format/lint | 20 hooks pass |
| `ty` + `mypy --strict` | clean, 26 modules |
| full suite | 1093 passed (was 1092), 100.00% coverage, `api.py` fully covered |

## One thing deliberately left alone

`float(f)` raises `TypeError`, not `ValueError`, for inputs like `chebfun([1, 2])` — so
that case bypasses this handler entirely and surfaces a raw numpy/builtin `TypeError`.
Widening the `except` would change which exception type callers see, which is a
behavioural change beyond what #455 asks for. Worth its own issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
