### PR TITLE
chore: add github-paper rhiza template

### DIFF
--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -1,0 +1,34 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Paper
+#
+# Purpose: Compile the LaTeX paper (docs/paper/*.tex) to a PDF and publish it
+#          as a downloadable workflow artifact. Pushes the PDF to a paper branch.
+#
+# Trigger: On push/PR to main/master when docs/paper/** changes, or manual dispatch.
+
+name: "(RHIZA) PAPER"
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'docs/paper/**'
+      - '.github/workflows/rhiza_paper.yml'
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'docs/paper/**'
+      - '.github/workflows/rhiza_paper.yml'
+  workflow_dispatch:
+
+jobs:
+  paper:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v1.3.2
+    secrets: inherit
+    permissions:
+      contents: write

--- a/.rhiza/make.d/paper.mk
+++ b/.rhiza/make.d/paper.mk
@@ -1,0 +1,33 @@
+## paper.mk - LaTeX paper compilation targets
+# This file is included by the main Makefile
+
+PAPER_DIR ?= docs/paper
+
+.PHONY: paper paper-clean
+
+##@ Paper
+
+paper:: ## compile LaTeX documents in docs/paper to PDF using latexmk
+	@printf "${BLUE}[INFO] Checking for latexmk...${RESET}\n"
+	@if ! command -v latexmk >/dev/null 2>&1; then \
+	  printf "${RED}[ERROR] latexmk not found. Please install a LaTeX distribution (e.g., MacTeX, TeX Live).${RESET}\n"; \
+	  exit 1; \
+	fi
+	@if [ -z "$$(find $(PAPER_DIR) -maxdepth 1 -name '*.tex' 2>/dev/null)" ]; then \
+	  printf "${YELLOW}[WARN] No .tex files found in $(PAPER_DIR), skipping.${RESET}\n"; \
+	  exit 0; \
+	fi
+	@if [ -f $(PAPER_DIR)/basanos.tex ]; then \
+	  tex_file="basanos.tex"; \
+	else \
+	  tex_file=$$(find $(PAPER_DIR) -maxdepth 1 -name "*.tex" | head -1 | xargs basename); \
+	fi; \
+	printf "${BLUE}[INFO] Compiling $$tex_file...${RESET}\n"; \
+	cd $(PAPER_DIR) && latexmk -pdf -bibtex -interaction=nonstopmode "$$tex_file" || exit 1; \
+	pdf_file="$${tex_file%.tex}.pdf"; \
+	printf "${GREEN}[SUCCESS] $(PAPER_DIR)/$$pdf_file${RESET}\n"
+
+paper-clean:: ## remove latexmk build artifacts in docs/paper
+	@printf "${BLUE}[INFO] Cleaning paper artifacts...${RESET}\n"
+	@cd $(PAPER_DIR) && latexmk -C 2>/dev/null || true
+	@printf "${GREEN}[SUCCESS] Cleaned $(PAPER_DIR)${RESET}\n"

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -7,10 +7,9 @@ exclude:
 - book/marimo/notebooks/rhiza.py
 templates:
 - devcontainer
-- github
-- github-marimo
-- github-tests
-- github-book
+- github-paper
+profiles:
+- github-project
 files:
 - .bandit
 - .devcontainer/README.md
@@ -36,6 +35,7 @@ files:
 - .github/workflows/rhiza_fuzzing.yml
 - .github/workflows/rhiza_marimo.yml
 - .github/workflows/rhiza_mutation.yml
+- .github/workflows/rhiza_paper.yml
 - .github/workflows/rhiza_release.yml
 - .github/workflows/rhiza_scorecard.yml
 - .github/workflows/rhiza_weekly.yml
@@ -56,6 +56,7 @@ files:
 - .rhiza/make.d/doctor.mk
 - .rhiza/make.d/github.mk
 - .rhiza/make.d/marimo.mk
+- .rhiza/make.d/paper.mk
 - .rhiza/make.d/python.mk
 - .rhiza/make.d/quality.mk
 - .rhiza/make.d/test.mk
@@ -80,5 +81,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-04T18:39:08Z'
+synced_at: '2026-08-09T04:25:35Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -6,6 +6,9 @@ profiles:
 
 templates:
   - devcontainer
+  # Ships .github/workflows/rhiza_paper.yml, which compiles docs/paper/*.tex and
+  # publishes the PDF both as a workflow artifact and on the `paper` branch.
+  - github-paper
 
 exclude:
   - book/marimo/notebooks/rhiza.py  


### PR DESCRIPTION
Adds the `github-paper` template to `.rhiza/template.yml` and applies the sync.

**Template:** `jebel-quant/rhiza` @ `v1.3.2` (ref unchanged — this adds a template, it is not a version bump).

**Files the sync added (2):**

- `.github/workflows/rhiza_paper.yml` — compiles `docs/paper/*.tex` and publishes the PDF as a workflow artifact and on the `paper` branch. Triggers on push/PR to `master` touching `docs/paper/**`, plus `workflow_dispatch`.
- `.rhiza/make.d/paper.mk` — pulled in via the `paper` bundle that `github-paper` depends on. Provides `make paper` (latexmk) and `make paper-clean`.

No conflicts. Nothing was left unstaged — the working tree is clean.

Note: the workflow only does anything once `docs/paper/` contains a `.tex` file; until then the path filter never fires and `make paper` warns and exits 0.

The lock's `templates:`/`profiles:` keys were also rewritten to the current format (the previous lock predated the `profiles:` key). No entries were dropped from the `files:` list.

**No gates were run** — run `/rhiza:quality` for a scorecard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
