### PR TITLE
Add doctest examples to the seven core modules that carried none

### DIFF
--- a/src/chebpy/chebtech.py
+++ b/src/chebpy/chebtech.py
@@ -51,6 +51,30 @@ class Chebtech(Smoothfun, ABC):
 
     The user will rarely work with these classes directly so we make
     several assumptions regarding input data types.
+
+    Examples:
+        The adaptive constructor picks however many coefficients the function
+        needs to reach machine precision on [-1, 1]:
+
+        >>> import numpy as np
+        >>> f = Chebtech.initfun_adaptive(np.exp)
+        >>> bool(abs(f(0.0) - 1.0) < 1e-14)
+        True
+        >>> bool(abs(f(0.5) - np.exp(0.5)) < 1e-14)
+        True
+
+        A constant needs exactly one:
+
+        >>> c = Chebtech.initconst(3.0)
+        >>> c.size
+        1
+        >>> c.isconst
+        True
+
+        Coefficients are in the T_k basis, so the identity is ``[0, 1]``:
+
+        >>> Chebtech.initidentity().coeffs.tolist()
+        [0, 1]
     """
 
     @classmethod

--- a/src/chebpy/classicfun.py
+++ b/src/chebpy/classicfun.py
@@ -35,6 +35,33 @@ class Classicfun(Fun, ABC):
     The Classicfun class serves as a base class for specific implementations like Bndfun.
     It handles the mapping between the arbitrary interval and the standard domain,
     delegating the actual function representation to the underlying Onefun object.
+
+    Examples:
+        ``Classicfun`` is abstract; construct through a concrete subclass such
+        as :class:`~chebpy.bndfun.Bndfun`. The interval is carried by the
+        object, so evaluation and calculus happen in the user's coordinates
+        rather than on [-1, 1]:
+
+        >>> import numpy as np
+        >>> from chebpy.bndfun import Bndfun
+        >>> from chebpy.utilities import Interval
+        >>> f = Bndfun.initfun_adaptive(np.sin, Interval(0.0, np.pi))
+        >>> f.support.tolist()
+        [0.0, 3.141592653589793]
+        >>> bool(abs(f(np.pi / 2) - 1.0) < 1e-14)
+        True
+
+        The integral of sin over [0, pi] is 2:
+
+        >>> bool(abs(f.sum() - 2.0) < 1e-14)
+        True
+
+        The representation is delegated to a Onefun, which the interval map
+        wraps:
+
+        >>> from chebpy.chebtech import Chebtech
+        >>> isinstance(f.onefun, Chebtech)
+        True
     """
 
     # ``_singularity_priority`` lets mixed-type binary operations dispatch

--- a/src/chebpy/compactfun.py
+++ b/src/chebpy/compactfun.py
@@ -261,6 +261,31 @@ class CompactFun(Classicfun):
         numerical_support: The finite storage interval.
         tail_left: Asymptotic value at ``-inf`` (``0.0`` if logical-left is finite).
         tail_right: Asymptotic value at ``+inf`` (``0.0`` if logical-right is finite).
+
+    Examples:
+        A Gaussian on the whole real line. The logical support is infinite,
+        but the discovered numerical support is finite:
+
+        >>> import numpy as np
+        >>> f = CompactFun.initfun_adaptive(lambda x: np.exp(-(x**2)), (-np.inf, np.inf))
+        >>> f.support.tolist()
+        [-inf, inf]
+        >>> a, b = f.numerical_support
+        >>> bool(np.isfinite(a) and np.isfinite(b))
+        True
+
+        Integration over the infinite interval recovers ``sqrt(pi)``:
+
+        >>> bool(abs(f.sum() - np.sqrt(np.pi)) < 1e-12)
+        True
+
+        Outside the numerical support the function reports its asymptotic
+        limit rather than extrapolating the polynomial:
+
+        >>> f.tail_left, f.tail_right
+        (0.0, 0.0)
+        >>> float(f(1e6))
+        0.0
     """
 
     def __init__(

--- a/src/chebpy/maps.py
+++ b/src/chebpy/maps.py
@@ -50,6 +50,31 @@ class MapParams:
             ``gap < 1e-10`` at ``alpha = 1.0``).
         alpha: Positive strip half-width. Controls the clustering
             strength; smaller ``alpha`` clusters more aggressively.
+
+    Examples:
+        >>> p = MapParams()
+        >>> p.L, p.alpha
+        (8.0, 1.0)
+
+        Both parameters must be strictly positive:
+
+        >>> MapParams(L=-1.0)
+        Traceback (most recent call last):
+            ...
+        ValueError: require L > 0
+        >>> MapParams(alpha=0.0)
+        Traceback (most recent call last):
+            ...
+        ValueError: require alpha > 0
+
+        A larger ``L`` shrinks the gap between the map's image and the
+        clustered endpoint:
+
+        >>> from chebpy.maps import SingleSlitMap
+        >>> wide = SingleSlitMap(0.0, 1.0, MapParams(L=4.0), side="left")
+        >>> tight = SingleSlitMap(0.0, 1.0, MapParams(L=8.0), side="left")
+        >>> bool(tight.gap < wide.gap)
+        True
     """
 
     L: float = 8.0

--- a/src/chebpy/quasimatrix.py
+++ b/src/chebpy/quasimatrix.py
@@ -30,6 +30,39 @@ class Quasimatrix:
 
     Attributes:
         columns: list of Chebfun objects forming the columns.
