### PR TITLE
Raise domain exception types where the condition is chebpy-specific

### DIFF
--- a/src/chebpy/_singular_construction.py
+++ b/src/chebpy/_singular_construction.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 from typing import Any
 
 from .bndfun import Bndfun
+from .exceptions import InvalidSingularitySide
 from .settings import _preferences as prefs
 from .utilities import Domain
 
@@ -65,7 +66,7 @@ def generate_singular_funs(
         list: Per-piece funs ready to feed to :class:`Chebfun`.
 
     Raises:
-        ValueError: If ``sing`` is not one of the recognised values.
+        InvalidSingularitySide: If ``sing`` is not one of the recognised values.
     """
     # Local import: chebfun and singfun are siblings under classicfun and
     # would otherwise risk a cyclic top-level import.
@@ -74,7 +75,7 @@ def generate_singular_funs(
 
     if sing not in ("left", "right", "both"):
         msg = f"sing must be 'left', 'right', or 'both'; got {sing!r}"
-        raise ValueError(msg)
+        raise InvalidSingularitySide(msg)
     if params is None:
         params = MapParams()
     dom = Domain(domain if domain is not None else prefs.domain)

--- a/src/chebpy/api.py
+++ b/src/chebpy/api.py
@@ -12,6 +12,7 @@ import numpy as np
 from .algorithms import barywts2, chebpts2, funqui
 from .bndfun import Bndfun
 from .chebfun import Chebfun
+from .exceptions import InvalidDomain
 from .settings import _preferences as prefs
 from .utilities import Domain, Interval
 
@@ -130,17 +131,17 @@ def _validated_samples(values: np.ndarray | list[float | complex]) -> np.ndarray
 
 
 def _validated_interval(domain: np.ndarray | list[float] | None) -> Domain:
-    """Return *domain* as a Domain of two finite increasing endpoints, or raise ValueError."""
+    """Return *domain* as a Domain of two finite increasing endpoints, or raise InvalidDomain."""
     dom = np.asarray(prefs.domain if domain is None else domain, dtype=float)
     if dom.ndim != 1 or dom.size != 2:
         msg = "domain must contain exactly two endpoints"
-        raise ValueError(msg)
+        raise InvalidDomain(msg)
     if not np.all(np.isfinite(dom)):
         msg = "domain endpoints must be finite"
-        raise ValueError(msg)
+        raise InvalidDomain(msg)
     if dom[0] >= dom[1]:
         msg = "domain endpoints must be strictly increasing"
-        raise ValueError(msg)
+        raise InvalidDomain(msg)
     return Domain(dom)
 
 
@@ -157,8 +158,9 @@ def equifun(values: np.ndarray | list[float | complex], domain: np.ndarray | lis
         rational interpolant through the equispaced samples.
 
     Raises:
-        ValueError: If values are empty, non-numeric, not one-dimensional, or
-            if domain is not exactly two finite endpoints.
+        ValueError: If values are empty, non-numeric, or not one-dimensional.
+        InvalidDomain: If domain is not exactly two finite, strictly
+            increasing endpoints.
 
     Examples:
         >>> import numpy as np

--- a/src/chebpy/chebtech.py
+++ b/src/chebpy/chebtech.py
@@ -37,6 +37,7 @@ from .algorithms import (
     vals2coeffs2,
 )
 from .decorators import self_empty
+from .exceptions import BadFunLengthArgument
 from .plotting import plotfun, plotfuncoeffs
 from .settings import _preferences as prefs
 from .smoothfun import Smoothfun
@@ -92,7 +93,7 @@ class Chebtech(Smoothfun, ABC):
         a fixed number of degrees of freedom specified by n.
         """
         if n is None:
-            raise ValueError("n must be specified for fixed-length initialization")  # noqa: TRY003
+            raise BadFunLengthArgument("n must be specified for fixed-length initialization")  # noqa: TRY003
         points = cls._chebpts(int(n))
         values = fun(points)
         coeffs = vals2coeffs2(values)

--- a/src/chebpy/exceptions.py
+++ b/src/chebpy/exceptions.py
@@ -201,6 +201,28 @@ BadFunLengthArgument: type[ChebpyBaseError] = type(
 
 
 # ===============================================
+#    chebpy.singfun.Singfun exceptions
+# ===============================================
+
+# Exception raised when a singularity side is not one of the recognised values
+InvalidSingularitySide: type[ChebpyBaseError] = type(
+    "InvalidSingularitySide",
+    (ChebpyBaseError,),
+    {
+        "default_message": "The singularity side must be 'left', 'right', or 'both'",
+        "__doc__": """Exception raised when a singularity side is invalid.
+
+        Raised when the ``sing`` (or ``side``) argument naming which endpoints
+        of an interval carry a singularity is not one of the recognised
+        values. :class:`~chebpy.maps.SingleSlitMap` accepts ``"left"`` or
+        ``"right"``; the Singfun and Chebfun constructors additionally accept
+        ``"both"``.
+        """,
+    },
+)
+
+
+# ===============================================
 #    chebpy.compactfun.CompactFun exceptions
 # ===============================================
 

--- a/src/chebpy/quasimatrix.py
+++ b/src/chebpy/quasimatrix.py
@@ -19,6 +19,7 @@ from matplotlib.axes import Axes
 from matplotlib.patches import Rectangle
 
 from .chebfun import Chebfun
+from .exceptions import SupportMismatch
 
 
 class Quasimatrix:
@@ -57,7 +58,7 @@ class Quasimatrix:
             for k, col in enumerate(cols[1:], 1):
                 if col.support != ref:
                     msg = f"Column {k} support {col.support} does not match column 0 support {ref}"
-                    raise ValueError(msg)
+                    raise SupportMismatch(msg)
         self.columns: list[Chebfun] = cols
 
     # ------------------------------------------------------------------

--- a/src/chebpy/singfun.py
+++ b/src/chebpy/singfun.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from typing import Any
 
 from .classicfun import Classicfun, techdict
+from .exceptions import InvalidSingularitySide, NotSubinterval
 from .maps import DoubleSlitMap, MapParams, SingleSlitMap
 from .settings import _preferences as prefs
 from .utilities import Interval, IntervalMap
@@ -49,14 +50,14 @@ def _build_map(a: float, b: float, sing: str, params: MapParams) -> IntervalMap:
             or :class:`DoubleSlitMap` (for ``"both"``).
 
     Raises:
-        ValueError: If ``sing`` is not one of the recognised values.
+        InvalidSingularitySide: If ``sing`` is not one of the recognised values.
     """
     if sing in ("left", "right"):
         return SingleSlitMap(a, b, params, side=sing)
     if sing == "both":
         return DoubleSlitMap(a, b, params)
     msg = f"sing must be 'left', 'right', or 'both'; got {sing!r}"
-    raise ValueError(msg)
+    raise InvalidSingularitySide(msg)
 
 
 class Singfun(Classicfun):
@@ -336,8 +337,6 @@ class Singfun(Classicfun):
         from .bndfun import Bndfun
 
         if subinterval not in self.interval:
-            from .exceptions import NotSubinterval
-
             raise NotSubinterval(self.interval, subinterval)
         a, b = float(self._interval[0]), float(self._interval[1])
         sa, sb = float(subinterval[0]), float(subinterval[1])

--- a/src/chebpy/trigtech.py
+++ b/src/chebpy/trigtech.py
@@ -43,6 +43,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from .decorators import self_empty
+from .exceptions import BadFunLengthArgument
 from .plotting import plotfun, plotfuncoeffs
 from .settings import _preferences as prefs
 from .smoothfun import Smoothfun
@@ -172,7 +173,7 @@ class Trigtech(Smoothfun, ABC):
     def initfun_fixedlen(cls, fun: Any = None, n: Any = None, *, interval: Any = None) -> "Trigtech":
         """Initialise a Trigtech from callable *fun* using *n* equispaced points."""
         if n is None:
-            raise ValueError("initfun_fixedlen requires the n parameter to be specified")  # noqa: TRY003
+            raise BadFunLengthArgument("initfun_fixedlen requires the n parameter to be specified")  # noqa: TRY003
         points = cls._trigpts(int(n))
         values = fun(points)
         coeffs = cls._vals2coeffs(values)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,7 @@ import pytest
 
 import chebpy
 from chebpy import chebfun, equifun, pwc
+from chebpy.exceptions import InvalidDomain
 from chebpy.settings import DefaultPreferences
 
 
@@ -246,7 +247,7 @@ def test_equifun_rejects_invalid_values(values: list[object], match: str) -> Non
 )
 def test_equifun_rejects_invalid_domains(domain: list[float], match: str) -> None:
     """Test equifun rejects unsupported domains."""
-    with pytest.raises(ValueError, match=match):
+    with pytest.raises(InvalidDomain, match=match):
         equifun([1.0, 2.0], domain)
 
 

--- a/tests/test_chebtech.py
+++ b/tests/test_chebtech.py
@@ -16,6 +16,7 @@ import pytest
 
 from chebpy.algorithms import standard_chop
 from chebpy.chebtech import Chebtech
+from chebpy.exceptions import BadFunLengthArgument
 from tests.generic.algebra import *  # noqa: F403
 from tests.generic.class_usage import test_constfun_value  # noqa: F401
 from tests.generic.complex import (  # noqa: F401
@@ -83,7 +84,7 @@ class TestConstruction:
 
     def test_initfun_fixedlen_n_none(self):
         """initfun_fixedlen raises ValueError when n is None."""
-        with pytest.raises(ValueError, match="n must be specified"):
+        with pytest.raises(BadFunLengthArgument, match="n must be specified"):
             Chebtech.initfun_fixedlen(np.sin, n=None)
 
     def test_imag_complex_chebtech(self):

--- a/tests/test_quasimatrix.py
+++ b/tests/test_quasimatrix.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from chebpy import Quasimatrix, chebfun, polyfit
+from chebpy.exceptions import SupportMismatch
 
 
 @pytest.fixture
@@ -304,7 +305,7 @@ class TestMisc:
 
     def test_support_mismatch(self, x):
         y = chebfun("x", [0, 2])
-        with pytest.raises(ValueError, match="support"):
+        with pytest.raises(SupportMismatch, match="support"):
             Quasimatrix([x, y])
 
     def test_unsupported_norm(self, A):

--- a/tests/test_singfun.py
+++ b/tests/test_singfun.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from chebpy.bndfun import Bndfun
-from chebpy.exceptions import NotSubinterval
+from chebpy.exceptions import InvalidSingularitySide, NotSubinterval
 from chebpy.maps import DoubleSlitMap, MapParams, SingleSlitMap
 from chebpy.singfun import Singfun
 from chebpy.utilities import Interval
@@ -71,8 +71,8 @@ class TestConstruction:
         assert f.size == n
 
     def test_invalid_sing_raises(self):
-        """An unrecognised ``sing`` keyword raises :class:`ValueError`."""
-        with pytest.raises(ValueError):
+        """An unrecognised ``sing`` keyword raises :class:`InvalidSingularitySide`."""
+        with pytest.raises(InvalidSingularitySide):
             Singfun.initfun_adaptive(np.sqrt, [0.0, 1.0], sing="middle")
 
 

--- a/tests/test_singfun_integration.py
+++ b/tests/test_singfun_integration.py
@@ -10,6 +10,7 @@ import pytest
 import chebpy
 from chebpy import chebfun
 from chebpy.bndfun import Bndfun
+from chebpy.exceptions import InvalidSingularitySide
 from chebpy.maps import MapParams
 from chebpy.singfun import Singfun
 
@@ -62,8 +63,8 @@ class TestChebfunSingKwarg:
         assert float(f.sum()) == pytest.approx(np.pi / 8.0, abs=1e-13)
 
     def test_invalid_sing_raises(self):
-        """An unrecognised ``sing`` keyword raises :class:`ValueError`."""
-        with pytest.raises(ValueError):
+        """An unrecognised ``sing`` keyword raises :class:`InvalidSingularitySide`."""
+        with pytest.raises(InvalidSingularitySide):
             chebfun(np.sqrt, [0.0, 1.0], sing="middle")
 
     def test_fixedlen_with_sing_raises(self):

--- a/tests/test_trigtech.py
+++ b/tests/test_trigtech.py
@@ -10,6 +10,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+from chebpy.exceptions import BadFunLengthArgument
 from chebpy.settings import DefaultPreferences
 from chebpy.settings import _preferences as prefs
 from chebpy.trigtech import Trigtech, _trig_adaptive
@@ -108,7 +109,7 @@ class TestConstruction:
         assert f.size == n
 
     def test_fixedlen_none_raises(self):
-        with pytest.raises(ValueError, match="n parameter"):
+        with pytest.raises(BadFunLengthArgument, match="n parameter"):
             Trigtech.initfun_fixedlen(sin, n=None)
 
     def test_initfun_delegates_adaptive(self):


### PR DESCRIPTION
Closes #474.

`src/chebpy/exceptions.py` defines a well-shaped hierarchy under an abstract
`ChebpyBaseError`, but generic raises outnumbered it 32 to 20. A caller wanting
to catch "chebpy rejected my domain" had to catch bare `ValueError` — far too
broad — or match on the message string.

### Converted (9 sites)

| Site | Was | Now |
| --- | --- | --- |
| `api._validated_interval` × 3 | `ValueError` | `InvalidDomain` |
| `Chebtech.initfun_fixedlen` | `ValueError` | `BadFunLengthArgument` |
| `Trigtech.initfun_fixedlen` | `ValueError` | `BadFunLengthArgument` |
| `Quasimatrix.__init__` column support | `ValueError` | `SupportMismatch` |
| `singfun._map_for` | `ValueError` | `InvalidSingularitySide` |
| `_singular_construction.generate_singular_funs` | `ValueError` | `InvalidSingularitySide` |

Each reuses a type whose existing default message already describes exactly the
condition being raised — `BadFunLengthArgument` is literally about the `n`
argument, `SupportMismatch` about objects not sharing an interval.

### One new type

`InvalidSingularitySide`, for the `sing` / `side` argument. It had no type of
its own and is validated on both the Singfun and Chebfun construction paths,
so it is the one genuinely missing name rather than a reuse.

### Deliberately left as `ValueError`

The other 23 sites are generic argument validation with no chebpy-specific
meaning — empty or non-numeric arrays, an unsupported norm order, a negative
derivative count, an unknown evaluation method.

`maps.py` is also left alone on purpose. It sits in the foundation layer, which
by design has **no intra-package imports at all**; importing `.exceptions`
there would trade one architectural property for another. Worth a separate
discussion about whether `exceptions` should be a sub-layer the foundations may
import — but not something to slip into this PR.

### Note for callers

`ChebpyBaseError` derives from `Exception`, not `ValueError`, so code catching
`ValueError` on these six paths must be updated. The package is pre-1.0 and
these are all construction-time validation errors, but flagging it explicitly.

### Also

`singfun.py`'s function-local `from .exceptions import NotSubinterval` is
promoted to module scope, since the module now imports from `.exceptions`
anyway.

### Verification

- `make test` — 1098 passed, coverage 100.00%
- `make typecheck` — `ty` clean, `mypy --strict` clean on 26 files
- `make fmt` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)