### PR TITLE
Document accuracy and related preferences

### DIFF
--- a/docs/user/features/approximation.md
+++ b/docs/user/features/approximation.md
@@ -73,6 +73,104 @@ ChebPy can represent functions with breakpoints as piecewise Chebyshev expansion
 f = chebfun(lambda x: np.abs(x), [-1, 0, 1])
 ```
 
+## Accuracy and Preferences
+
+Adaptive construction samples the function on Chebyshev grids of length
+`2**k + 1`.  It converts the samples to Chebyshev coefficients and stops when
+the coefficient tail can be chopped below a tolerance.  The default tolerance is
+roughly machine epsilon:
+
+```python
+from chebpy import UserPreferences
+
+prefs = UserPreferences()
+prefs.eps       # default: numpy.finfo(float).eps
+prefs.maxpow2   # default: 16, so the largest grid has 65537 points
+```
+
+Use the preferences object to change these defaults:
+
+```python
+from chebpy import UserPreferences
+
+prefs = UserPreferences()
+prefs.eps = 1e-12
+prefs.maxpow2 = 17
+
+# Restore one setting, or all settings:
+prefs.reset("eps")
+prefs.reset()
+```
+
+Preferences are global.  For temporary changes, use the object as a context
+manager:
+
+```python
+from chebpy import UserPreferences, chebfun
+
+prefs = UserPreferences()
+
+with prefs as local_prefs:
+    local_prefs.eps = 1e-12
+    f = chebfun(lambda x: x**2)
+
+# eps is restored here
+```
+
+`eps` is a construction tolerance, not a certified maximum error.  It controls
+the coefficient chopping test used during construction, but the final pointwise
+error also depends on smoothness, conditioning, floating-point roundoff, and
+whether the function is resolved on the chosen interval.  In practice, validate
+sensitive approximations against extra sample points:
+
+```python
+import numpy as np
+from chebpy import chebfun
+
+def g(x):
+    return 0.3 + 0.02*x + abs(x)**1.8
+
+f = chebfun(g, [-1, 1])
+x_test = np.linspace(-1, 1, 1001)
+err_est = np.max(np.abs(g(x_test) - f(x_test)))
+```
+
+The adaptive constructor also uses an absolute zero test.  On each interval it
+sets the approximation to zero when all sampled values have magnitude at most
+`eps * max(hscale, 1)`, where `hscale` is ChebPy's horizontal scale for that
+interval.  Raising `eps` can therefore erase functions whose overall amplitude
+is smaller than this threshold, even when their relative variation matters.
+
+The example above is deliberately difficult at `x = 0`: `abs(x)**1.8` is not
+twice differentiable there.  A single global polynomial therefore converges only
+algebraically, and its largest interpolation error can occur near the cusp even
+though the function is continuous.  If you know the location of the nonsmooth
+point, add it as a breakpoint:
+
+```python
+f = chebfun(g, [-1, 0, 1])
+```
+
+Here the breakpoint moves the fractional-power singularity from the interior to
+the endpoints of two pieces.  Those pieces are still not fully smooth, so their
+convergence remains algebraic, but the split usually reduces the interpolation
+error substantially.  When a function consists of genuinely smooth branches,
+breakpoints let ChebPy approximate each branch separately.
+
+If construction remains unresolved at `maxpow2`, ChebPy emits this warning:
+
+```text
+The Chebtech constructor did not converge: using 65537 points
+```
+
+Treat this as a resolution warning.  The returned object contains the largest
+sampled interpolant, but ChebPy has not seen coefficient decay strong enough to
+declare it resolved.  For a smooth but highly oscillatory function, increasing
+`maxpow2` may be appropriate.  For a nonsmooth function, add breakpoints at
+known kinks or jumps.  For supported endpoint singularities, use the specialized
+[`sing=` construction](singularities.md).  For noisy or discontinuous data, a
+polynomial interpolant may not be the right model.
+
 ## Chebyshev Points
 
 Use `chebpts` to get the Chebyshev interpolation points and barycentric weights:

--- a/docs/user/features/approximation.md
+++ b/docs/user/features/approximation.md
@@ -120,7 +120,8 @@ with prefs as local_prefs:
 `eps` is a construction tolerance, not a certified maximum error.  It controls
 the coefficient chopping test used during construction, but the final pointwise
 error also depends on smoothness, conditioning, floating-point roundoff, and
-whether the function is resolved on the chosen interval.  In practice, validate
+whether the function is resolved on the chosen interval.  ChebPy does not
+currently provide a certified maximum-error bound.  In practice, validate
 sensitive approximations against extra sample points:
 
 ```python
@@ -135,11 +136,22 @@ x_test = np.linspace(-1, 1, 1001)
 err_est = np.max(np.abs(g(x_test) - f(x_test)))
 ```
 
+This is an error estimate over the selected test points, not a bound between
+them.  Denser or problem-specific validation points may be needed when the
+function has narrow or rapidly varying features.
+
 The adaptive constructor also uses an absolute zero test.  On each interval it
 sets the approximation to zero when all sampled values have magnitude at most
 `eps * max(hscale, 1)`, where `hscale` is ChebPy's horizontal scale for that
 interval.  Raising `eps` can therefore erase functions whose overall amplitude
 is smaller than this threshold, even when their relative variation matters.
+
+Lowering `eps` below its default, `numpy.finfo(float).eps`, may request a longer
+polynomial and reduce truncation error for a difficult function, but it cannot
+provide floating-point accuracy beyond machine precision.  The requested
+tolerance is then below roundoff and may simply drive construction to
+`maxpow2`.  Use independent validation to decide whether the longer
+approximation is useful.
 
 The example above is deliberately difficult at `x = 0`: `abs(x)**1.8` is not
 twice differentiable there.  A single global polynomial therefore converges only

--- a/docs/user/intro.md
+++ b/docs/user/intro.md
@@ -44,6 +44,10 @@ by default). This means:
 - Functions with localised features may require breakpoint detection
 - The resulting representation is accurate to roughly 15 digits
 
+See [Accuracy and Preferences](features/approximation.md#accuracy-and-preferences)
+for how `eps`, `maxpow2`, and non-convergence warnings affect adaptive
+construction.
+
 ### Operations
 
 Once a function is represented as a Chebfun, operations such as differentiation,

--- a/docs/user/intro.md
+++ b/docs/user/intro.md
@@ -42,7 +42,8 @@ by default). This means:
 
 - Smooth functions are represented compactly (low degree)
 - Functions with localised features may require breakpoint detection
-- The resulting representation is accurate to roughly 15 digits
+- Well-resolved smooth functions are often accurate to nearly machine precision;
+  nonsmooth or under-resolved functions can be much less accurate
 
 See [Accuracy and Preferences](features/approximation.md#accuracy-and-preferences)
 for how `eps`, `maxpow2`, and non-convergence warnings affect adaptive


### PR DESCRIPTION
## Summary

Closes #38 

## Changes

Add "Accuracy and Preferences" section to docs/user/features/approximation.md

## Testing

- [x] `make test` passes locally
- [x] `make fmt` has been run
- [ ] ~New tests added (or explain why not needed)~

## Checklist

- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] ~`CHANGELOG.md` entry added (or not needed for this change)~
- [ ] ~Documentation updated if behaviour changed~
- [ ] ~`make deps` passes (no unused or missing dependencies)~