+
+    Examples:
+        Build a quasimatrix from Chebfun columns. One dimension is
+        continuous, so the shape is ``(inf, n)``:
+
+        >>> import numpy as np
+        >>> from chebpy import chebfun
+        >>> x = chebfun("x")
+        >>> A = Quasimatrix([x, x**2])
+        >>> A.shape
+        (inf, 2)
+        >>> len(A)
+        2
+
+        Calling evaluates every column at once:
+
+        >>> A(0.5).tolist()
+        [0.5, 0.25]
+
+        Matrix-vector products contract the discrete dimension, giving a
+        Chebfun back:
+
+        >>> f = A @ np.array([1.0, 1.0])
+        >>> bool(abs(f(0.5) - 0.75) < 1e-13)
+        True
+
+        The continuous analogue of QR yields orthonormal columns:
+
+        >>> Q, R = A.qr()
+        >>> R.shape
+        (2, 2)
+        >>> bool(np.allclose(Q.inner(), np.eye(2), atol=1e-10))
+        True
     """
 
     # ------------------------------------------------------------------

--- a/src/chebpy/singfun.py
+++ b/src/chebpy/singfun.py
@@ -77,6 +77,29 @@ class Singfun(Classicfun):
       :meth:`~chebpy.classicfun.Classicfun.__call__` and
       :meth:`~chebpy.classicfun.Classicfun.roots` route through the
       non-affine map without further changes.
+
+    Examples:
+        ``sqrt`` has a branch-point singularity at the left endpoint, which a
+        plain polynomial approximation resolves only slowly. Declaring the
+        side clusters the points there instead:
+
+        >>> import numpy as np
+        >>> f = Singfun.initfun_adaptive(np.sqrt, [0.0, 1.0], sing="left")
+        >>> f.map.side
+        'left'
+
+        The integral of ``sqrt`` over [0, 1] is 2/3:
+
+        >>> bool(abs(f.sum() - 2.0 / 3.0) < 1e-10)
+        True
+
+        The map is non-affine, unlike the plain
+        :class:`~chebpy.utilities.Interval` a :class:`~chebpy.bndfun.Bndfun`
+        would carry:
+
+        >>> from chebpy.maps import SingleSlitMap
+        >>> isinstance(f.map, SingleSlitMap)
+        True
     """
 
     # Mixed-subclass binary ops (Singfun + Bndfun, etc.) reconstruct on the

--- a/src/chebpy/trigtech.py
+++ b/src/chebpy/trigtech.py
@@ -130,6 +130,25 @@ class Trigtech(Smoothfun, ABC):
     abstract base and the concrete class: it is not further subclassed, but
     the ABC marker prevents accidental bare construction without going through
     a named constructor.
+
+    Examples:
+        A periodic function needs only a handful of Fourier modes, where the
+        Chebyshev constructor would need many more:
+
+        >>> import numpy as np
+        >>> f = Trigtech.initfun_adaptive(lambda x: np.cos(np.pi * x))
+        >>> f.size
+        3
+        >>> bool(abs(f(0.0) - 1.0) < 1e-13)
+        True
+        >>> bool(abs(f(1.0) + 1.0) < 1e-13)
+        True
+
+        Fixed-length construction samples on *n* equispaced points:
+
+        >>> g = Trigtech.initfun_fixedlen(lambda x: np.sin(np.pi * x), 16)
+        >>> g.size
+        16
     """
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
Closes #473.

Docstring *coverage* was already 100% and every existing example ran clean —
but the 102 doctests were concentrated in 6 of 26 modules, and the ones without
any were the largest in the package.

### The gap

| Module | Lines | Examples before |
| --- | --- | --- |
| `classicfun.py` | 838 | 0 |
| `compactfun.py` | 737 | 0 |
| `trigtech.py` | 692 | 0 |
| `chebtech.py` | 600 | 0 |
| `quasimatrix.py` | 450 | 0 |
| `maps.py` | 429 | 0 |
| `singfun.py` | 420 | 0 |

4166 lines of public surface described in prose, with nothing a reader could
paste into a REPL. `interrogate` passing at 100% is exactly what made it
invisible.

### What was added

An `Examples:` block on each module's primary entry point, showing the
construction that module exists for plus one property that distinguishes it:

- **Chebtech** — adaptive sizing to machine precision; identity coefficients in the T_k basis
- **Trigtech** — a periodic function in 3 Fourier modes, where Chebyshev would need many more
- **Classicfun** — constructed via `Bndfun` since it is abstract; interval carried by the object, so `sum()` is in user coordinates
- **CompactFun** — infinite logical support with finite *numerical* support; Gaussian integrating to `sqrt(pi)`; tail constants outside the support
- **Singfun** — endpoint clustering for the `sqrt` branch point; non-affine map
- **MapParams** — defaults, positivity rejection, and larger `L` shrinking the gap
- **Quasimatrix** — `(inf, n)` shape, evaluation, matrix-vector product, continuous QR with orthonormal columns

### These are checked, not decorative

`make rhiza-test` runs `.rhiza/tests/test_docstrings.py`, which executes every
doctest through `doctest.testmod` in the project environment. Three of the
examples I first wrote were **wrong** and the gate caught them:
`Chebtech.initidentity().coeffs` is int-dtype, `CompactFun.support` returns an
ndarray rather than a tuple, and `Classicfun.onefun.interval` is the mapped
interval, not `[-1, 1]`. All three are corrected here.

Package total: **102 examples in 6 modules → 160 in 13**.

### Verification

- `make rhiza-test` — 40 passed, all 160 doctests execute
- `make test` — 1098 passed, coverage 100.00%
- `make fmt` — all hooks pass, interrogate still 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)