### PR TITLE
Move generate_funs() out of utilities to resolve the layering inversion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,9 @@ upper at module scope):
 
 ```text
 api · quasimatrix · gpr                     high-level API / applications
-chebfun (+ _convolution, _pointwise,        piecewise container + its impl modules
-         _singular_construction, _ufuncs)
+chebfun (+ _construction, _convolution,     piecewise container + its impl modules
+         _pointwise, _singular_construction,
+         _ufuncs)
 bndfun · compactfun · singfun               Classicfun pieces
 classicfun                                  interval-mapped base ([-1,1] ↔ [a,b])
 chebtech · trigtech                         reference-interval representations (Onefun)
@@ -30,9 +31,11 @@ a container of `Fun` pieces, not part of the `Fun` hierarchy. `Chebfun`'s public
 methods are thin wrappers that delegate to the `_convolution` / `_pointwise` /
 `_singular_construction` / `_ufuncs` implementation modules.
 
-Known layering tech debt: `utilities.generate_funs()` reaches up to
-`compactfun.CompactFun` via a function-local import (tracked in
-[#417](https://github.com/chebpy/chebpy/issues/417)).
+`_construction.generate_funs()` and `_singular_construction`'s
+`generate_singular_funs()` are siblings: both build the per-piece `Fun` list a
+`Chebfun` wraps, dispatching between `Bndfun`, `CompactFun` and `Singfun`. They
+sit at this layer — rather than in `utilities` — precisely because that dispatch
+means knowing about the `Classicfun` pieces.
 
 ## Source ownership: this repo vs Rhiza
 

--- a/src/chebpy/_construction.py
+++ b/src/chebpy/_construction.py
@@ -1,0 +1,71 @@
+"""Construction of the piecewise fun list backing an ordinary Chebfun.
+
+Sibling of :mod:`chebpy._singular_construction`, which does the analogous job
+for domains with endpoint singularities. Both live above the ``Bndfun`` /
+``CompactFun`` layer because they dispatch between those representations, which
+is why neither belongs in :mod:`chebpy.utilities`.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+
+from .compactfun import CompactFun
+from .exceptions import InvalidDomain
+from .settings import _preferences as prefs
+from .utilities import Domain, Interval
+
+
+def generate_funs(
+    domain: Domain | list[float] | None, bndfun_constructor: Callable[..., Any], kwds: dict[str, Any] | None = None
+) -> list[Any]:
+    """Generate a collection of function objects over a domain.
+
+    This method is used by several of the Chebfun classmethod constructors to
+    generate a collection of function objects over the specified domain. For
+    pieces with finite endpoints the supplied ``bndfun_constructor`` is used;
+    for pieces with one or both endpoints at ``±inf`` the corresponding
+    classmethod on :class:`CompactFun` is invoked instead, dispatched by
+    method name.
+
+    Args:
+        domain (array-like or None): Domain breakpoints. If None, uses default domain from preferences.
+            The outermost breakpoints may be ``±inf``; interior breakpoints must be finite.
+        bndfun_constructor (callable): Constructor function for creating function objects on
+            finite intervals (typically a :class:`Bndfun` classmethod).
+        kwds (dict, optional): Additional keyword arguments to pass to the constructor. Defaults to {}.
+
+    Returns:
+        list: List of function objects covering the domain.
+
+    Raises:
+        InvalidDomain: If a piece has an infinite endpoint but
+            ``bndfun_constructor`` has no matching :class:`CompactFun`
+            classmethod to build it with.
+    """
+    if kwds is None:
+        kwds = {}
+    domain = Domain(domain if domain is not None else prefs.domain)
+
+    method_name = getattr(bndfun_constructor, "__name__", None)
+    compact_constructor: Callable[..., Any] | None = (
+        getattr(CompactFun, method_name) if method_name is not None and hasattr(CompactFun, method_name) else None
+    )
+
+    funs = []
+    for a, b in itertools.pairwise(domain):
+        a_f, b_f = float(a), float(b)
+        if np.isfinite(a_f) and np.isfinite(b_f):
+            interval: Any = Interval(a_f, b_f)
+            ctor = bndfun_constructor
+        else:
+            if compact_constructor is None:
+                raise InvalidDomain
+            interval = (a_f, b_f)  # CompactFun classmethods accept (a, b) tuples with ±inf
+            ctor = compact_constructor
+        funs.append(ctor(**{**kwds, "interval": interval}))
+    return funs

--- a/src/chebpy/chebfun.py
+++ b/src/chebpy/chebfun.py
@@ -18,13 +18,14 @@ from typing import Any, cast
 import numpy as np
 from matplotlib.axes import Axes
 
+from ._construction import generate_funs
 from ._ufuncs import register_ufuncs
 from .bndfun import Bndfun
 from .decorators import cache, cast_arg_to_chebfun, float_argument, self_empty
 from .exceptions import BadFunLengthArgument
 from .plotting import plot_chebfun, plotcoeffs_chebfun
 from .settings import _preferences as prefs
-from .utilities import Domain, check_funs, compute_breakdata, generate_funs
+from .utilities import Domain, check_funs, compute_breakdata
 
 
 class Chebfun:

--- a/src/chebpy/utilities.py
+++ b/src/chebpy/utilities.py
@@ -7,7 +7,7 @@ It defines the core data structures for representing and manipulating intervals 
 
 import itertools
 from collections import OrderedDict
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from typing import Any, Protocol, cast, runtime_checkable
 
 import numpy as np
@@ -547,55 +547,6 @@ def compute_breakdata(funs: np.ndarray) -> OrderedDict[float, Any]:
         xout = np.append(np.append(xl, x), xr)
         yout = np.append(np.append(yl, y), yr)
         return OrderedDict(zip(xout, yout, strict=False))
-
-
-def generate_funs(
-    domain: Domain | list[float] | None, bndfun_constructor: Callable[..., Any], kwds: dict[str, Any] | None = None
-) -> list[Any]:
-    """Generate a collection of function objects over a domain.
-
-    This method is used by several of the Chebfun classmethod constructors to
-    generate a collection of function objects over the specified domain. For
-    pieces with finite endpoints the supplied ``bndfun_constructor`` is used;
-    for pieces with one or both endpoints at ``±inf`` the corresponding
-    classmethod on :class:`CompactFun` is invoked instead, dispatched by
-    method name.
-
-    Args:
-        domain (array-like or None): Domain breakpoints. If None, uses default domain from preferences.
-            The outermost breakpoints may be ``±inf``; interior breakpoints must be finite.
-        bndfun_constructor (callable): Constructor function for creating function objects on
-            finite intervals (typically a :class:`Bndfun` classmethod).
-        kwds (dict, optional): Additional keyword arguments to pass to the constructor. Defaults to {}.
-
-    Returns:
-        list: List of function objects covering the domain.
-    """
-    if kwds is None:
-        kwds = {}
-    domain = Domain(domain if domain is not None else prefs.domain)
-    # Local import avoids a circular dependency with chebpy.compactfun, which
-    # imports from utilities for Interval / Domain.
-    from .compactfun import CompactFun
-
-    method_name = getattr(bndfun_constructor, "__name__", None)
-    compact_constructor: Callable[..., Any] | None = (
-        getattr(CompactFun, method_name) if method_name is not None and hasattr(CompactFun, method_name) else None
-    )
-
-    funs = []
-    for a, b in itertools.pairwise(domain):
-        a_f, b_f = float(a), float(b)
-        if np.isfinite(a_f) and np.isfinite(b_f):
-            interval: Any = Interval(a_f, b_f)
-            ctor = bndfun_constructor
-        else:
-            if compact_constructor is None:
-                raise InvalidDomain
-            interval = (a_f, b_f)  # CompactFun classmethods accept (a, b) tuples with ±inf
-            ctor = compact_constructor
-        funs.append(ctor(**{**kwds, "interval": interval}))
-    return funs
 
 
 def infnorm(vals: np.ndarray) -> float:

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -1,0 +1,42 @@
+"""Unit tests for chebpy._construction."""
+
+import numpy as np
+import pytest
+
+from chebpy._construction import generate_funs
+from chebpy.bndfun import Bndfun
+from chebpy.compactfun import CompactFun
+from chebpy.exceptions import InvalidDomain
+
+
+def test_generate_funs_infinite_without_compact_constructor():
+    """An unbounded piece with no matching CompactFun constructor is rejected."""
+
+    # A constructor whose name is not a CompactFun classmethod yields no compact
+    # fallback, so an infinite endpoint has nothing to build the piece with.
+    def not_a_real_constructor(**_kwds):
+        return None  # pragma: no cover - never reached; the guard fires first
+
+    with pytest.raises(InvalidDomain):
+        generate_funs([-np.inf, np.inf], not_a_real_constructor)
+
+
+def test_generate_funs_finite_pieces_use_the_bndfun_constructor():
+    """Every piece of a finite domain is built by the supplied constructor."""
+    funs = generate_funs([-1.0, 0.0, 1.0], Bndfun.initconst, {"c": 2.0})
+    assert len(funs) == 2
+    assert all(isinstance(fun, Bndfun) for fun in funs)
+
+
+def test_generate_funs_unbounded_piece_dispatches_to_compactfun():
+    """An infinite endpoint is built by the matching CompactFun classmethod."""
+    funs = generate_funs([-np.inf, 0.0, 1.0], Bndfun.initconst, {"c": 2.0})
+    assert len(funs) == 2
+    assert isinstance(funs[0], CompactFun)
+    assert isinstance(funs[1], Bndfun)
+
+
+def test_generate_funs_none_domain_falls_back_to_preferences():
+    """Passing None uses the default domain from preferences."""
+    funs = generate_funs(None, Bndfun.initconst, {"c": 1.0})
+    assert len(funs) == 1

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -21,7 +21,7 @@ from chebpy.exceptions import (
     SupportMismatch,
 )
 from chebpy.settings import DefaultPreferences
-from chebpy.utilities import Domain, Interval, IntervalMap, check_funs, compute_breakdata, generate_funs, htol
+from chebpy.utilities import Domain, Interval, IntervalMap, check_funs, compute_breakdata, htol
 
 rng = np.random.default_rng(0)  # Use a fixed seed for reproducibility
 eps = DefaultPreferences.eps
@@ -247,18 +247,6 @@ def test_domain_init_disallow():
     # NaN is never permitted, even at an endpoint.
     with pytest.raises(InvalidDomain):
         Domain([np.nan, 1.0])
-
-
-def test_generate_funs_infinite_without_compact_constructor():
-    """An unbounded piece with no matching CompactFun constructor is rejected."""
-
-    # A constructor whose name is not a CompactFun classmethod yields no compact
-    # fallback, so an infinite endpoint has nothing to build the piece with.
-    def not_a_real_constructor(**_kwds):
-        return None  # pragma: no cover - never reached; the guard fires first
-
-    with pytest.raises(InvalidDomain):
-        generate_funs([-np.inf, np.inf], not_a_real_constructor)
 
 
 def test_domain_iter():


### PR DESCRIPTION
Closes #475. Also closes #417, which tracked the same debt.

`utilities.generate_funs()` reached up to `compactfun.CompactFun` through a
function-local import — the **only** upward dependency in the package, and the
one piece of layering debt `CLAUDE.md` called out by name.

### Why a move rather than injection

The deferred import was a working workaround, not a fix. `generate_funs()`
dispatches between `Bndfun` (finite pieces) and `CompactFun` (pieces with a
`±inf` endpoint), so knowing about the `Classicfun` layer is intrinsic to what
it does — it cannot honestly sit in the primitives layer no matter how the
import is spelled.

It also already has a sibling: `_singular_construction.generate_singular_funs()`
does the analogous job for domains with endpoint singularities, dispatching
between `Bndfun` and `Singfun`, and lives at the Chebfun impl-module layer. The
two belong together.

So `generate_funs()` moves to a new `src/chebpy/_construction.py` at that same
layer, where `from .compactfun import CompactFun` is an ordinary downward
module-scope import.

### Changes

- **New** `src/chebpy/_construction.py` — `generate_funs()`, unchanged in
  behaviour, with the `Raises:` section its docstring was missing.
- `src/chebpy/utilities.py` — function removed; `Callable` import dropped, now
  unused there.
- `src/chebpy/chebfun.py` — imports `generate_funs` from `._construction`.
- **New** `tests/test_construction.py` — the moved rejection-guard test plus
  three new ones covering the finite, unbounded-endpoint and default-domain
  paths, which previously had only indirect coverage.
- `CLAUDE.md` — layer diagram updated; the "known layering tech debt" paragraph
  is replaced by a note on why the two construction modules sit where they do.

### Verification

- `make test` — 1101 passed, coverage 100.00%, `_construction.py` at 100%
- `make typecheck` — `ty` clean, `mypy --strict` clean on 27 files
- Import-graph re-scan: **zero** upward function-local imports remain in
  `src/chebpy/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)