### PR TITLE
chore: drop the exclude entries for the retired mutation/fuzzing workflows

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -14,14 +14,6 @@ templates:
 # where it lives in the template clone. An entry spelled clone-relative
 # (`bundles/github/.github/…`) matches nothing, silently.
 exclude:
-  # Opt-in workflows this repo has never opted into (`gh variable list` is empty, so
-  # neither MUTATION_ENABLED nor FUZZING_ENABLED was ever configured). Mutation's gate
-  # is in the caller so it never starts; fuzzing's is inside the reusable workflow, so
-  # it ran on every PR just to skip. Both files are deleted, not merely unsynced — an
-  # excluded-but-present workflow freezes its `uses: …@vX` pin because the sync stops
-  # touching it.
-  - .github/workflows/rhiza_mutation.yml
-  - .github/workflows/rhiza_fuzzing.yml
   # Generic community boilerplate. chebpy never customised these (their only commits
   # are sync commits), and issue/discussion forms are a repo-owned editorial choice
   # rather than something the template should keep overwriting.


### PR DESCRIPTION
rhiza v1.5.0 retired `.github/workflows/rhiza_fuzzing.yml` (#1568) and `.github/workflows/rhiza_mutation.yml` (#1572), and stopped offering mutation testing in the ecosystem at all (#1492). Nothing under `bundles/` ships either path now, so excluding them declines a file the sync can no longer deliver.

This drops the two entries and the comment paragraphs that existed only to justify them. Where a comment also explained why the *other* workflow was deliberately left in the sync, that note goes too — it describes a live gate that no longer exists.

**No CI behaviour changes.** Neither workflow is delivered with or without these entries.

**This does not delete any leftover workflow file.** Orphan cleanup only considers paths recorded in `.rhiza/template.lock`'s `files:` list, and these are absent from it, so a copy still present in `.github/workflows/` stays put either way. That is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)