### PR TITLE
Promote two unnecessary function-local imports to module scope

### DIFF
--- a/src/chebpy/_singular_construction.py
+++ b/src/chebpy/_singular_construction.py
@@ -11,7 +11,9 @@ from collections.abc import Callable
 from typing import Any
 
 from .bndfun import Bndfun
+from .maps import MapParams
 from .settings import _preferences as prefs
+from .singfun import Singfun
 from .utilities import Domain
 
 
@@ -67,11 +69,6 @@ def generate_singular_funs(
     Raises:
         ValueError: If ``sing`` is not one of the recognised values.
     """
-    # Local import: chebfun and singfun are siblings under classicfun and
-    # would otherwise risk a cyclic top-level import.
-    from .maps import MapParams
-    from .singfun import Singfun
-
     if sing not in ("left", "right", "both"):
         msg = f"sing must be 'left', 'right', or 'both'; got {sing!r}"
         raise ValueError(msg)

--- a/src/chebpy/chebyshev.py
+++ b/src/chebpy/chebyshev.py
@@ -13,7 +13,7 @@ import numpy as np
 import numpy.polynomial.chebyshev as cheb
 from matplotlib.axes import Axes
 
-from .algorithms import coeffs2vals2, standard_chop, vals2coeffs2
+from .algorithms import chebpts2, coeffs2vals2, standard_chop, vals2coeffs2
 from .settings import _preferences as prefs
 
 # Type aliases
@@ -452,8 +452,6 @@ def from_function(
     Returns:
         A new Chebyshev polynomial that approximates the given function.
     """
-    from .algorithms import chebpts2, vals2coeffs2
-
     domain_arr = np.array([-1, 1]) if domain is None else np.array(domain)
 
     # Create a wrapper function that maps points from [-1, 1] to the custom domain


### PR DESCRIPTION
Closes #472.

Two function-local imports deferred for no reason the import graph supports.

### `src/chebpy/_singular_construction.py`

The deferred `maps` / `singfun` imports carried a comment claiming they avoided
"a cyclic top-level import". No such cycle exists — `singfun` imports
`classicfun`, `maps`, `settings`, `utilities`, never `chebfun` or
`_singular_construction`, and `maps` has no intra-package imports at all. Both
now sit at module scope and the misleading comment is gone.

### `src/chebpy/chebyshev.py`

`_polyfit` deferred `from .algorithms import chebpts2, vals2coeffs2`, but
`vals2coeffs2` was **already** imported at module scope (line 16), so the local
import redundantly shadowed it. `algorithms` never imports `chebyshev`, so
there was no cycle to avoid. `chebpts2` joins the existing module-level import.

### Why it matters

`utilities.py:579` holds the one *genuine* upward reach in the package
(tracked in #475). Deferred imports that look like they work around the same
problem, but don't, make that real violation harder to spot.

### Verification

- `make test` — 1098 passed, coverage 100.00% (unchanged)
- `make typecheck` — `ty` clean, `mypy --strict` clean on 26 files
- `make fmt` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)