### PR TITLE
Remove DEVCONTAINER badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 
 [![CI](https://github.com/chebpy/chebpy/actions/workflows/rhiza_ci.yml/badge.svg?event=push)](https://github.com/chebpy/chebpy/actions/workflows/rhiza_ci.yml)
 [![MARIMO](https://github.com/chebpy/chebpy/actions/workflows/rhiza_marimo.yml/badge.svg?event=push)](https://github.com/chebpy/chebpy/actions/workflows/rhiza_marimo.yml)
-[![DEVCONTAINER](https://github.com/chebpy/chebpy/actions/workflows/rhiza_devcontainer.yml/badge.svg?event=push)](https://github.com/chebpy/chebpy/actions/workflows/rhiza_devcontainer.yml)
 
 **🔬 Numerical computing with Chebyshev series approximations**
 


### PR DESCRIPTION
Removed the DEVCONTAINER badge from the README.

## Summary

<!-- One or two sentences describing what this PR does and why. -->

Closes #<!-- issue number -->

## Changes

<!-- Bullet list of what changed. -->

-

## Testing

- [ ] `make test` passes locally
- [ ] `make fmt` has been run
- [ ] New tests added (or explain why not needed)

## Checklist

- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] `CHANGELOG.md` entry added (or not needed for this change)
- [ ] Documentation updated if behaviour changed
- [ ] `make deps` passes (no unused or missing dependencies)
